### PR TITLE
Add CLI option `clear-terminal`

### DIFF
--- a/docs/installation/cli-usage.md
+++ b/docs/installation/cli-usage.md
@@ -9,6 +9,7 @@ Options
   --async-only, -A               force all tests to take a callback (async) or return a promise
   --colors, -c                   force enabling of colors
   --interactive                  force interactive mode
+  --clear-terminal               clear current terminal, purging its histroy
   --quiet, -q                    does not display informational messages
   --growl, -G                    enable growl notification support
   --recursive                    include sub directories

--- a/src/MochaWebpack.js
+++ b/src/MochaWebpack.js
@@ -22,6 +22,7 @@ export type MochaWebpackOptions = {
   asyncOnly: boolean,
   delay: boolean,
   interactive: boolean,
+  clearTerminal: boolean,
   quiet: boolean,
   growl?: boolean,
 };
@@ -60,6 +61,7 @@ export default class MochaWebpack {
     asyncOnly: false,
     delay: false,
     interactive: !!((process.stdout: any).isTTY),
+    clearTerminal: false,
     quiet: false,
   };
 
@@ -376,6 +378,21 @@ export default class MochaWebpack {
   }
 
   /**
+   * Clear terminal on startup
+   *
+   * @public
+   * @param {boolean} clearTerminal
+   * @return {MochaWebpack}
+   */
+  clearTerminal(clearTerminal: boolean): MochaWebpack {
+    this.options = {
+      ...this.options,
+      clearTerminal,
+    };
+    return this;
+  }
+
+  /**
    * Enable growl notification support
    *
    * @public
@@ -403,6 +420,7 @@ export default class MochaWebpack {
       interactive: this.options.interactive,
       quiet: this.options.quiet,
       cwd: this.options.cwd,
+      clearTerminal: this.options.clearTerminal,
     });
     return runner.run();
   }
@@ -418,6 +436,7 @@ export default class MochaWebpack {
       interactive: this.options.interactive,
       quiet: this.options.quiet,
       cwd: this.options.cwd,
+      clearTerminal: this.options.clearTerminal,
     });
     await runner.watch();
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -61,6 +61,7 @@ mochaWebpack.bail(options.bail);
 mochaWebpack.reporter(options.reporter, options.reporterOptions);
 mochaWebpack.ui(options.ui);
 mochaWebpack.interactive(options.interactive);
+mochaWebpack.clearTerminal(options.clearTerminal);
 
 if (options.fgrep) {
   mochaWebpack.fgrep(options.fgrep);

--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -33,6 +33,12 @@ const options = {
     describe: 'force interactive mode (default enabled in terminal)',
     group: OUTPUT_GROUP,
   },
+  'clear-terminal': {
+    type: 'boolean',
+    default: false,
+    describe: 'clear current terminal, purging its histroy',
+    group: OUTPUT_GROUP,
+  },
   growl: {
     alias: 'G',
     type: 'boolean',

--- a/src/runner/testRunnerReporter.js
+++ b/src/runner/testRunnerReporter.js
@@ -24,21 +24,15 @@ const formatTitleError = (title) => chalk.white.bold.bgRed('', title, '');
 class Reporter {
   added: Array<string>;
   removed: Array<string>;
-  interactive: boolean;
-  clrTerm: boolean;
-  quiet: boolean;
+  options: ReporterOptions;
   formatStats: (stats: Stats) => { warnings: Array<string>, errors: Array<string> };
 
   constructor(options: ReporterOptions) {
-    const {
-      eventEmitter, interactive, quiet, cwd, clearTerminal,
-    } = options;
+    const { cwd, eventEmitter } = options;
 
+    this.options = options;
     this.added = [];
     this.removed = [];
-    this.interactive = interactive;
-    this.quiet = quiet;
-    this.clrTerm = clearTerminal;
     this.formatStats = createStatsFormatter(cwd);
 
     eventEmitter.on('uncaughtException', this.onUncaughtException);
@@ -53,13 +47,13 @@ class Reporter {
   }
 
   logInfo(...args: Array<any>) {
-    if (!this.quiet) {
+    if (!this.options.quiet) {
       log(...args);
     }
   }
 
   clearTerminal() {
-    if (this.clrTerm && this.interactive) {
+    if (this.options.clearTerminal && this.options.interactive) {
       process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
     }
   }

--- a/test/unit/MochaWebpack.test.js
+++ b/test/unit/MochaWebpack.test.js
@@ -31,6 +31,7 @@ describe('MochaWebpack', function () {
       asyncOnly: false,
       delay: false,
       interactive: !!(process.stdout.isTTY),
+      clearTerminal: false,
       quiet: false,
     };
     assert.deepEqual(mochaWebpack.options, expected);
@@ -275,6 +276,17 @@ describe('MochaWebpack', function () {
 
       assert.propertyVal(this.mochaWebpack.options, 'interactive', newValue, 'interactive should be changed');
       assert.notStrictEqual(this.mochaWebpack.options, oldOptions, 'interactive() should not mutate');
+      assert.strictEqual(returnValue, this.mochaWebpack, 'api should be chainable');
+    });
+
+    it('clearTerminal()', function () {
+      const oldOptions = this.mochaWebpack.options;
+      const clearTerminal = false;
+
+      const returnValue = this.mochaWebpack.clearTerminal(clearTerminal);
+
+      assert.propertyVal(this.mochaWebpack.options, 'clearTerminal', clearTerminal, 'clearTerminal should be changed');
+      assert.notStrictEqual(this.mochaWebpack.options, oldOptions, 'clearTerminal() should not mutate');
       assert.strictEqual(returnValue, this.mochaWebpack, 'api should be chainable');
     });
 


### PR DESCRIPTION
Add CLI option `clear-terminal` which clears the current terminal and purges its history; defaults to `false`. 

Fixes #26 