### PR TITLE
Support for `--forbid--only` Mocha option

### DIFF
--- a/docs/installation/cli-usage.md
+++ b/docs/installation/cli-usage.md
@@ -19,6 +19,7 @@ Options
   --glob                         only test files matching <pattern> (only valid for directory entry)
   --grep, -g                     only run tests matching <pattern>
   --fgrep, -f                    only run tests containing <string>
+  --forbid-only                  fail if exclusive test(s) encountered
   --invert, -i                   inverts --grep and --fgrep matches
   --require, -r                  require the given module
   --include                      include the given module into test bundle

--- a/src/MochaWebpack.js
+++ b/src/MochaWebpack.js
@@ -25,6 +25,7 @@ export type MochaWebpackOptions = {
   clearTerminal: boolean,
   quiet: boolean,
   growl?: boolean,
+  forbidOnly: boolean,
 };
 
 export default class MochaWebpack {
@@ -63,6 +64,7 @@ export default class MochaWebpack {
     interactive: !!((process.stdout: any).isTTY),
     clearTerminal: false,
     quiet: false,
+    forbidOnly: false,
   };
 
   /**
@@ -403,6 +405,21 @@ export default class MochaWebpack {
     this.options = {
       ...this.options,
       growl: true,
+    };
+    return this;
+  }
+
+  /**
+   * Disallow .only in tests
+   *
+   * @public
+   * @param {boolean} forbidOnly
+   * @return {MochaWebpack}
+   */
+  forbidOnly(): MochaWebpack {
+    this.options = {
+      ...this.options,
+      forbidOnly: true,
     };
     return this;
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -109,6 +109,10 @@ if (options.growl) {
   mochaWebpack.growl();
 }
 
+if (options.forbidOnly) {
+  mochaWebpack.forbidOnly();
+}
+
 Promise
   .resolve()
   .then(() => {

--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -205,6 +205,12 @@ const options = {
     group: BASIC_GROUP,
     requiresArg: true,
   },
+  'forbid-only': {
+    type: 'boolean',
+    describe: 'fail if exclusive test(s) encountered',
+    group: ADVANCED_GROUP,
+    default: false,
+  },
 };
 
 const paramList = (opts) => _.map(_.keys(opts), _.camelCase);

--- a/src/runner/configureMocha.js
+++ b/src/runner/configureMocha.js
@@ -81,6 +81,11 @@ export default function configureMocha(options: MochaWebpackOptions) {
     mocha.suite.retries(options.retries);
   }
 
+  // forbid-only
+  if (options.forbidOnly) {
+    mocha.forbidOnly();
+  }
+
   // interface
   const ui = loadUI(options.ui, options.cwd);
   mocha.ui(ui);

--- a/test/integration/cli/fixture/only/simple-only.js
+++ b/test/integration/cli/fixture/only/simple-only.js
@@ -1,0 +1,8 @@
+/* eslint-disable */
+var assert = require('assert');
+
+describe.only('simple test with only', function () {
+  it('it works', function () {
+    assert.ok(true);
+  });
+});

--- a/test/integration/cli/forbidOnly.test.js
+++ b/test/integration/cli/forbidOnly.test.js
@@ -1,0 +1,19 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback */
+
+import { assert } from 'chai';
+import path from 'path';
+import { exec } from './util/childProcess';
+
+const fixtureDir = path.relative(process.cwd(), path.join(__dirname, 'fixture'));
+const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
+const test = path.join(fixtureDir, 'only/simple-only.js');
+
+describe('cli --forbid-only', function () {
+  it('gets really angry if there is an only in the test', function (done) {
+    exec(`node ${binPath} --mode development --forbid-only "${test}"`, (err) => {
+      assert.isNotNull(err);
+      done();
+    });
+  });
+});

--- a/test/unit/MochaWebpack.test.js
+++ b/test/unit/MochaWebpack.test.js
@@ -33,6 +33,7 @@ describe('MochaWebpack', function () {
       interactive: !!(process.stdout.isTTY),
       clearTerminal: false,
       quiet: false,
+      forbidOnly: false,
     };
     assert.deepEqual(mochaWebpack.options, expected);
   });
@@ -299,6 +300,18 @@ describe('MochaWebpack', function () {
 
       assert.propertyVal(this.mochaWebpack.options, 'growl', true, 'growl should be changed to true');
       assert.notStrictEqual(this.mochaWebpack.options, oldOptions, 'growl() should not mutate');
+      assert.strictEqual(returnValue, this.mochaWebpack, 'api should be chainable');
+    });
+
+    it('forbidOnly()', function () {
+      const oldOptions = this.mochaWebpack.options;
+      const oldValue = oldOptions.forbidOnly;
+      assert.isNotOk(oldValue, 'forbidOnly should be falsy');
+
+      const returnValue = this.mochaWebpack.forbidOnly();
+
+      assert.propertyVal(this.mochaWebpack.options, 'forbidOnly', true, 'forbidOnly should be changed to true');
+      assert.notStrictEqual(this.mochaWebpack.options, oldOptions, 'forbidOnly() should not mutate');
       assert.strictEqual(returnValue, this.mochaWebpack, 'api should be chainable');
     });
   });

--- a/test/unit/cli/parseArgv.test.js
+++ b/test/unit/cli/parseArgv.test.js
@@ -921,5 +921,32 @@ describe('parseArgv', function () {
         });
       }
     });
+
+    context('forbid-only', function () {
+      it('uses false as default value', function () {
+        // given
+        const { argv } = this;
+
+        // when
+        const parsedArgv = this.parseArgv(argv);
+
+        // then
+        assert.propertyVal(parsedArgv, 'forbidOnly', false);
+      });
+
+
+      for (const parameter of ['--forbid-only']) {
+        it(`parses ${parameter}`, function () {
+          // given
+          const argv = this.argv.concat([parameter]);
+
+          // when
+          const parsedArgv = this.parseArgv(argv);
+
+          // then
+          assert.propertyVal(parsedArgv, 'forbidOnly', true);
+        });
+      }
+    });
   });
 });

--- a/test/unit/runner/configureMocha.test.js
+++ b/test/unit/runner/configureMocha.test.js
@@ -22,6 +22,7 @@ describe('configureMocha', function () {
       slow: 75,
       asyncOnly: false,
       delay: false,
+      forbidOnly: true,
     };
     this.sandbox = sandbox.create();
     this.spyReporter = this.sandbox.spy(Mocha.prototype, 'reporter');
@@ -30,6 +31,7 @@ describe('configureMocha', function () {
     this.spyEnableTimeouts = this.sandbox.spy(Mocha.prototype, 'enableTimeouts');
     this.spyGrep = this.sandbox.spy(Mocha.prototype, 'grep');
     this.spyGrowl = this.sandbox.spy(Mocha.prototype, 'growl');
+    this.spyForbidOnly = this.sandbox.spy(Mocha.prototype, 'forbidOnly');
   });
 
   afterEach(function () {
@@ -104,5 +106,14 @@ describe('configureMocha', function () {
     });
 
     assert.isTrue(this.spyGrowl.called, 'growl() should be called');
+  });
+
+  it('should call forbidOnly()', function () {
+    configureMocha({
+      ...this.options,
+      timeout: 0,
+    });
+
+    assert.isTrue(this.spyForbidOnly.called, 'spyForbidOnly() should be called');
   });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

Allows mochapack to pass through the [`--forbid-only`](https://mochajs.org/#command-line-usage) option to Mocha.

See https://github.com/sysgears/mochapack/issues/14, https://github.com/zinserjan/mocha-webpack/issues/197

**How did you fix it?**

In a manner consistent with other pass through options to Mocha.
