### PR TITLE
Fix incorrect webpack environment variables

### DIFF
--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -292,9 +292,13 @@ function parse(argv, ignoreDefaults) {
     return _.pick(validOptions, usedAliases);
   }
 
-  if (validOptions.webpackEnv && Array.isArray(validOptions.webpackEnv.env)) {
-    const [first] = validOptions.webpackEnv.env;
-    validOptions.webpackEnv.env = first;
+  if (validOptions.webpackEnv) {
+    _.mapValues(validOptions.webpackEnv, (value, key) => {
+      if (Array.isArray(value)) {
+        const [first] = value;
+        validOptions.webpackEnv[key] = first;
+      }
+    });
   }
 
   return validOptions;

--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -279,6 +279,15 @@ function parse(argv, ignoreDefaults) {
   validOptions.require = validOptions.require || [];
   validOptions.include = validOptions.include || [];
 
+  if (validOptions.webpackEnv) {
+    _.mapValues(validOptions.webpackEnv, (value, key) => {
+      if (Array.isArray(value)) {
+        const [first] = value;
+        validOptions.webpackEnv[key] = first;
+      }
+    });
+  }
+
   if (ignoreDefaults) {
     const userOptions = yargs(argv).argv;
     const providedKeys = _.keys(userOptions);
@@ -290,15 +299,6 @@ function parse(argv, ignoreDefaults) {
     }
 
     return _.pick(validOptions, usedAliases);
-  }
-
-  if (validOptions.webpackEnv) {
-    _.mapValues(validOptions.webpackEnv, (value, key) => {
-      if (Array.isArray(value)) {
-        const [first] = value;
-        validOptions.webpackEnv[key] = first;
-      }
-    });
   }
 
   return validOptions;

--- a/test/integration/cli/config.test.js
+++ b/test/integration/cli/config.test.js
@@ -10,6 +10,31 @@ const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
 const testSimple = path.join(fixtureDir, 'simple/simple.js');
 
 describe('cli --webpack-config', function () {
+  it('does not throw for missing default config', function (done) {	
+    exec(`node ${binPath} "${testSimple}"`, (err) => {	
+      assert.isNull(err);	
+      done();	
+    });	
+  });	
+
+  it('throws when not found', function (done) {	
+    const configNotFound = 'xxxxxxx.js';	
+    exec(`node ${binPath} --webpack-config ${configNotFound} "${testSimple}"`, (err) => {	
+      assert.include(err.message, `Webpack config could not be found: ${configNotFound}`);	
+      done();	
+    });	
+  });	
+
+  it('passes --webpack-env random to config', function (done) {	
+    const config = path.join(fixtureDir, 'config/config.env.js');	
+    const env = Math.random();	
+    exec(`node ${binPath} --webpack-config ${config} --webpack-env ${env} "${testSimple}"`, (err, output) => {	
+      assert.isNull(err);	
+      assert.include(output, env);	
+      done();	
+    });	
+  });
+
   it('passes --webpack-env object to config', function (done) {
     const config = path.join(fixtureDir, 'config/config.env.js');
     const env = Math.random();

--- a/test/integration/cli/config.test.js
+++ b/test/integration/cli/config.test.js
@@ -10,29 +10,29 @@ const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
 const testSimple = path.join(fixtureDir, 'simple/simple.js');
 
 describe('cli --webpack-config', function () {
-  it('does not throw for missing default config', function (done) {	
-    exec(`node ${binPath} "${testSimple}"`, (err) => {	
-      assert.isNull(err);	
-      done();	
-    });	
-  });	
+  it('does not throw for missing default config', function (done) {
+    exec(`node ${binPath} "${testSimple}"`, (err) => {
+      assert.isNull(err);
+      done();
+    });
+  });
 
-  it('throws when not found', function (done) {	
-    const configNotFound = 'xxxxxxx.js';	
-    exec(`node ${binPath} --webpack-config ${configNotFound} "${testSimple}"`, (err) => {	
-      assert.include(err.message, `Webpack config could not be found: ${configNotFound}`);	
-      done();	
-    });	
-  });	
+  it('throws when not found', function (done) {
+    const configNotFound = 'xxxxxxx.js';
+    exec(`node ${binPath} --webpack-config ${configNotFound} "${testSimple}"`, (err) => {
+      assert.include(err.message, `Webpack config could not be found: ${configNotFound}`);
+      done();
+    });
+  });
 
-  it('passes --webpack-env random to config', function (done) {	
-    const config = path.join(fixtureDir, 'config/config.env.js');	
-    const env = Math.random();	
-    exec(`node ${binPath} --webpack-config ${config} --webpack-env ${env} "${testSimple}"`, (err, output) => {	
-      assert.isNull(err);	
-      assert.include(output, env);	
-      done();	
-    });	
+  it('passes --webpack-env random to config', function (done) {
+    const config = path.join(fixtureDir, 'config/config.env.js');
+    const env = Math.random();
+    exec(`node ${binPath} --webpack-config ${config} --webpack-env ${env} "${testSimple}"`, (err, output) => {
+      assert.isNull(err);
+      assert.include(output, env);
+      done();
+    });
   });
 
   it('passes --webpack-env object to config', function (done) {

--- a/test/integration/cli/config.test.js
+++ b/test/integration/cli/config.test.js
@@ -10,37 +10,12 @@ const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
 const testSimple = path.join(fixtureDir, 'simple/simple.js');
 
 describe('cli --webpack-config', function () {
-  it('does not throw for missing default config', function (done) {
-    exec(`node ${binPath} "${testSimple}"`, (err) => {
-      assert.isNull(err);
-      done();
-    });
-  });
-
-  it('throws when not found', function (done) {
-    const configNotFound = 'xxxxxxx.js';
-    exec(`node ${binPath} --webpack-config ${configNotFound} "${testSimple}"`, (err) => {
-      assert.include(err.message, `Webpack config could not be found: ${configNotFound}`);
-      done();
-    });
-  });
-
-  it('passes --webpack-env random to config', function (done) {
-    const config = path.join(fixtureDir, 'config/config.env.js');
-    const env = Math.random();
-    exec(`node ${binPath} --webpack-config ${config} --webpack-env ${env} "${testSimple}"`, (err, output) => {
-      assert.isNull(err);
-      assert.include(output, env);
-      done();
-    });
-  });
-
   it('passes --webpack-env object to config', function (done) {
     const config = path.join(fixtureDir, 'config/config.env.js');
     const env = Math.random();
     exec(`node ${binPath} --webpack-config ${config} --webpack-env.test ${env} "${testSimple}"`, (err, output) => {
       assert.isNull(err);
-      assert.include(output, env);
+      assert.include(output, `{ test: '${env}' }`);
       done();
     });
   });

--- a/test/unit/cli/parseArgv.test.js
+++ b/test/unit/cli/parseArgv.test.js
@@ -845,6 +845,10 @@ describe('parseArgv', function () {
         { given: ['--webpack-env', 'production'], expected: 'production' },
         { given: ['--webpack-env.env', 'production'], expected: { env: 'production' } },
         { given: ['--webpack-env.anotherEnv', 'production'], expected: { anotherEnv: 'production' } },
+        {
+          given: ['--webpack-env.env', 'production', '--webpack-env.anotherEnv', 'test'],
+          expected: { env: 'production', anotherEnv: 'test' },
+        },
       ];
       for (const parameter of parameters) {
         it(`parses ${parameter.given.join(' ')}`, function () {

--- a/test/unit/cli/parseArgv.test.js
+++ b/test/unit/cli/parseArgv.test.js
@@ -844,6 +844,7 @@ describe('parseArgv', function () {
       const parameters = [
         { given: ['--webpack-env', 'production'], expected: 'production' },
         { given: ['--webpack-env.env', 'production'], expected: { env: 'production' } },
+        { given: ['--webpack-env.anotherEnv', 'production'], expected: { anotherEnv: 'production' } },
       ];
       for (const parameter of parameters) {
         it(`parses ${parameter.given.join(' ')}`, function () {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes #42 hopefully.

**How did you fix it?**

I was unable to locate the bug. While it looks like that going through `yargs().parse(argv)` caused the issue, I was unable to reproduce this in yargs. I also suspected that the version of yargs could be an issue, but upgrading yargs didn't help.

Therefore, I fixed this bug by basically following the code below:

https://github.com/sysgears/mochapack/blob/41cb27512f86d4f24127f6605b7404b839e6e1c7/src/cli/parseArgv.js#L295-L298

and generalizing it to apply to all attributes. I would say it doesn't appear to be an ideal way to solve this bug.