### PR TITLE
Allow Webpack config as Promise

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,108 +25,112 @@ function exit(lazy, code) {
   }
 }
 
-const cliOptions = parseArgv(process.argv.slice(2), true);
-const configOptions = parseConfig(cliOptions.opts);
-const requiresWebpackConfig = cliOptions.webpackConfig != null || configOptions.webpackConfig != null;
-const defaultOptions = parseArgv([]);
+async function cli() {
+  const cliOptions = parseArgv(process.argv.slice(2), true);
+  const configOptions = parseConfig(cliOptions.opts);
+  const requiresWebpackConfig = cliOptions.webpackConfig != null || configOptions.webpackConfig != null;
+  const defaultOptions = parseArgv([]);
 
-const options = _.defaults({}, cliOptions, configOptions, defaultOptions);
+  const options = _.defaults({}, cliOptions, configOptions, defaultOptions);
 
-options.require.forEach((mod) => {
-  require(resolve(mod)); // eslint-disable-line global-require, import/no-dynamic-require
-});
-
-options.include = options.include.map(resolve);
-
-options.webpackConfig = requireWebpackConfig(
-  options.webpackConfig,
-  requiresWebpackConfig,
-  options.webpackEnv,
-  options.mode,
-);
-
-const mochaWebpack = createMochaWebpack();
-
-options.include.forEach((f) => mochaWebpack.addInclude(f));
-
-const extensions = _.get(options.webpackConfig, 'resolve.extensions', ['.js']);
-const fallbackFileGlob = extensionsToGlob(extensions);
-const fileGlob = options.glob != null ? options.glob : fallbackFileGlob;
-
-options.files.forEach((f) => mochaWebpack.addEntry(ensureGlob(f, options.recursive, fileGlob)));
-
-mochaWebpack.cwd(process.cwd());
-mochaWebpack.webpackConfig(options.webpackConfig);
-mochaWebpack.bail(options.bail);
-mochaWebpack.reporter(options.reporter, options.reporterOptions);
-mochaWebpack.ui(options.ui);
-mochaWebpack.interactive(options.interactive);
-mochaWebpack.clearTerminal(options.clearTerminal);
-
-if (options.fgrep) {
-  mochaWebpack.fgrep(options.fgrep);
-}
-
-if (options.grep) {
-  mochaWebpack.grep(options.grep);
-}
-
-if (options.invert) {
-  mochaWebpack.invert();
-}
-
-if (options.checkLeaks) {
-  mochaWebpack.ignoreLeaks(false);
-}
-
-if (options.fullTrace) {
-  mochaWebpack.fullStackTrace();
-}
-
-if (options.quiet) {
-  mochaWebpack.quiet();
-}
-
-mochaWebpack.useColors(options.colors);
-mochaWebpack.useInlineDiffs(options.inlineDiffs);
-mochaWebpack.timeout(options.timeout);
-
-if (options.retries) {
-  mochaWebpack.retries(options.retries);
-}
-
-mochaWebpack.slow(options.slow);
-
-if (options.asyncOnly) {
-  mochaWebpack.asyncOnly();
-}
-
-if (options.delay) {
-  mochaWebpack.delay();
-}
-
-if (options.growl) {
-  mochaWebpack.growl();
-}
-
-if (options.forbidOnly) {
-  mochaWebpack.forbidOnly();
-}
-
-Promise
-  .resolve()
-  .then(() => {
-    if (options.watch) {
-      return mochaWebpack.watch();
-    }
-    return mochaWebpack.run();
-  })
-  .then((failures) => {
-    exit(options.exit, failures);
-  })
-  .catch((e) => {
-    if (e) {
-      console.error(e.stack); // eslint-disable-line
-    }
-    exit(options.exit, 1);
+  options.require.forEach((mod) => {
+    require(resolve(mod)); // eslint-disable-line global-require, import/no-dynamic-require
   });
+
+  options.include = options.include.map(resolve);
+
+  options.webpackConfig = await requireWebpackConfig(
+    options.webpackConfig,
+    requiresWebpackConfig,
+    options.webpackEnv,
+    options.mode,
+  );
+
+  const mochaWebpack = createMochaWebpack();
+
+  options.include.forEach((f) => mochaWebpack.addInclude(f));
+
+  const extensions = _.get(options.webpackConfig, 'resolve.extensions', ['.js']);
+  const fallbackFileGlob = extensionsToGlob(extensions);
+  const fileGlob = options.glob != null ? options.glob : fallbackFileGlob;
+
+  options.files.forEach((f) => mochaWebpack.addEntry(ensureGlob(f, options.recursive, fileGlob)));
+
+  mochaWebpack.cwd(process.cwd());
+  mochaWebpack.webpackConfig(options.webpackConfig);
+  mochaWebpack.bail(options.bail);
+  mochaWebpack.reporter(options.reporter, options.reporterOptions);
+  mochaWebpack.ui(options.ui);
+  mochaWebpack.interactive(options.interactive);
+  mochaWebpack.clearTerminal(options.clearTerminal);
+
+  if (options.fgrep) {
+    mochaWebpack.fgrep(options.fgrep);
+  }
+
+  if (options.grep) {
+    mochaWebpack.grep(options.grep);
+  }
+
+  if (options.invert) {
+    mochaWebpack.invert();
+  }
+
+  if (options.checkLeaks) {
+    mochaWebpack.ignoreLeaks(false);
+  }
+
+  if (options.fullTrace) {
+    mochaWebpack.fullStackTrace();
+  }
+
+  if (options.quiet) {
+    mochaWebpack.quiet();
+  }
+
+  mochaWebpack.useColors(options.colors);
+  mochaWebpack.useInlineDiffs(options.inlineDiffs);
+  mochaWebpack.timeout(options.timeout);
+
+  if (options.retries) {
+    mochaWebpack.retries(options.retries);
+  }
+
+  mochaWebpack.slow(options.slow);
+
+  if (options.asyncOnly) {
+    mochaWebpack.asyncOnly();
+  }
+
+  if (options.delay) {
+    mochaWebpack.delay();
+  }
+
+  if (options.growl) {
+    mochaWebpack.growl();
+  }
+
+  if (options.forbidOnly) {
+    mochaWebpack.forbidOnly();
+  }
+
+  Promise
+    .resolve()
+    .then(() => {
+      if (options.watch) {
+        return mochaWebpack.watch();
+      }
+      return mochaWebpack.run();
+    })
+    .then((failures) => {
+      exit(options.exit, failures);
+    })
+    .catch((e) => {
+      if (e) {
+        console.error(e.stack); // eslint-disable-line
+      }
+      exit(options.exit, 1);
+    });
+}
+
+cli();

--- a/src/cli/requireWebpackConfig.js
+++ b/src/cli/requireWebpackConfig.js
@@ -64,7 +64,7 @@ function registerCompiler(moduleDescriptor) {
   }
 }
 
-export default function requireWebpackConfig(webpackConfig, required, env, mode) {
+export default async function requireWebpackConfig(webpackConfig, required, env, mode) {
   const configPath = path.resolve(webpackConfig);
   const configExtension = getConfigExtension(configPath);
   let configFound = false;
@@ -103,7 +103,7 @@ export default function requireWebpackConfig(webpackConfig, required, env, mode)
   config = config.default || config;
 
   if (typeof config === 'function') {
-    config = config(env);
+    config = await Promise.resolve(config(env));
   }
 
   if (mode != null) {

--- a/test/integration/cli/config.test.js
+++ b/test/integration/cli/config.test.js
@@ -17,14 +17,12 @@ describe('cli --webpack-config', function () {
     });
   });
 
-  it('throws when not found', async function () {
+  it('throws when not found', function (done) {
     const configNotFound = 'xxxxxxx.js';
     const command = `node ${binPath} --webpack-config ${configNotFound} "${testSimple}"`;
-    await new Promise((res) => {
-      exec(command, (err, stdout) => {
-        assert.include(stdout, `Webpack config could not be found: ${configNotFound}`);
-        res(stdout);
-      });
+    exec(command, (err, output) => {
+      assert.include(output, `Webpack config could not be found: ${configNotFound}`);
+      done();
     });
   });
 

--- a/test/integration/cli/config.test.js
+++ b/test/integration/cli/config.test.js
@@ -17,11 +17,14 @@ describe('cli --webpack-config', function () {
     });
   });
 
-  it('throws when not found', function (done) {
+  it('throws when not found', async function () {
     const configNotFound = 'xxxxxxx.js';
-    exec(`node ${binPath} --webpack-config ${configNotFound} "${testSimple}"`, (err) => {
-      assert.include(err.message, `Webpack config could not be found: ${configNotFound}`);
-      done();
+    const command = `node ${binPath} --webpack-config ${configNotFound} "${testSimple}"`;
+    await new Promise((res) => {
+      exec(command, (err, stdout) => {
+        assert.include(stdout, `Webpack config could not be found: ${configNotFound}`);
+        res(stdout);
+      });
     });
   });
 

--- a/test/unit/cli/fixture/webpackConfig/webpack.config-promise.js
+++ b/test/unit/cli/fixture/webpackConfig/webpack.config-promise.js
@@ -1,0 +1,4 @@
+module.exports = Promise.resolve({
+  mode: 'development',
+  target: 'node',
+});

--- a/test/unit/cli/requireWebpackConfig.test.js
+++ b/test/unit/cli/requireWebpackConfig.test.js
@@ -2,6 +2,7 @@
 
 import path from 'path';
 import { assert } from 'chai';
+import { rejects } from 'assert';
 import requireWebpackConfig from '../../../src/cli/requireWebpackConfig';
 
 describe('requireWebpackConfig', () => {
@@ -11,49 +12,57 @@ describe('requireWebpackConfig', () => {
   const expectedConfigPath = path.join(__dirname, 'fixture', 'webpackConfig', 'expected.json');
   const expectedConfig = require(expectedConfigPath); // eslint-disable-line global-require, import/no-dynamic-require
 
-  it('requires plain JavaScript Webpack config file', () => {
+  it('requires plain JavaScript Webpack config file', async () => {
     const configPath = getConfigPath('.js');
-    assert.deepEqual(requireWebpackConfig(configPath), expectedConfig);
+    assert.deepEqual(await requireWebpackConfig(configPath), expectedConfig);
   });
 
-  (process.platform === 'win32' ? it.skip : it)('requires symlinked config file', () => {
+  (process.platform === 'win32' ? it.skip : it)('requires symlinked config file', async () => {
     const configPath = getConfigPath('.js', 'config-symlink');
-    assert.deepEqual(requireWebpackConfig(configPath), expectedConfig);
+    assert.deepEqual(await requireWebpackConfig(configPath), expectedConfig);
   });
 
-  it('requires Babel Webpack config file', () => {
+  it('requires Babel Webpack config file', async () => {
     const configPath = getConfigPath('.babel.js');
-    assert.deepEqual(requireWebpackConfig(configPath), expectedConfig);
+    assert.deepEqual(await requireWebpackConfig(configPath), expectedConfig);
   });
 
-  it('requires CoffeeScript Webpack config file', () => {
+  it('requires CoffeeScript Webpack config file', async () => {
     const configPath = getConfigPath('.coffee');
-    assert.deepEqual(requireWebpackConfig(configPath), expectedConfig);
+    assert.deepEqual(await requireWebpackConfig(configPath), expectedConfig);
   });
 
-  it('requires CoffeeScript Webpack config file with config.js', () => {
+  it('requires CoffeeScript Webpack config file with config.js', async () => {
     const configPath = getConfigPath('.js', 'config');
-    assert.deepEqual(requireWebpackConfig(configPath), expectedConfig);
+    assert.deepEqual(await requireWebpackConfig(configPath), expectedConfig);
   });
 
-  it('supports config that exports a function', () => {
+  it('supports config that exports a function', async () => {
     const configPath = getConfigPath('.js', 'config-function');
-    assert.deepEqual(requireWebpackConfig(configPath, false, 'test'), expectedConfig);
+    assert.deepEqual(await requireWebpackConfig(configPath, false, 'test'), expectedConfig);
   });
 
-  it('throws error when multi compiler config is given', () => {
+  it('supports config that exports a Promise', async () => {
+    const configPath = getConfigPath('.js', 'config-promise');
+    assert.deepEqual(await requireWebpackConfig(configPath, false, 'test'), expectedConfig);
+  });
+
+  it('throws error when multi compiler config is given', async () => {
     const configPath = getConfigPath('.js', 'config-multi');
     const error = 'Passing multiple configs as an Array is not supported. Please provide a single config instead.';
-    assert.throws(() => requireWebpackConfig(configPath, true), error);
+    await rejects(() => requireWebpackConfig(configPath, true), { message: error });
   });
 
-  it('throws error when not found when required', () => {
+  it('throws error when not found when required', async () => {
     const configPath = getConfigPath('.js', 'config-xxx');
-    assert.throws(() => requireWebpackConfig(configPath, true), /Webpack config could not be found/);
+    await rejects(
+      () => requireWebpackConfig(configPath, true),
+      { message: `Webpack config could not be found: ${configPath}` },
+    );
   });
 
-  it('return empty config when not found and not required', () => {
+  it('return empty config when not found and not required', async () => {
     const configPath = getConfigPath('.xxx', 'config-xxx');
-    assert.deepEqual(requireWebpackConfig(configPath), {});
+    assert.deepEqual(await requireWebpackConfig(configPath), {});
   });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/sysgears/mochapack/issues/44: Promised Webpack config is not resolved

**How did you fix it?**

* Converted the `requireWebpackConfig` function to `async`
* Wrapped the contents of `cli/index.js` into an async function that `await`s the result of `requireWebpackConfig`

Note that some specs had to be adjusted to account for the change to the `requireWebpackConfig` function, but only to ensure the `Promise` resolves before the assertion is made. The overall functionality asserted by the specs remains the same, and a spec was added for the specific case this fix addresses.

Furthermore, I did give it a quick run-through after `yarn link`ing it to the project I was having trouble in, and the issue is resolved.