### PR TITLE
Disable Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 
+dist: bionic
+
+cache: false
+
 # Build only master & PRs
 branches:
   only:


### PR DESCRIPTION
**What's the problem this PR addresses?**

Travis CI default `node_modules` cache slows down the build

**How did you fix it?**

Disabled Travis cache