### PR TITLE
Create mocha file to fix Webstorm 2020 issue

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+/*
+ * entry file to support mocha-intellij
+ */
+require('../lib/cli');


### PR DESCRIPTION
Adding this file allows Webstorm 2020.1 to continue to work. For some reason it's very picky about which file it finds.

Resolves #66 

**What's the problem this PR addresses?**
Webstorm 2020 does not run unit tests
...

**How did you fix it?**
Adding a specific file name with the same content of _mocha resolves the issue. 
...
