### PR TITLE
fix: support webpack.optimize.LimitChunkCountPlugin

### DIFF
--- a/src/webpack/types.ts
+++ b/src/webpack/types.ts
@@ -39,7 +39,7 @@ export type Chunk = {
   chunks: Array<Chunk>
   parents: Array<Chunk>
   files: Array<string>
-  isOnlyInitial: () => boolean
+  hasEntryModule: () => boolean
   getModules: () => Array<Module>
 }
 

--- a/src/webpack/util/getBuildStats.ts
+++ b/src/webpack/util/getBuildStats.ts
@@ -26,7 +26,7 @@ export default function getBuildStats(
   sortedChunks.forEach((chunk: Chunk) => {
     const files = Array.isArray(chunk.files) ? chunk.files : [chunk.files]
 
-    if (chunk.isOnlyInitial()) {
+    if (chunk.hasEntryModule()) {
       // only entry files
       const entry = files[0]
       entries.push(entry)


### PR DESCRIPTION
**What's the problem this PR addresses?**
Mochapack will not run when using the following plugin in webpack config, when more than one chunk is created by webpack i.e. when dynamic imports are used.

```js
new webpack.optimize.LimitChunkCountPlugin({
  maxChunks: 1
})
```
...

**How did you fix it?**
Rather than using "IsInitialOnly" method call, which checks if each chunk "IsInitial", check instead of the chunk has the entry module.
...
