### PR TITLE
Support for mocha 8.2.0 validateLegacyPlugin change

### DIFF
--- a/src/cli/argsParser/parseArgv/mocha/parseMochaArgs.ts
+++ b/src/cli/argsParser/parseArgv/mocha/parseMochaArgs.ts
@@ -5,7 +5,7 @@ import {
   createUnsupportedError
 } from 'mocha/lib/errors'
 import { ONE_AND_DONES } from 'mocha/lib/cli/one-and-dones'
-import { handleRequires, validatePlugin } from 'mocha/lib/cli/run-helpers'
+import { handleRequires, validatePlugin, validateLegacyPlugin } from 'mocha/lib/cli/run-helpers'
 import { aliases, types } from 'mocha/lib/cli/run-option-metadata'
 import yargs, { Arguments } from 'yargs'
 
@@ -52,8 +52,16 @@ const mochaChecks = (yargsInstance: any, argv: Arguments) => {
 
   // load requires first, because it can impact "plugin" validation
   handleRequires(argv.require)
-  validatePlugin(argv, 'reporter', Mocha.reporters)
-  validatePlugin(argv, 'ui', Mocha.interfaces)
+
+  // necessary since mocha 8.2.0 version
+  if (validatePlugin) {
+    validatePlugin(argv, 'reporter', Mocha.reporters)
+    validatePlugin(argv, 'ui', Mocha.interfaces)
+  }
+  else {
+    validateLegacyPlugin(argv, 'reporter', Mocha.reporters)
+    validateLegacyPlugin(argv, 'ui', Mocha.interfaces)
+  }
 
   return true
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The new version of [mocha (8.2.0)](https://github.com/mochajs/mocha/releases/tag/v8.2.0) included a [change](https://github.com/mochajs/mocha/pull/4360) that renamed the `validatePlugin` function to `validateLegacyPlugin`. 

Even though mochapack only supports mocha up to version 7, projects that use other dependencies that use recent versions of mocha override the mocha version of mochapack. This is a quick fix for the change.

**How did you fix it?**

Checks if the `validatePlugin` function is defined, if not, uses the `validateLegacyPlugin` function.

Not sure if this is the best solution, if not, I'm open to changes :)
