### PR TITLE
Integration tests: Add additional assertion coverage to forbidOnly case

### DIFF
--- a/test/integration/cli/forbidOnly.test.ts
+++ b/test/integration/cli/forbidOnly.test.ts
@@ -12,6 +12,8 @@ describe('cli --forbid-only', function() {
   it('gets really angry if there is an only in the test', function(done) {
     exec(`node ${binPath} --mode development --forbid-only "${test}"`, err => {
       assert.isNotNull(err)
+      assert.include(err.message, 'only')
+      assert.include(err.message, 'forbidden')
       done()
     })
   })


### PR DESCRIPTION
**What's the problem this PR addresses?**
Adds a small amount of extra test coverage to an integration test; it's a low-importance issue discovered during continued investigation work for #83. 

**How did you fix it?**
The `_mocha` binary wasn't being resolved as expected in my local environment.  After trying a possible fix for that, this integration test began to pass, but I wasn't convinced it was working correctly.