### PR TITLE
Fix #99: fix warnings with webpack 5 on Windows

### DIFF
--- a/src/runner/runnerUtils/createWebpackConfig/createWebpackConfig.test.ts
+++ b/src/runner/runnerUtils/createWebpackConfig/createWebpackConfig.test.ts
@@ -1,4 +1,4 @@
-import { join, resolve, sep } from 'path'
+import { join, resolve, sep, normalize } from 'path'
 import { expect } from 'chai'
 import { merge as _merge } from 'lodash'
 import { SinonSandbox, createSandbox } from 'sinon'
@@ -74,7 +74,9 @@ describe('createWebpackConfig', () => {
     })
 
     it('uses the existing output path', () => {
-      expect(createdConfig.webpackConfig.output.path).to.eql('existing/path')
+      expect(createdConfig.webpackConfig.output.path).to.eql(
+        normalize('existing/path')
+      )
     })
 
     context('when a public path is not provided', () => {

--- a/src/webpack/loader/entryLoader.ts
+++ b/src/webpack/loader/entryLoader.ts
@@ -1,5 +1,5 @@
+import { normalize } from 'path'
 import loaderUtils from 'loader-utils'
-import normalizePath from 'normalize-path'
 import createEntry from '../util/createEntry'
 
 export class EntryConfig {
@@ -10,12 +10,12 @@ export class EntryConfig {
   }
 
   addFile(file: string): void {
-    const normalizedFile = normalizePath(file)
+    const normalizedFile = normalize(file)
     this.files.push(normalizedFile)
   }
 
   removeFile(file: string): void {
-    const normalizedFile = normalizePath(file)
+    const normalizedFile = normalize(file)
     this.files = this.files.filter(f => f !== normalizedFile)
   }
 


### PR DESCRIPTION
This PR fixes #99 which caused webpack to emit warnings because it didn't recognize the paths generated by mochapack as absolute paths on Windows. The issue has been solved by replacing `normalize-path` with Node's native `path.normalize` which takes into account the OS mochapack is being used on.