### PR TITLE
Upgrade chokidar

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "chalk": "^2.4.2",
-    "chokidar": "^3.5.1",
+    "chokidar": "^3.5.2",
     "glob-parent": "5.1.0",
     "globby": "^10.0.1",
     "interpret": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3418,7 +3418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.4.0, chokidar@npm:^3.5.1":
+"chokidar@npm:^3.4.0, chokidar@npm:^3.5.2":
   version: 3.5.2
   resolution: "chokidar@npm:3.5.2"
   dependencies:
@@ -9295,7 +9295,7 @@ fsevents@~2.3.2:
     bdd-lazy-var: ^2.5.0
     chai: ^4.1.0
     chalk: ^2.4.2
-    chokidar: ^3.5.1
+    chokidar: ^3.5.2
     coffee-script: ^1.11.1
     commander: 2.11.0
     cross-env: 6.0.3


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn audit` shows a vulnerability advisory with glob-parent, a dependency of mochapack throuth chokidar.

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Regular expression denial of service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ glob-parent                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=5.1.2                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ mochapack                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ mochapack > chokidar > glob-parent                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1002627                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

**How did you fix it?**

Bumped chokidar to a fixed version [3.5.2](https://github.com/paulmillr/chokidar/releases/tag/3.5.2).
