### PR TITLE
Enable Mocha 9 checks on CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14]
-        mocha: [7, 8]
+        mocha: [7, 8, 9]
         webpack: [4, 5]
 
     name: 'Mocha ${{matrix.mocha}} w/ Webpack ${{matrix.webpack}} w/ Node.js ${{matrix.node}}.x'

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If any build errors happens, they will be shown like below
 
 mochapack works with
 - webpack in versions `4.x.x` - `5.x.x`
-- mocha in versions `5.x.x` - `8.x.x`
+- mocha in versions `5.x.x` - `9.x.x`
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mochapack",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "mocha cli with webpack support",
   "bin": "./bin/mochapack",
   "main": "./lib/createMochapack.js",


### PR DESCRIPTION
**What's the problem this PR addresses?**

The tests were not run against Mocha 9

**How did you fix it?**

Added Mocha 9 insto GH actions matrix

CC: @BeeMargarida 
