### PR TITLE
Implements better GHA caching strategy

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,13 +19,20 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.yarn/berry
-          ./.yarn
+        key: global-cache
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ./.yarn/install-state.gz
           ./node_modules
         key: ${{ runner.os }}-install-${{ hashFiles('yarn.lock') }}-v1
+        restore-keys: |
+          ${{ runner.os }}-install-
 
     - name: 'Use Node.js ${{matrix.node}}'
       uses: actions/setup-node@master

--- a/.pinyarn.js
+++ b/.pinyarn.js
@@ -9,19 +9,11 @@ const { PassThrough } = require('stream');
 const config = {
   "ghTokens": [
     [
-      "ghp_H",
-      "bcraD8d0OUWoxJdIlgNLNXpyhzS7n1HutiA"
-    ],
-    [
-      "ghp_9",
-      "HV9r3y93wz0unBeT1SyeILnFZxUzz3dBdrA"
-    ],
-    [
-      "ghp_r",
-      "7dvv4UhJhdhbXSKkcGnjCNtUBFznY1vDhx4"
+      "github_pat_",
+      "11AAJTTFQ0REJCNOIAnP5j_f7uJsYJPDzc0vBxTK5HnKH6Vi0UpqPjvmMuK28AQKFDD5DV2J2E3Mim8CQ4"
     ]
   ],
-  "yarnUrl": "https://raw.githubusercontent.com/yarnpkg/berry/%40yarnpkg/cli/3.2.0-rc.12/packages/yarnpkg-cli/bin/yarn.js"
+  "yarnUrl": "https://raw.githubusercontent.com/yarnpkg/berry/%40yarnpkg/cli/4.0.0-rc.31/packages/yarnpkg-cli/bin/yarn.js"
 };
 
 const getUrlHash = url => crypto.createHash('sha256').update(url).digest('hex').substring(0, 8);

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,9 +1,5 @@
 yarnPath: .pinyarn.js
-nodeLinker: pnpm
+nodeLinker: node-modules
+nmMode: hardlinks-global
 enableGlobalCache: true
 compressionLevel: 0
-
-packageExtensions:
-  eslint-module-utils@*:
-    dependencies:
-      eslint-import-resolver-node: "*"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "gitbook-plugin-prism": "^2.0.0",
     "glob": "7.1.4",
     "mocha": "9.2.0",
-    "node-sass": "^4.11.0",
     "np": "5.1.0",
     "nyc": "14.1.1",
     "optimist": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -105,8 +105,7 @@
     "strip-ansi": "^5.2.0",
     "tiny-worker": "2.3.0",
     "ts-mocha": "^7.0.0",
-    "typescript": "^3.8.3",
-    "webpack": "5.0.0",
+    "typescript": "^4.9.3",
     "worker-loader": "^3.0.5"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,22 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 6
-  cacheKey: 8c0
+  version: 7
+  cacheKey: 9c0
 
 "@babel/cli@npm:^7.0.0":
   version: 7.16.8
   resolution: "@babel/cli@npm:7.16.8"
   dependencies:
-    "@nicolo-ribaudo/chokidar-2": 2.1.8-no-fsevents.3
-    chokidar: ^3.4.0
-    commander: ^4.0.1
-    convert-source-map: ^1.1.0
-    fs-readdir-recursive: ^1.1.0
-    glob: ^7.0.0
-    make-dir: ^2.1.0
-    slash: ^2.0.0
-    source-map: ^0.5.0
+    "@nicolo-ribaudo/chokidar-2": "npm:2.1.8-no-fsevents.3"
+    chokidar: "npm:^3.4.0"
+    commander: "npm:^4.0.1"
+    convert-source-map: "npm:^1.1.0"
+    fs-readdir-recursive: "npm:^1.1.0"
+    glob: "npm:^7.0.0"
+    make-dir: "npm:^2.1.0"
+    slash: "npm:^2.0.0"
+    source-map: "npm:^0.5.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   dependenciesMeta:
@@ -36,7 +36,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/code-frame@npm:7.16.7"
   dependencies:
-    "@babel/highlight": ^7.16.7
+    "@babel/highlight": "npm:^7.16.7"
   checksum: bed53eab44e67480e67b353b94ab9bef7bce6cdea799dde591c296cfb47d872348f20cf9a3b82b0dbf8530bf67ca438b5bed3d80622ea76c7227cea3e6f04aa6
   languageName: node
   linkType: hard
@@ -52,21 +52,21 @@ __metadata:
   version: 7.16.12
   resolution: "@babel/core@npm:7.16.12"
   dependencies:
-    "@babel/code-frame": ^7.16.7
-    "@babel/generator": ^7.16.8
-    "@babel/helper-compilation-targets": ^7.16.7
-    "@babel/helper-module-transforms": ^7.16.7
-    "@babel/helpers": ^7.16.7
-    "@babel/parser": ^7.16.12
-    "@babel/template": ^7.16.7
-    "@babel/traverse": ^7.16.10
-    "@babel/types": ^7.16.8
-    convert-source-map: ^1.7.0
-    debug: ^4.1.0
-    gensync: ^1.0.0-beta.2
-    json5: ^2.1.2
-    semver: ^6.3.0
-    source-map: ^0.5.0
+    "@babel/code-frame": "npm:^7.16.7"
+    "@babel/generator": "npm:^7.16.8"
+    "@babel/helper-compilation-targets": "npm:^7.16.7"
+    "@babel/helper-module-transforms": "npm:^7.16.7"
+    "@babel/helpers": "npm:^7.16.7"
+    "@babel/parser": "npm:^7.16.12"
+    "@babel/template": "npm:^7.16.7"
+    "@babel/traverse": "npm:^7.16.10"
+    "@babel/types": "npm:^7.16.8"
+    convert-source-map: "npm:^1.7.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.1.2"
+    semver: "npm:^6.3.0"
+    source-map: "npm:^0.5.0"
   checksum: 3e62056eb6e9e20dc785001d720f7958d4e407e5d3ad6203471f85482381c59b5fd9237601be10941aa47394a3bbba2679e7c5850c31225bbae3aa0db45009bf
   languageName: node
   linkType: hard
@@ -75,9 +75,9 @@ __metadata:
   version: 7.16.8
   resolution: "@babel/generator@npm:7.16.8"
   dependencies:
-    "@babel/types": ^7.16.8
-    jsesc: ^2.5.1
-    source-map: ^0.5.0
+    "@babel/types": "npm:^7.16.8"
+    jsesc: "npm:^2.5.1"
+    source-map: "npm:^0.5.0"
   checksum: e09b35d855597b8b1759ef6e80cff28bc915d24b74eaba32a8a9e45ac89470c98f7b66fbe8b19df2eafd9968c60f138670b69dc3735b069709f6f5a1f9c5923d
   languageName: node
   linkType: hard
@@ -86,7 +86,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-annotate-as-pure@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: ce0ba7e9ab86c6c61cb111240428deeded48a0c293a0fc912608875cd30d4783937beba5b303dc97b9296048c09c0156756598939fc172bb36ddbe7760e5e154
   languageName: node
   linkType: hard
@@ -95,8 +95,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-builder-binary-assignment-operator-visitor@npm:7.16.7"
   dependencies:
-    "@babel/helper-explode-assignable-expression": ^7.16.7
-    "@babel/types": ^7.16.7
+    "@babel/helper-explode-assignable-expression": "npm:^7.16.7"
+    "@babel/types": "npm:^7.16.7"
   checksum: ea08e5491ac2edc9d7d57092abf1704835e986ac4184449940dca082b03909f8f4f672f862c582d05a2e5635acd2aaf4efcf57027cd37a027d24034d63cf0610
   languageName: node
   linkType: hard
@@ -105,10 +105,10 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-compilation-targets@npm:7.16.7"
   dependencies:
-    "@babel/compat-data": ^7.16.4
-    "@babel/helper-validator-option": ^7.16.7
-    browserslist: ^4.17.5
-    semver: ^6.3.0
+    "@babel/compat-data": "npm:^7.16.4"
+    "@babel/helper-validator-option": "npm:^7.16.7"
+    browserslist: "npm:^4.17.5"
+    semver: "npm:^6.3.0"
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: a553394b55f1ec7a2b92ca9c9c381dd706f69074ef5404cb146e65b5221d249602f2e78aab56e5e0930f33b0641b3e6aefdd1032df532c50482a3308ec8d2810
@@ -119,13 +119,13 @@ __metadata:
   version: 7.16.10
   resolution: "@babel/helper-create-class-features-plugin@npm:7.16.10"
   dependencies:
-    "@babel/helper-annotate-as-pure": ^7.16.7
-    "@babel/helper-environment-visitor": ^7.16.7
-    "@babel/helper-function-name": ^7.16.7
-    "@babel/helper-member-expression-to-functions": ^7.16.7
-    "@babel/helper-optimise-call-expression": ^7.16.7
-    "@babel/helper-replace-supers": ^7.16.7
-    "@babel/helper-split-export-declaration": ^7.16.7
+    "@babel/helper-annotate-as-pure": "npm:^7.16.7"
+    "@babel/helper-environment-visitor": "npm:^7.16.7"
+    "@babel/helper-function-name": "npm:^7.16.7"
+    "@babel/helper-member-expression-to-functions": "npm:^7.16.7"
+    "@babel/helper-optimise-call-expression": "npm:^7.16.7"
+    "@babel/helper-replace-supers": "npm:^7.16.7"
+    "@babel/helper-split-export-declaration": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: ffd4fbf242c6b7e664fe58c5540174e708a7b789c44643f89bbeb02897a9064a9ba52838414f6b8f1252d602f682c1880aed68ef6c48115366bd2dca8608d3f6
@@ -136,8 +136,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-create-regexp-features-plugin@npm:7.16.7"
   dependencies:
-    "@babel/helper-annotate-as-pure": ^7.16.7
-    regexpu-core: ^4.7.1
+    "@babel/helper-annotate-as-pure": "npm:^7.16.7"
+    regexpu-core: "npm:^4.7.1"
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: fd1e402e21a2abdfd971d0c04bdfe53bf570fb6501e4a837f3c392e6a84056a5fe6a3dc99cbf7c9d2a4963f84569b9ef252f02a3dbfa3f56df74f1c79a18965f
@@ -148,14 +148,14 @@ __metadata:
   version: 0.3.1
   resolution: "@babel/helper-define-polyfill-provider@npm:0.3.1"
   dependencies:
-    "@babel/helper-compilation-targets": ^7.13.0
-    "@babel/helper-module-imports": ^7.12.13
-    "@babel/helper-plugin-utils": ^7.13.0
-    "@babel/traverse": ^7.13.0
-    debug: ^4.1.1
-    lodash.debounce: ^4.0.8
-    resolve: ^1.14.2
-    semver: ^6.1.2
+    "@babel/helper-compilation-targets": "npm:^7.13.0"
+    "@babel/helper-module-imports": "npm:^7.12.13"
+    "@babel/helper-plugin-utils": "npm:^7.13.0"
+    "@babel/traverse": "npm:^7.13.0"
+    debug: "npm:^4.1.1"
+    lodash.debounce: "npm:^4.0.8"
+    resolve: "npm:^1.14.2"
+    semver: "npm:^6.1.2"
   peerDependencies:
     "@babel/core": ^7.4.0-0
   checksum: 1daf68e594bd7d32429693c4083e3cda78f34ebc8b716f54a8bb65b5786a88653e7e0182f98099473599f7717e0da3e96afe1b7f04c420465f3a4c43b2663389
@@ -166,7 +166,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-environment-visitor@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: d89bc719efea94c866b2fddcc349a26c98fc1e0c38e61e23c40bf7c3e34d9e0e43b6c5327bf0b0de95bda4b8ae61388cba1d477cafecf05b3a7c1a71b05a65a6
   languageName: node
   linkType: hard
@@ -175,7 +175,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-explode-assignable-expression@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: f7a990743f8078f9690d4c1d8c190607b8d6acee3c6b25a261a85344a79f60a41c55809954840fd9a31f5d0a4babef1c49692f461a5957d3f193654e1ab454c7
   languageName: node
   linkType: hard
@@ -184,9 +184,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-function-name@npm:7.16.7"
   dependencies:
-    "@babel/helper-get-function-arity": ^7.16.7
-    "@babel/template": ^7.16.7
-    "@babel/types": ^7.16.7
+    "@babel/helper-get-function-arity": "npm:^7.16.7"
+    "@babel/template": "npm:^7.16.7"
+    "@babel/types": "npm:^7.16.7"
   checksum: 1c6a415ee71055bd9a57c8a204ff81417be418990c1a6a5ef2a655e9b74d34658190a051a9b716f77689c292e8b66889d74720d4d69a5c272cf172887f691d0c
   languageName: node
   linkType: hard
@@ -195,7 +195,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-get-function-arity@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: e1bca6793a77144f023af577e8761cab096d5945c4081c54841f58724ae9f5009c1d91603afd266f0f4d279c94bae9430cf029d04445dabd46b1f2e7bc165419
   languageName: node
   linkType: hard
@@ -204,7 +204,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-hoist-variables@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: 20e9775db9d37bd8ba76be5fe08c80a916be794a645311a78c38382d415305690194f61337b508c23528479bf2768ab7484c133c75e8194c6ae55ab46c05bde7
   languageName: node
   linkType: hard
@@ -213,7 +213,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-member-expression-to-functions@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: 73d81b890d322d97dc14a7b43a0fdbb52f2e0ee2bde044f4d07928efbda4f51f0814179c31b4c8ec1f0f8a3c8b47fe2d98602a039e0f48d904b1e30f34b60e47
   languageName: node
   linkType: hard
@@ -222,7 +222,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-module-imports@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: 134e3979d822ddd6871285ead2b7eed7fb4cd8862fec64692c98bb5bd401199a149b510394d75ca39a9dad6d3ecd6f2f14b61ff1f7b8b59781cba5efeb881d04
   languageName: node
   linkType: hard
@@ -231,14 +231,14 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-module-transforms@npm:7.16.7"
   dependencies:
-    "@babel/helper-environment-visitor": ^7.16.7
-    "@babel/helper-module-imports": ^7.16.7
-    "@babel/helper-simple-access": ^7.16.7
-    "@babel/helper-split-export-declaration": ^7.16.7
-    "@babel/helper-validator-identifier": ^7.16.7
-    "@babel/template": ^7.16.7
-    "@babel/traverse": ^7.16.7
-    "@babel/types": ^7.16.7
+    "@babel/helper-environment-visitor": "npm:^7.16.7"
+    "@babel/helper-module-imports": "npm:^7.16.7"
+    "@babel/helper-simple-access": "npm:^7.16.7"
+    "@babel/helper-split-export-declaration": "npm:^7.16.7"
+    "@babel/helper-validator-identifier": "npm:^7.16.7"
+    "@babel/template": "npm:^7.16.7"
+    "@babel/traverse": "npm:^7.16.7"
+    "@babel/types": "npm:^7.16.7"
   checksum: d3417ab9570974487282d0274c9cff8cff4a75130912b4ad88ef256ca3e83732930b4f7a0c0279f574e7549807a3c89961a743a02d29613c5cbce218d1e043d7
   languageName: node
   linkType: hard
@@ -247,7 +247,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-optimise-call-expression@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: 8ceb6ddeaba2709fd9601157175314ec1e1e2536bc01e3a4609c5d4133b899a94f94d9cbd1549e22dce2442d0497270e97cadf796f76d29b60fa8bd0acec9c78
   languageName: node
   linkType: hard
@@ -263,9 +263,9 @@ __metadata:
   version: 7.16.8
   resolution: "@babel/helper-remap-async-to-generator@npm:7.16.8"
   dependencies:
-    "@babel/helper-annotate-as-pure": ^7.16.7
-    "@babel/helper-wrap-function": ^7.16.8
-    "@babel/types": ^7.16.8
+    "@babel/helper-annotate-as-pure": "npm:^7.16.7"
+    "@babel/helper-wrap-function": "npm:^7.16.8"
+    "@babel/types": "npm:^7.16.8"
   checksum: b3a5e62ee58bffb745b3ab1724453c325e1fa191abaa003cbcaf59934df4b5e1d5225519676ab0e3418c8dcd847c71bfc191bd65cdc91d3a92880ce6093ffd6c
   languageName: node
   linkType: hard
@@ -274,11 +274,11 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-replace-supers@npm:7.16.7"
   dependencies:
-    "@babel/helper-environment-visitor": ^7.16.7
-    "@babel/helper-member-expression-to-functions": ^7.16.7
-    "@babel/helper-optimise-call-expression": ^7.16.7
-    "@babel/traverse": ^7.16.7
-    "@babel/types": ^7.16.7
+    "@babel/helper-environment-visitor": "npm:^7.16.7"
+    "@babel/helper-member-expression-to-functions": "npm:^7.16.7"
+    "@babel/helper-optimise-call-expression": "npm:^7.16.7"
+    "@babel/traverse": "npm:^7.16.7"
+    "@babel/types": "npm:^7.16.7"
   checksum: 34cf10dcf113999b3cc9d06443803a0320a0fa4c1be869bbd5f57043d6d3b325374da76eed71bf8aa1d754c7aaa0ae69502cf442b68e9f4496f09a85f08d60ef
   languageName: node
   linkType: hard
@@ -287,7 +287,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-simple-access@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: e46265892655675cc5968ea9c9932104389146258e2b383fdb3b4aef9052acb03cd5463abc712c97745bc619de68f612b7337f0d607f57f822db91e9064605d2
   languageName: node
   linkType: hard
@@ -296,7 +296,7 @@ __metadata:
   version: 7.16.0
   resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.16.0"
   dependencies:
-    "@babel/types": ^7.16.0
+    "@babel/types": "npm:^7.16.0"
   checksum: d3b8668a355e82a1c18137a1d5f3d8565ec88cff464f1c0a7c6e99c4cd0d92a77aeb51ca7fa71afa3bf8c50035bc5cf25504f46e01a94b9e6a297bdf3ac35f40
   languageName: node
   linkType: hard
@@ -305,7 +305,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-split-export-declaration@npm:7.16.7"
   dependencies:
-    "@babel/types": ^7.16.7
+    "@babel/types": "npm:^7.16.7"
   checksum: a710d13e67747040167064e90e9a4eb262f89cecde75ecdd0a1bd456186a7a2c4cede8ad5e28e12d2437230970f38e9ee97e878801bafcb49b2cc755a1753434
   languageName: node
   linkType: hard
@@ -328,10 +328,10 @@ __metadata:
   version: 7.16.8
   resolution: "@babel/helper-wrap-function@npm:7.16.8"
   dependencies:
-    "@babel/helper-function-name": ^7.16.7
-    "@babel/template": ^7.16.7
-    "@babel/traverse": ^7.16.8
-    "@babel/types": ^7.16.8
+    "@babel/helper-function-name": "npm:^7.16.7"
+    "@babel/template": "npm:^7.16.7"
+    "@babel/traverse": "npm:^7.16.8"
+    "@babel/types": "npm:^7.16.8"
   checksum: 3f73620d6ea744d1dadcc3c9141bfe91ddf1cb6e09fbb750f5d5fdc615e8b1a6d27985901b7eaffa6524284c557b187589272fa3b49aa678be6a32ff84dd4b38
   languageName: node
   linkType: hard
@@ -340,9 +340,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helpers@npm:7.16.7"
   dependencies:
-    "@babel/template": ^7.16.7
-    "@babel/traverse": ^7.16.7
-    "@babel/types": ^7.16.7
+    "@babel/template": "npm:^7.16.7"
+    "@babel/traverse": "npm:^7.16.7"
+    "@babel/types": "npm:^7.16.7"
   checksum: 4dd010db47af5cf4486274e885d22ae41ab7df896fa2bf15e7e8f493a3042a12ba2ccef96e2e6ddf4a2ade69439c9aa00dfebcdfd2bcf76147d6aaa87d5b0a11
   languageName: node
   linkType: hard
@@ -351,9 +351,9 @@ __metadata:
   version: 7.16.10
   resolution: "@babel/highlight@npm:7.16.10"
   dependencies:
-    "@babel/helper-validator-identifier": ^7.16.7
-    chalk: ^2.0.0
-    js-tokens: ^4.0.0
+    "@babel/helper-validator-identifier": "npm:^7.16.7"
+    chalk: "npm:^2.0.0"
+    js-tokens: "npm:^4.0.0"
   checksum: 0ec2007a1fbd826f4433daded828a65b824fa653c65c57d7a45aea161636994099db8c071a7a4e0844c2a2cec3aeaea62359f4b8b907f9cae7e440693af65331
   languageName: node
   linkType: hard
@@ -371,7 +371,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 42b5f75ad16404802675c7b997ccf3f5a4e096eb1d55d711b10adcc2c2179b604080121bdf93302b184269abc2449601e66dc88bdc3621ad7f6db718f809ef3b
@@ -382,9 +382,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-skip-transparent-expression-wrappers": ^7.16.0
-    "@babel/plugin-proposal-optional-chaining": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.16.0"
+    "@babel/plugin-proposal-optional-chaining": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.13.0
   checksum: 4b365feab29261f217d324de8a20b1defc85f53f78057ca779dab2544a3cac8667ad49039c510cf5aeafe7fb6e22face09ca2aa7ea99588bc2880593d4da59bd
@@ -395,9 +395,9 @@ __metadata:
   version: 7.16.8
   resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.16.8"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-remap-async-to-generator": ^7.16.8
-    "@babel/plugin-syntax-async-generators": ^7.8.4
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-remap-async-to-generator": "npm:^7.16.8"
+    "@babel/plugin-syntax-async-generators": "npm:^7.8.4"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 557d81220310694abcece8c33f1bba1e3fe911cd7368bd04ff3c109a8b5fd4d4d2892b60f0ed6d3e4f919dca65d65cf8bac515a4e94ada3b037f1aff3d3106a7
@@ -408,8 +408,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-class-properties@npm:7.16.7"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-create-class-features-plugin": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 70b7995e67800525478bf27e98ee91473c68628b1e61e262e98e06606502baaa3c5350e5afe2fbf15ae8c176b2c9472b8019faa53bded378dd2193bbdd8f54c1
@@ -420,9 +420,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-class-static-block@npm:7.16.7"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-class-static-block": ^7.14.5
+    "@babel/helper-create-class-features-plugin": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-class-static-block": "npm:^7.14.5"
   peerDependencies:
     "@babel/core": ^7.12.0
   checksum: 5d274cbc170844478810901f2d404491239fb25910f36ac021cea84cb5f40cb26c15da4918f6913df644f467904f7ff1c870f2fe3316580bb1aeea6259a2f913
@@ -433,9 +433,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-decorators@npm:7.16.7"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-decorators": ^7.16.7
+    "@babel/helper-create-class-features-plugin": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-decorators": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 77ee8440d03b01e92245108320f3d98d2abfe6a0c54c5ab0f0112110376eb22da953c6f7ab04dcb2741edff1ff811a107c3900c1821ad9f9dde8d7c6245c4ea6
@@ -446,8 +446,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-dynamic-import@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1d8af47bfef56d36dd1cf8b54dcd2b52f740eccbe9530384739b0b8ed5caeb0eae366d275cf16658ff917c1cb05880e41039a497e169206c99cab49b99624e82
@@ -458,8 +458,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-export-namespace-from@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-export-namespace-from": "npm:^7.8.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 97f0746e994768834bf2138f0da69e1c75d987ce62779bacf4a22552e2bb1557634cfeecfd1413d8442a0d0893b8ecb23aae128da4749a3374887c671b866132
@@ -470,8 +470,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-json-strings@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-json-strings": ^7.8.3
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-json-strings": "npm:^7.8.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: a41971e27a9a87403d562604e8a4fbc4f74c5a2ad8490fb44cea69fa6baa1ce5ce46bf350c2bc2ca98f51a597aab29cbed650124627fb73fbcf143cc19bf622f
@@ -482,8 +482,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-logical-assignment-operators@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-logical-assignment-operators": "npm:^7.10.4"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 09c724facc4f3520a4e66ecc5afff26f57875d2af1bbd87d531af76dcec0fdbce450b62fe57a9cc65a8928fe5248d66bc16370df0972ea6bdeae329d11525311
@@ -494,8 +494,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-nullish-coalescing-operator@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.8.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 648065e8bfb10d6c68e4916f89a3aa368ce89139e2615dbcbc39b5d149d7d0275705e6032130fa14a38a4da04b61444a829e128ee224ffd906ccb3545c85a1fc
@@ -506,8 +506,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-numeric-separator@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-numeric-separator": "npm:^7.10.4"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 9f7d8223df576e9e8966c02354d9edec8c9c2edcd47162e08342693142be2fff0bc58c636d93bb83c36ab16f276cdcbc03cf68360f496153be1fe035ca72feb6
@@ -518,11 +518,11 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.16.7"
   dependencies:
-    "@babel/compat-data": ^7.16.4
-    "@babel/helper-compilation-targets": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
-    "@babel/plugin-transform-parameters": ^7.16.7
+    "@babel/compat-data": "npm:^7.16.4"
+    "@babel/helper-compilation-targets": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-object-rest-spread": "npm:^7.8.3"
+    "@babel/plugin-transform-parameters": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 14dd5a094e38ab0b624bceab9fde13c8def5abd1b6d5a9c4be8d554901e496a6fc0429d3d88ffd8b0a8001ec2ef48a6865f2a8a2826eaa9d44aea05fcbef9072
@@ -533,8 +533,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-optional-catch-binding@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-optional-catch-binding": "npm:^7.8.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 8bfd71d663dd8e45e7bc9024d178f5046519e1d8af13ee1dd25b9a42155c7c7745eac779ed416438fb0be946d9f1da8b9dfae94c77a419e05bf4df9b4623071e
@@ -545,9 +545,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-optional-chaining@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-skip-transparent-expression-wrappers": ^7.16.0
-    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.16.0"
+    "@babel/plugin-syntax-optional-chaining": "npm:^7.8.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 7b710bb6cee4757ef7f85adb127b91217eee2876269275ccf35aa0a183296337abd9357948706337e532b279d156acb359a7eb61ce8b95f5cdfdbdb22665ecb4
@@ -558,8 +558,8 @@ __metadata:
   version: 7.16.11
   resolution: "@babel/plugin-proposal-private-methods@npm:7.16.11"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.16.10
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-create-class-features-plugin": "npm:^7.16.10"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 3e57910a383762414e3c96c3e29b493e75a2aa33d32ae44cb35e5a7ba2f7fea31bb2808496525724abef2c7048e0328fd1821a0c90a92f0d34325ae149ac9d96
@@ -570,10 +570,10 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.16.7"
   dependencies:
-    "@babel/helper-annotate-as-pure": ^7.16.7
-    "@babel/helper-create-class-features-plugin": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+    "@babel/helper-annotate-as-pure": "npm:^7.16.7"
+    "@babel/helper-create-class-features-plugin": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-private-property-in-object": "npm:^7.14.5"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 19a985270fbc243f049c2ac306705cd05b7b965f0a08ba48279daffb68f2565da6d3898faf960091ec2f2c85c3a337ba99e5a7389410dfd6a57447cbcd6c7992
@@ -584,8 +584,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-proposal-unicode-property-regex@npm:7.16.7"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 4b0c93be393483691fc9ae85f0b386c0a50094a9a45b0bcffc5e60665f78e55832e5611243565ddf42ba596508b1dffd77a0871d78725a6b679086ff065095cb
@@ -596,7 +596,7 @@ __metadata:
   version: 7.8.4
   resolution: "@babel/plugin-syntax-async-generators@npm:7.8.4"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: d13efb282838481348c71073b6be6245b35d4f2f964a8f71e4174f235009f929ef7613df25f8d2338e2d3e44bc4265a9f8638c6aaa136d7a61fe95985f9725c8
@@ -607,7 +607,7 @@ __metadata:
   version: 7.12.13
   resolution: "@babel/plugin-syntax-class-properties@npm:7.12.13"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.12.13
+    "@babel/helper-plugin-utils": "npm:^7.12.13"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 95168fa186416195280b1264fb18afcdcdcea780b3515537b766cb90de6ce042d42dd6a204a39002f794ae5845b02afb0fd4861a3308a861204a55e68310a120
@@ -618,7 +618,7 @@ __metadata:
   version: 7.14.5
   resolution: "@babel/plugin-syntax-class-static-block@npm:7.14.5"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-plugin-utils": "npm:^7.14.5"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 4464bf9115f4a2d02ce1454411baf9cfb665af1da53709c5c56953e5e2913745b0fcce82982a00463d6facbdd93445c691024e310b91431a1e2f024b158f6371
@@ -629,7 +629,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-syntax-decorators@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: e8843aa21d351dcaf747fa0c48d66f94c9b6e8788d4cbb585381a40bf2120d3f78be2228cde6a6320e36ade694199ea4d057167a9cfeab1756832f4106671641
@@ -640,7 +640,7 @@ __metadata:
   version: 7.8.3
   resolution: "@babel/plugin-syntax-dynamic-import@npm:7.8.3"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 9c50927bf71adf63f60c75370e2335879402648f468d0172bc912e303c6a3876927d8eb35807331b57f415392732ed05ab9b42c68ac30a936813ab549e0246c5
@@ -651,7 +651,7 @@ __metadata:
   version: 7.8.3
   resolution: "@babel/plugin-syntax-export-namespace-from@npm:7.8.3"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.8.3
+    "@babel/helper-plugin-utils": "npm:^7.8.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 5100d658ba563829700cd8d001ddc09f4c0187b1a13de300d729c5b3e87503f75a6d6c99c1794182f7f1a9f546ee009df4f15a0ce36376e206ed0012fa7cdc24
@@ -662,7 +662,7 @@ __metadata:
   version: 7.8.3
   resolution: "@babel/plugin-syntax-json-strings@npm:7.8.3"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: e98f31b2ec406c57757d115aac81d0336e8434101c224edd9a5c93cefa53faf63eacc69f3138960c8b25401315af03df37f68d316c151c4b933136716ed6906e
@@ -673,7 +673,7 @@ __metadata:
   version: 7.10.4
   resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/helper-plugin-utils": "npm:^7.10.4"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2594cfbe29411ad5bc2ad4058de7b2f6a8c5b86eda525a993959438615479e59c012c14aec979e538d60a584a1a799b60d1b8942c3b18468cb9d99b8fd34cd0b
@@ -684,7 +684,7 @@ __metadata:
   version: 7.8.3
   resolution: "@babel/plugin-syntax-nullish-coalescing-operator@npm:7.8.3"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2024fbb1162899094cfc81152449b12bd0cc7053c6d4bda8ac2852545c87d0a851b1b72ed9560673cbf3ef6248257262c3c04aabf73117215c1b9cc7dd2542ce
@@ -695,7 +695,7 @@ __metadata:
   version: 7.10.4
   resolution: "@babel/plugin-syntax-numeric-separator@npm:7.10.4"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/helper-plugin-utils": "npm:^7.10.4"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: c55a82b3113480942c6aa2fcbe976ff9caa74b7b1109ff4369641dfbc88d1da348aceb3c31b6ed311c84d1e7c479440b961906c735d0ab494f688bf2fd5b9bb9
@@ -706,7 +706,7 @@ __metadata:
   version: 7.8.3
   resolution: "@babel/plugin-syntax-object-rest-spread@npm:7.8.3"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: ee1eab52ea6437e3101a0a7018b0da698545230015fc8ab129d292980ec6dff94d265e9e90070e8ae5fed42f08f1622c14c94552c77bcac784b37f503a82ff26
@@ -717,7 +717,7 @@ __metadata:
   version: 7.8.3
   resolution: "@babel/plugin-syntax-optional-catch-binding@npm:7.8.3"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 27e2493ab67a8ea6d693af1287f7e9acec206d1213ff107a928e85e173741e1d594196f99fec50e9dde404b09164f39dec5864c767212154ffe1caa6af0bc5af
@@ -728,7 +728,7 @@ __metadata:
   version: 7.8.3
   resolution: "@babel/plugin-syntax-optional-chaining@npm:7.8.3"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 46edddf2faa6ebf94147b8e8540dfc60a5ab718e2de4d01b2c0bdf250a4d642c2bd47cbcbb739febcb2bf75514dbcefad3c52208787994b8d0f8822490f55e81
@@ -739,7 +739,7 @@ __metadata:
   version: 7.14.5
   resolution: "@babel/plugin-syntax-private-property-in-object@npm:7.14.5"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-plugin-utils": "npm:^7.14.5"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 69822772561706c87f0a65bc92d0772cea74d6bc0911537904a676d5ff496a6d3ac4e05a166d8125fce4a16605bace141afc3611074e170a994e66e5397787f3
@@ -750,7 +750,7 @@ __metadata:
   version: 7.14.5
   resolution: "@babel/plugin-syntax-top-level-await@npm:7.14.5"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-plugin-utils": "npm:^7.14.5"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 14bf6e65d5bc1231ffa9def5f0ef30b19b51c218fcecaa78cd1bdf7939dfdf23f90336080b7f5196916368e399934ce5d581492d8292b46a2fb569d8b2da106f
@@ -761,7 +761,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-syntax-typescript@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 8eb1dbc06511035293d1af8172be5edec8d80e1a5c908258a1abd4fccb18879cdbae31e8ff813b310e4598a0a5484ebe0b686d50a0e820c17ed518bdca8c1af9
@@ -772,7 +772,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-arrow-functions@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 69dce936e6684d9b3760bb2d7aefb2490db245a79b5437385da1ddfbe2ecaf673dfc0b5510aa6b871bd1b9dce1b3c2e4fdbdc8e94006f15ee2526e17e7f4af4a
@@ -783,9 +783,9 @@ __metadata:
   version: 7.16.8
   resolution: "@babel/plugin-transform-async-to-generator@npm:7.16.8"
   dependencies:
-    "@babel/helper-module-imports": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-remap-async-to-generator": ^7.16.8
+    "@babel/helper-module-imports": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-remap-async-to-generator": "npm:^7.16.8"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: d75d5cd8560a589578e1e33be1542da17116b1778347af17122910cd0bbb94e0f70ae92beae4f18a1b36dd8dc5251a51e68112e6940117615c667d9147f365cc
@@ -796,7 +796,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 22069250a48e47c2818e1b5d5f81a7309792db07b1c9130faac2c47278b81d03e498ea12bed40f45ffdd5f240babc852c0cb2c65e77720b42ab6934cf2d52ea0
@@ -807,7 +807,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-block-scoping@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 8ba89b3b52f630d7e481d39d2bf71ff4a66d52442ccad00873f38169a39f847bd53a100ce84a96e29b1c38c75330812ff34ab798c265dc7547e3d5cda35f9f58
@@ -818,14 +818,14 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-classes@npm:7.16.7"
   dependencies:
-    "@babel/helper-annotate-as-pure": ^7.16.7
-    "@babel/helper-environment-visitor": ^7.16.7
-    "@babel/helper-function-name": ^7.16.7
-    "@babel/helper-optimise-call-expression": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-replace-supers": ^7.16.7
-    "@babel/helper-split-export-declaration": ^7.16.7
-    globals: ^11.1.0
+    "@babel/helper-annotate-as-pure": "npm:^7.16.7"
+    "@babel/helper-environment-visitor": "npm:^7.16.7"
+    "@babel/helper-function-name": "npm:^7.16.7"
+    "@babel/helper-optimise-call-expression": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-replace-supers": "npm:^7.16.7"
+    "@babel/helper-split-export-declaration": "npm:^7.16.7"
+    globals: "npm:^11.1.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 61b13fd9308711fbf364674c5931fa50619ee98e9e26b44c081e43e8074e7aec96c470b42ddeeda287bab065005229079b39c20074a8cd592f5194b3c7434f74
@@ -836,7 +836,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-computed-properties@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 6be05be2c6d434ced8d86ccf4f98e591fc556faf7470b09eac9422dece9876b2c4b96d3f3c51d4260045a7cd2770a1de70fb3dc900e61a3132dcd69cfe8b9b5c
@@ -847,7 +847,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-destructuring@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 67550752bbf9847490356b4a243f5efed320bbe904825ff0ccc60c9b6122ee5fc24134a5bc469d298d4ccde880ce33843abe4d5157da5f8f864573583e9b6aa1
@@ -858,8 +858,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-dotall-regex@npm:7.16.7"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: d2f6aa2dc2562c9969dbe3338f2afca7cd53f16989a14054ff7e45d0b7c5fc626e4b378904e29d13078db62ef6bd6805775644a27b3c461c0e679e590aac8d49
@@ -870,7 +870,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-duplicate-keys@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 3313e9a3bc7878c3d139d25891c6fb7a7ed6e23a4cdf80aaac25c6930f3a1005e5bb774f7f5dda4116e5914b2b898953b500f85d2f3d19ab77246a366117afc2
@@ -881,8 +881,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.16.7"
   dependencies:
-    "@babel/helper-builder-binary-assignment-operator-visitor": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-builder-binary-assignment-operator-visitor": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 8c0f3a8c51179a695592329d9fa5e6ce435d79dfb818b4069c26722d5f6f9b97c61cb45118d45218c5aed7c1ce50ca29daa6059c71532f681f54726d1bf524e4
@@ -893,7 +893,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-for-of@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: cddf6264096bea79ca662f267acf0f12cce783799f29e1b4b60a3ab543d2e426e9da2fc16b63c6f4df123d50c657bf57d58a43549bfdba28340c67f7eb67513c
@@ -904,9 +904,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-function-name@npm:7.16.7"
   dependencies:
-    "@babel/helper-compilation-targets": ^7.16.7
-    "@babel/helper-function-name": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-compilation-targets": "npm:^7.16.7"
+    "@babel/helper-function-name": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 0f4e5af926b990c98a53caf1c4dcc215ab02588de0eaae616d658ab3e5947f5cd41140a0d84b73cae925cfa4b93b7ee9a4079cb0566cae369ede52d6d0c0a45c
@@ -917,7 +917,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-literals@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 3d3566e6ce02a2b1c7f8cf26f1b80d361b9df665c7256ddcf0177b59e411ebf3df094bdd5fd90aeef81bcb33f47e5de58e16d7e82113304bfd6eabc48cf47ca1
@@ -928,7 +928,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-member-expression-literals@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: db1ccd139f6e4278a215503effd52be8c92fe689c0e6856da43689a67fc56418c10b3907bde91eba13e932ba99a3ebee08bff2b5b7b4d250e6538f308eb6d332
@@ -939,9 +939,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-modules-amd@npm:7.16.7"
   dependencies:
-    "@babel/helper-module-transforms": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    babel-plugin-dynamic-import-node: ^2.3.3
+    "@babel/helper-module-transforms": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    babel-plugin-dynamic-import-node: "npm:^2.3.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: eea74b0436124035ef1672f8181e00a4a2fca8105f4893c2464bb299cb55ab5be7530121ab68e45003279174fa3e8c357ce96baaaeae08bf2354897911ea63d0
@@ -952,10 +952,10 @@ __metadata:
   version: 7.16.8
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.16.8"
   dependencies:
-    "@babel/helper-module-transforms": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-simple-access": ^7.16.7
-    babel-plugin-dynamic-import-node: ^2.3.3
+    "@babel/helper-module-transforms": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-simple-access": "npm:^7.16.7"
+    babel-plugin-dynamic-import-node: "npm:^2.3.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 9ace3c1ebceb4a40548939f14b53f7ac57a6648aac2fae4a65a75710579a4b92e08c0a1e2d5dfba82fb3ce2da91bc017d248a4473e9cdac7ef0f78ae3a157f22
@@ -966,11 +966,11 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-modules-systemjs@npm:7.16.7"
   dependencies:
-    "@babel/helper-hoist-variables": ^7.16.7
-    "@babel/helper-module-transforms": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-validator-identifier": ^7.16.7
-    babel-plugin-dynamic-import-node: ^2.3.3
+    "@babel/helper-hoist-variables": "npm:^7.16.7"
+    "@babel/helper-module-transforms": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-validator-identifier": "npm:^7.16.7"
+    babel-plugin-dynamic-import-node: "npm:^2.3.3"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 7a8239d7aae270c6230729c3eb8f352b150cc5d4467e9121ce4aa38593191b4f53eb8b523255b9d8bca481357f2cd666de38119cb877515dc28a1c9fd2d9e375
@@ -981,8 +981,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-modules-umd@npm:7.16.7"
   dependencies:
-    "@babel/helper-module-transforms": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-module-transforms": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2129af03c2e12df5267da56ce909e7164b2b644362e7c2fcc37391e9bc68d50095834b94c4f73293f1778e5234b2b82b89692bfc16ac5b27e889b82c23db0971
@@ -993,7 +993,7 @@ __metadata:
   version: 7.16.8
   resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.16.8"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": ^7.16.7
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 05467b5cef1ee5882b83aa72e09550680d291d1e01528d138e6651d0cc8dfcf696d0decbc563b4d65376785e2dca7573bac709a9fd1d21bc440ff1e21f1a7383
@@ -1004,7 +1004,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-new-target@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 7d2287274facc4a63224525f33fc1278871eea6d89dcfa5bf9791bae4e1f0e919a1a31bd3be783b4122fc0a883852ff59000b6689518dd1d4516d2f289d00266
@@ -1015,8 +1015,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-object-super@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-replace-supers": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-replace-supers": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 641621635783251f8b42346f7359d8985aa1b821ab83a3a841f7393fddf94c71f5f1c373bd4ee8d0d39c95c29c593df004f7d379c9e552e86297f6ff174b9036
@@ -1027,7 +1027,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-parameters@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 3b7b350ce808a6bc858348f51329e232ef332c5326a30e9b80d927b4b43a1f68a31ddc2d791e08c8ec6f43d4878e726f46de9e84e76234213fc4fa2645660de7
@@ -1038,7 +1038,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-property-literals@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 7a5362389d479964af471a714e8194ba9f41ad22e1918a2878a8ed9e1375977dc61125f04a50012f1b63cf6e4afbbc785afd8b4fd9d70010def211016ae450d5
@@ -1049,7 +1049,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-regenerator@npm:7.16.7"
   dependencies:
-    regenerator-transform: ^0.14.2
+    regenerator-transform: "npm:^0.14.2"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1b0774be99826b5c2bfb06d4d301a01b929c14d87670045f5cb347f80eca4095da9458f8288b3686ca490b1d70544035f015e24996e181a76087c932ce2e1ccd
@@ -1060,7 +1060,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-reserved-words@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: fe61e3dd89b1b733a118145179552d0b31c68e40ed296f122728a13f462b29a43a3b7cf4686c367b6ad4d15670874676d04da5ea5eace41c393e81aeb66351bb
@@ -1071,12 +1071,12 @@ __metadata:
   version: 7.16.10
   resolution: "@babel/plugin-transform-runtime@npm:7.16.10"
   dependencies:
-    "@babel/helper-module-imports": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    babel-plugin-polyfill-corejs2: ^0.3.0
-    babel-plugin-polyfill-corejs3: ^0.5.0
-    babel-plugin-polyfill-regenerator: ^0.3.0
-    semver: ^6.3.0
+    "@babel/helper-module-imports": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    babel-plugin-polyfill-corejs2: "npm:^0.3.0"
+    babel-plugin-polyfill-corejs3: "npm:^0.5.0"
+    babel-plugin-polyfill-regenerator: "npm:^0.3.0"
+    semver: "npm:^6.3.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 08ffe52331d972a3c9c7cb35cfd7ec1c71c409541ab3a6b971d943a85e2877771f525716c93a509805dec62a427f7a738a5421f5848dbb74289d60a819935f7d
@@ -1087,7 +1087,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-shorthand-properties@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 7b873b600cfecafb701ea08e55573c784983f353ecd3c39cc5ac635d87ee508fe7ba2833835b8cfb55b70e3d1ed0a10d48b970ea1311e2886f8abbd746fb8c5f
@@ -1098,8 +1098,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-spread@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-skip-transparent-expression-wrappers": ^7.16.0
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.16.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 171ec5c6a873afa3999ab96acd211aafd7b8194d38ae254e0ff03148ebd2600400f7280af0aa0da78f90c1adb5d0af84a6dfc6b418cc891bc351a34065ee7cc1
@@ -1110,7 +1110,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-sticky-regex@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: da1d346c479c0b438eeb2fe2a993e48d19e5d1103e0c8684d56f09f0f15fec21e88e469445920b3fdd955ae6d365524f7ea3c54bd5772ecacefa65d0b94c80e0
@@ -1121,7 +1121,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-template-literals@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: f9e6ace71abfaad5c86197b5a6040b7b170a918000a8bccb7ca49bb4e088bf90383739cfba63513526f239f5073562e6661efd978de354ae39656d7f9fcf37e6
@@ -1132,7 +1132,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-typeof-symbol@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: fca9883472cc1687350b2261aa6da32dccd213a0629431f45d1501c7192947d543b320c17d892feac93e30f8965cd0c8bee460510f72a4d3e4ffa5dfbff8d29e
@@ -1143,9 +1143,9 @@ __metadata:
   version: 7.16.8
   resolution: "@babel/plugin-transform-typescript@npm:7.16.8"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-typescript": ^7.16.7
+    "@babel/helper-create-class-features-plugin": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/plugin-syntax-typescript": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 4a563fa4b52233fc7529fa55fe3d6ac717429a4e8f52e762cb50423c685e1bf9b1177accf4b768515f4bcae8129baf4ca79540bb3ede2f19f5567aecce4d2cd1
@@ -1156,7 +1156,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-unicode-escapes@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: aabd933bc4c0936e45991ccd43b46b50e33e5495da36a32244693145fa5707c82a5d6d7f43e9a02f7e6df41da942707b4336461de5c7be5b82f4de2346ac7361
@@ -1167,8 +1167,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/plugin-transform-unicode-regex@npm:7.16.7"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: ce3843c02e5e2b0007e4fd64f75282c5f69f9bd55e24574991a5fd3ee12aa2e4754304a7580ea8bb72f611b892303bce583dcfc2c4379869548413fa975ae549
@@ -1179,80 +1179,80 @@ __metadata:
   version: 7.16.11
   resolution: "@babel/preset-env@npm:7.16.11"
   dependencies:
-    "@babel/compat-data": ^7.16.8
-    "@babel/helper-compilation-targets": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-validator-option": ^7.16.7
-    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": ^7.16.7
-    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.16.7
-    "@babel/plugin-proposal-async-generator-functions": ^7.16.8
-    "@babel/plugin-proposal-class-properties": ^7.16.7
-    "@babel/plugin-proposal-class-static-block": ^7.16.7
-    "@babel/plugin-proposal-dynamic-import": ^7.16.7
-    "@babel/plugin-proposal-export-namespace-from": ^7.16.7
-    "@babel/plugin-proposal-json-strings": ^7.16.7
-    "@babel/plugin-proposal-logical-assignment-operators": ^7.16.7
-    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.16.7
-    "@babel/plugin-proposal-numeric-separator": ^7.16.7
-    "@babel/plugin-proposal-object-rest-spread": ^7.16.7
-    "@babel/plugin-proposal-optional-catch-binding": ^7.16.7
-    "@babel/plugin-proposal-optional-chaining": ^7.16.7
-    "@babel/plugin-proposal-private-methods": ^7.16.11
-    "@babel/plugin-proposal-private-property-in-object": ^7.16.7
-    "@babel/plugin-proposal-unicode-property-regex": ^7.16.7
-    "@babel/plugin-syntax-async-generators": ^7.8.4
-    "@babel/plugin-syntax-class-properties": ^7.12.13
-    "@babel/plugin-syntax-class-static-block": ^7.14.5
-    "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
-    "@babel/plugin-syntax-json-strings": ^7.8.3
-    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
-    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
-    "@babel/plugin-syntax-numeric-separator": ^7.10.4
-    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
-    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
-    "@babel/plugin-syntax-optional-chaining": ^7.8.3
-    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
-    "@babel/plugin-syntax-top-level-await": ^7.14.5
-    "@babel/plugin-transform-arrow-functions": ^7.16.7
-    "@babel/plugin-transform-async-to-generator": ^7.16.8
-    "@babel/plugin-transform-block-scoped-functions": ^7.16.7
-    "@babel/plugin-transform-block-scoping": ^7.16.7
-    "@babel/plugin-transform-classes": ^7.16.7
-    "@babel/plugin-transform-computed-properties": ^7.16.7
-    "@babel/plugin-transform-destructuring": ^7.16.7
-    "@babel/plugin-transform-dotall-regex": ^7.16.7
-    "@babel/plugin-transform-duplicate-keys": ^7.16.7
-    "@babel/plugin-transform-exponentiation-operator": ^7.16.7
-    "@babel/plugin-transform-for-of": ^7.16.7
-    "@babel/plugin-transform-function-name": ^7.16.7
-    "@babel/plugin-transform-literals": ^7.16.7
-    "@babel/plugin-transform-member-expression-literals": ^7.16.7
-    "@babel/plugin-transform-modules-amd": ^7.16.7
-    "@babel/plugin-transform-modules-commonjs": ^7.16.8
-    "@babel/plugin-transform-modules-systemjs": ^7.16.7
-    "@babel/plugin-transform-modules-umd": ^7.16.7
-    "@babel/plugin-transform-named-capturing-groups-regex": ^7.16.8
-    "@babel/plugin-transform-new-target": ^7.16.7
-    "@babel/plugin-transform-object-super": ^7.16.7
-    "@babel/plugin-transform-parameters": ^7.16.7
-    "@babel/plugin-transform-property-literals": ^7.16.7
-    "@babel/plugin-transform-regenerator": ^7.16.7
-    "@babel/plugin-transform-reserved-words": ^7.16.7
-    "@babel/plugin-transform-shorthand-properties": ^7.16.7
-    "@babel/plugin-transform-spread": ^7.16.7
-    "@babel/plugin-transform-sticky-regex": ^7.16.7
-    "@babel/plugin-transform-template-literals": ^7.16.7
-    "@babel/plugin-transform-typeof-symbol": ^7.16.7
-    "@babel/plugin-transform-unicode-escapes": ^7.16.7
-    "@babel/plugin-transform-unicode-regex": ^7.16.7
-    "@babel/preset-modules": ^0.1.5
-    "@babel/types": ^7.16.8
-    babel-plugin-polyfill-corejs2: ^0.3.0
-    babel-plugin-polyfill-corejs3: ^0.5.0
-    babel-plugin-polyfill-regenerator: ^0.3.0
-    core-js-compat: ^3.20.2
-    semver: ^6.3.0
+    "@babel/compat-data": "npm:^7.16.8"
+    "@babel/helper-compilation-targets": "npm:^7.16.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-validator-option": "npm:^7.16.7"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "npm:^7.16.7"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "npm:^7.16.7"
+    "@babel/plugin-proposal-async-generator-functions": "npm:^7.16.8"
+    "@babel/plugin-proposal-class-properties": "npm:^7.16.7"
+    "@babel/plugin-proposal-class-static-block": "npm:^7.16.7"
+    "@babel/plugin-proposal-dynamic-import": "npm:^7.16.7"
+    "@babel/plugin-proposal-export-namespace-from": "npm:^7.16.7"
+    "@babel/plugin-proposal-json-strings": "npm:^7.16.7"
+    "@babel/plugin-proposal-logical-assignment-operators": "npm:^7.16.7"
+    "@babel/plugin-proposal-nullish-coalescing-operator": "npm:^7.16.7"
+    "@babel/plugin-proposal-numeric-separator": "npm:^7.16.7"
+    "@babel/plugin-proposal-object-rest-spread": "npm:^7.16.7"
+    "@babel/plugin-proposal-optional-catch-binding": "npm:^7.16.7"
+    "@babel/plugin-proposal-optional-chaining": "npm:^7.16.7"
+    "@babel/plugin-proposal-private-methods": "npm:^7.16.11"
+    "@babel/plugin-proposal-private-property-in-object": "npm:^7.16.7"
+    "@babel/plugin-proposal-unicode-property-regex": "npm:^7.16.7"
+    "@babel/plugin-syntax-async-generators": "npm:^7.8.4"
+    "@babel/plugin-syntax-class-properties": "npm:^7.12.13"
+    "@babel/plugin-syntax-class-static-block": "npm:^7.14.5"
+    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
+    "@babel/plugin-syntax-export-namespace-from": "npm:^7.8.3"
+    "@babel/plugin-syntax-json-strings": "npm:^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators": "npm:^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.8.3"
+    "@babel/plugin-syntax-numeric-separator": "npm:^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread": "npm:^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding": "npm:^7.8.3"
+    "@babel/plugin-syntax-optional-chaining": "npm:^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object": "npm:^7.14.5"
+    "@babel/plugin-syntax-top-level-await": "npm:^7.14.5"
+    "@babel/plugin-transform-arrow-functions": "npm:^7.16.7"
+    "@babel/plugin-transform-async-to-generator": "npm:^7.16.8"
+    "@babel/plugin-transform-block-scoped-functions": "npm:^7.16.7"
+    "@babel/plugin-transform-block-scoping": "npm:^7.16.7"
+    "@babel/plugin-transform-classes": "npm:^7.16.7"
+    "@babel/plugin-transform-computed-properties": "npm:^7.16.7"
+    "@babel/plugin-transform-destructuring": "npm:^7.16.7"
+    "@babel/plugin-transform-dotall-regex": "npm:^7.16.7"
+    "@babel/plugin-transform-duplicate-keys": "npm:^7.16.7"
+    "@babel/plugin-transform-exponentiation-operator": "npm:^7.16.7"
+    "@babel/plugin-transform-for-of": "npm:^7.16.7"
+    "@babel/plugin-transform-function-name": "npm:^7.16.7"
+    "@babel/plugin-transform-literals": "npm:^7.16.7"
+    "@babel/plugin-transform-member-expression-literals": "npm:^7.16.7"
+    "@babel/plugin-transform-modules-amd": "npm:^7.16.7"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.16.8"
+    "@babel/plugin-transform-modules-systemjs": "npm:^7.16.7"
+    "@babel/plugin-transform-modules-umd": "npm:^7.16.7"
+    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.16.8"
+    "@babel/plugin-transform-new-target": "npm:^7.16.7"
+    "@babel/plugin-transform-object-super": "npm:^7.16.7"
+    "@babel/plugin-transform-parameters": "npm:^7.16.7"
+    "@babel/plugin-transform-property-literals": "npm:^7.16.7"
+    "@babel/plugin-transform-regenerator": "npm:^7.16.7"
+    "@babel/plugin-transform-reserved-words": "npm:^7.16.7"
+    "@babel/plugin-transform-shorthand-properties": "npm:^7.16.7"
+    "@babel/plugin-transform-spread": "npm:^7.16.7"
+    "@babel/plugin-transform-sticky-regex": "npm:^7.16.7"
+    "@babel/plugin-transform-template-literals": "npm:^7.16.7"
+    "@babel/plugin-transform-typeof-symbol": "npm:^7.16.7"
+    "@babel/plugin-transform-unicode-escapes": "npm:^7.16.7"
+    "@babel/plugin-transform-unicode-regex": "npm:^7.16.7"
+    "@babel/preset-modules": "npm:^0.1.5"
+    "@babel/types": "npm:^7.16.8"
+    babel-plugin-polyfill-corejs2: "npm:^0.3.0"
+    babel-plugin-polyfill-corejs3: "npm:^0.5.0"
+    babel-plugin-polyfill-regenerator: "npm:^0.3.0"
+    core-js-compat: "npm:^3.20.2"
+    semver: "npm:^6.3.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 69e4d82f56533e3d761d08abf066e598268b71576da64ec4a2cda10b8065f4aac4a25f7652c7bf8210df6c9eb8193ceb99141214abd69975d1fb6d583d55033e
@@ -1263,11 +1263,11 @@ __metadata:
   version: 0.1.5
   resolution: "@babel/preset-modules@npm:0.1.5"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.0.0
-    "@babel/plugin-proposal-unicode-property-regex": ^7.4.4
-    "@babel/plugin-transform-dotall-regex": ^7.4.4
-    "@babel/types": ^7.4.4
-    esutils: ^2.0.2
+    "@babel/helper-plugin-utils": "npm:^7.0.0"
+    "@babel/plugin-proposal-unicode-property-regex": "npm:^7.4.4"
+    "@babel/plugin-transform-dotall-regex": "npm:^7.4.4"
+    "@babel/types": "npm:^7.4.4"
+    esutils: "npm:^2.0.2"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: bd90081d96b746c1940dc1ce056dee06ed3a128d20936aee1d1795199f789f9a61293ef738343ae10c6d53970c17285d5e147a945dded35423aacb75083b8a89
@@ -1278,9 +1278,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/preset-typescript@npm:7.16.7"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/helper-validator-option": ^7.16.7
-    "@babel/plugin-transform-typescript": ^7.16.7
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    "@babel/helper-validator-option": "npm:^7.16.7"
+    "@babel/plugin-transform-typescript": "npm:^7.16.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 90444b3778fed5a961bf3ed9d4a56a963286de52bc7925aa88e27aa9df3e3e306755e290c5e92eaf9088a41321ddaae1fe4cec7e5eea9fb57236c180d3e82044
@@ -1291,11 +1291,11 @@ __metadata:
   version: 7.16.9
   resolution: "@babel/register@npm:7.16.9"
   dependencies:
-    clone-deep: ^4.0.1
-    find-cache-dir: ^2.0.0
-    make-dir: ^2.1.0
-    pirates: ^4.0.0
-    source-map-support: ^0.5.16
+    clone-deep: "npm:^4.0.1"
+    find-cache-dir: "npm:^2.0.0"
+    make-dir: "npm:^2.1.0"
+    pirates: "npm:^4.0.0"
+    source-map-support: "npm:^0.5.16"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 5cc7c70786f302dbb2cd8e65a989ffbe3aebf0487fd35350ddf7d089c55099864ce61c06e9d4936b46cc3d171955e307fef9488ed41bea6f6d5bb1d7aabe84d5
@@ -1306,8 +1306,8 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/runtime-corejs2@npm:7.16.7"
   dependencies:
-    core-js: ^2.6.5
-    regenerator-runtime: ^0.13.4
+    core-js: "npm:^2.6.5"
+    regenerator-runtime: "npm:^0.13.4"
   checksum: 957ea24d83abbe440d4e37b6e7cef7e3ed3c05943ec74a2f36fde53af12f42809eda78dc4192f47f0ddee5e5b9373b8ca86e3011184dbf548edeec98bd17d380
   languageName: node
   linkType: hard
@@ -1316,7 +1316,7 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/runtime@npm:7.16.7"
   dependencies:
-    regenerator-runtime: ^0.13.4
+    regenerator-runtime: "npm:^0.13.4"
   checksum: db68a6cd665930288d8fc96e751932413246eb72e71aa2f16376553eb6ed64db469bf462eb9fa137bda3109f181cab74ae136505fa4cca464674a1a1ab9c2fea
   languageName: node
   linkType: hard
@@ -1325,9 +1325,9 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/template@npm:7.16.7"
   dependencies:
-    "@babel/code-frame": ^7.16.7
-    "@babel/parser": ^7.16.7
-    "@babel/types": ^7.16.7
+    "@babel/code-frame": "npm:^7.16.7"
+    "@babel/parser": "npm:^7.16.7"
+    "@babel/types": "npm:^7.16.7"
   checksum: 6186aa6514c26fbf6bb17bf13cf3d57d253f507c8e39603feecb9968d47875c179348de082c3c05f962159542c95614c9f0dd633f62ac0864f757cf682479a96
   languageName: node
   linkType: hard
@@ -1336,16 +1336,16 @@ __metadata:
   version: 7.16.10
   resolution: "@babel/traverse@npm:7.16.10"
   dependencies:
-    "@babel/code-frame": ^7.16.7
-    "@babel/generator": ^7.16.8
-    "@babel/helper-environment-visitor": ^7.16.7
-    "@babel/helper-function-name": ^7.16.7
-    "@babel/helper-hoist-variables": ^7.16.7
-    "@babel/helper-split-export-declaration": ^7.16.7
-    "@babel/parser": ^7.16.10
-    "@babel/types": ^7.16.8
-    debug: ^4.1.0
-    globals: ^11.1.0
+    "@babel/code-frame": "npm:^7.16.7"
+    "@babel/generator": "npm:^7.16.8"
+    "@babel/helper-environment-visitor": "npm:^7.16.7"
+    "@babel/helper-function-name": "npm:^7.16.7"
+    "@babel/helper-hoist-variables": "npm:^7.16.7"
+    "@babel/helper-split-export-declaration": "npm:^7.16.7"
+    "@babel/parser": "npm:^7.16.10"
+    "@babel/types": "npm:^7.16.8"
+    debug: "npm:^4.1.0"
+    globals: "npm:^11.1.0"
   checksum: f0c1bac0f037f72a64628f768d1343326bc27facec2fa22b2c855400481faac3e6f4bbefc878c995e60885f6ca4580af56ab15ef147a3ba9d17c871e9804b019
   languageName: node
   linkType: hard
@@ -1354,8 +1354,8 @@ __metadata:
   version: 7.16.8
   resolution: "@babel/types@npm:7.16.8"
   dependencies:
-    "@babel/helper-validator-identifier": ^7.16.7
-    to-fast-properties: ^2.0.0
+    "@babel/helper-validator-identifier": "npm:^7.16.7"
+    to-fast-properties: "npm:^2.0.0"
   checksum: f8aebc9eefde65fba706caf71a6529ca99a741b691a8a6ebd0495890b09a494cd10d06cf0993a78410dde9b34a8089c9c7961e87aec55470a5ae7f661b05cc27
   languageName: node
   linkType: hard
@@ -1378,8 +1378,8 @@ __metadata:
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
   dependencies:
-    "@nodelib/fs.stat": 2.0.5
-    run-parallel: ^1.1.9
+    "@nodelib/fs.stat": "npm:2.0.5"
+    run-parallel: "npm:^1.1.9"
   checksum: 732c3b6d1b1e967440e65f284bd06e5821fedf10a1bea9ed2bb75956ea1f30e08c44d3def9d6a230666574edbaf136f8cfd319c14fd1f87c66e6a44449afb2eb
   languageName: node
   linkType: hard
@@ -1395,8 +1395,8 @@ __metadata:
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
-    "@nodelib/fs.scandir": 2.1.5
-    fastq: ^1.6.0
+    "@nodelib/fs.scandir": "npm:2.1.5"
+    fastq: "npm:^1.6.0"
   checksum: db9de047c3bb9b51f9335a7bb46f4fcfb6829fb628318c12115fbaf7d369bfce71c15b103d1fc3b464812d936220ee9bc1c8f762d032c9f6be9acc99249095b1
   languageName: node
   linkType: hard
@@ -1405,8 +1405,8 @@ __metadata:
   version: 1.1.0
   resolution: "@npmcli/fs@npm:1.1.0"
   dependencies:
-    "@gar/promisify": ^1.0.1
-    semver: ^7.3.5
+    "@gar/promisify": "npm:^1.0.1"
+    semver: "npm:^7.3.5"
   checksum: 64b4c3c19dd2c2fe192155e04932e4352bbe6d119a46f9a4bfc69f78dcbd511bff8a2f1eb427efb1bbd52e9765d0fc40f80e607ca6b0e657a3f1f9d6954d7e33
   languageName: node
   linkType: hard
@@ -1415,8 +1415,8 @@ __metadata:
   version: 1.1.2
   resolution: "@npmcli/move-file@npm:1.1.2"
   dependencies:
-    mkdirp: ^1.0.4
-    rimraf: ^3.0.2
+    mkdirp: "npm:^1.0.4"
+    rimraf: "npm:^3.0.2"
   checksum: 02e946f3dafcc6743132fe2e0e2b585a96ca7265653a38df5a3e53fcf26c7c7a57fc0f861d7c689a23fdb6d6836c7eea5050c8086abf3c994feb2208d1514ff0
   languageName: node
   linkType: hard
@@ -1425,7 +1425,7 @@ __metadata:
   version: 0.3.1
   resolution: "@samverschueren/stream-to-observable@npm:0.3.1"
   dependencies:
-    any-observable: ^0.3.0
+    any-observable: "npm:^0.3.0"
   peerDependenciesMeta:
     rxjs:
       optional: true
@@ -1446,7 +1446,7 @@ __metadata:
   version: 1.8.3
   resolution: "@sinonjs/commons@npm:1.8.3"
   dependencies:
-    type-detect: 4.0.8
+    type-detect: "npm:4.0.8"
   checksum: e4d2471feb19f735654f798fcdf389b90fab5913da609f566b04c4cdd9131a97e897d565251d35389aeebcca70a22ab4ed2291c7f7927706ead12e4f94841bf1
   languageName: node
   linkType: hard
@@ -1455,7 +1455,7 @@ __metadata:
   version: 6.0.1
   resolution: "@sinonjs/fake-timers@npm:6.0.1"
   dependencies:
-    "@sinonjs/commons": ^1.7.0
+    "@sinonjs/commons": "npm:^1.7.0"
   checksum: a77bead4d71b40d6f7f9a3ad66a00269aa2c078260f43f594b8aed4676c6c4e7c2b642d4b8e34df314e1c971589455f7b4267ab831bf44ffdccc0bda599850ad
   languageName: node
   linkType: hard
@@ -1464,7 +1464,7 @@ __metadata:
   version: 7.1.2
   resolution: "@sinonjs/fake-timers@npm:7.1.2"
   dependencies:
-    "@sinonjs/commons": ^1.7.0
+    "@sinonjs/commons": "npm:^1.7.0"
   checksum: c94de47ff2eceb2a7009c970f932509e81e474b555ea994343aea4c87aed26844ba298a70d585c0769e63fe379ebae6aaad61d37b3bca71f740a8d3d49f1bc27
   languageName: node
   linkType: hard
@@ -1473,9 +1473,9 @@ __metadata:
   version: 5.3.1
   resolution: "@sinonjs/samsam@npm:5.3.1"
   dependencies:
-    "@sinonjs/commons": ^1.6.0
-    lodash.get: ^4.4.2
-    type-detect: ^4.0.8
+    "@sinonjs/commons": "npm:^1.6.0"
+    lodash.get: "npm:^4.4.2"
+    type-detect: "npm:^4.0.8"
   checksum: bc6a95b55517da35322b0287e2aae62f5a340b8dce86ae239a9952c80fa4044339a4644d387a47bfded13e0a21066d4a70aee07e8294abc5b89c49d0bcfd7d9a
   languageName: node
   linkType: hard
@@ -1491,7 +1491,7 @@ __metadata:
   version: 1.1.2
   resolution: "@szmarczak/http-timer@npm:1.1.2"
   dependencies:
-    defer-to-connect: ^1.0.1
+    defer-to-connect: "npm:^1.0.1"
   checksum: 0594140e027ce4e98970c6d176457fcbff80900b1b3101ac0d08628ca6d21d70e0b94c6aaada94d4f76c1423fcc7195af83da145ce0fd556fc0595ca74a17b8b
   languageName: node
   linkType: hard
@@ -1514,8 +1514,8 @@ __metadata:
   version: 3.7.3
   resolution: "@types/eslint-scope@npm:3.7.3"
   dependencies:
-    "@types/eslint": "*"
-    "@types/estree": "*"
+    "@types/eslint": "npm:*"
+    "@types/estree": "npm:*"
   checksum: 3084e2619be57ca318dfddc2557fef855d63ea378d42b6b355216ea3e3aed82ce6adbfa6b620bff1d67aefa95245c5b41e998338bc307c948f8cbf08840b9bb2
   languageName: node
   linkType: hard
@@ -1531,8 +1531,8 @@ __metadata:
   version: 8.4.1
   resolution: "@types/eslint@npm:8.4.1"
   dependencies:
-    "@types/estree": "*"
-    "@types/json-schema": "*"
+    "@types/estree": "npm:*"
+    "@types/json-schema": "npm:*"
   checksum: 3ba1ddb8d2362316bafe65f90aa41ce23f923f8ae6a131e382540a7c0d8ad5f04117e6aba788392717a616bd6e2589a1d954630c49edb364d28dc8eeb5214890
   languageName: node
   linkType: hard
@@ -1555,8 +1555,8 @@ __metadata:
   version: 7.2.0
   resolution: "@types/glob@npm:7.2.0"
   dependencies:
-    "@types/minimatch": "*"
-    "@types/node": "*"
+    "@types/minimatch": "npm:*"
+    "@types/node": "npm:*"
   checksum: a8eb5d5cb5c48fc58c7ca3ff1e1ddf771ee07ca5043da6e4871e6757b4472e2e73b4cfef2644c38983174a4bc728c73f8da02845c28a1212f98cabd293ecae98
   languageName: node
   linkType: hard
@@ -1579,7 +1579,7 @@ __metadata:
   version: 3.1.3
   resolution: "@types/keyv@npm:3.1.3"
   dependencies:
-    "@types/node": "*"
+    "@types/node": "npm:*"
   checksum: 094c40f06b45a4d20d9d679bdecb2119d81ff45c124e5b394889aa99f0e82ec1f346266a98e7b61e5f37df339bed7166813cc83da56f6e0804ebada1f00ba6ab
   languageName: node
   linkType: hard
@@ -1630,7 +1630,7 @@ __metadata:
   version: 1.0.0
   resolution: "@types/responselike@npm:1.0.0"
   dependencies:
-    "@types/node": "*"
+    "@types/node": "npm:*"
   checksum: 474ac2402e6d43c007eee25f50d01eb1f67255ca83dd8e036877292bbe8dd5d2d1e50b54b408e233b50a8c38e681ff3ebeaf22f18b478056eddb65536abb003a
   languageName: node
   linkType: hard
@@ -1639,8 +1639,8 @@ __metadata:
   version: 3.2.8
   resolution: "@types/sinon-chai@npm:3.2.8"
   dependencies:
-    "@types/chai": "*"
-    "@types/sinon": "*"
+    "@types/chai": "npm:*"
+    "@types/sinon": "npm:*"
   checksum: 4458a743ba2e524dfc46835e6ecae3cb9b3545da6f27b4a94b6d130a00a0403cd8c19f5201533dd446190232114631a57a75b790d5aa2a5e67ee9d6f0ae4d5d5
   languageName: node
   linkType: hard
@@ -1649,7 +1649,7 @@ __metadata:
   version: 10.0.8
   resolution: "@types/sinon@npm:10.0.8"
   dependencies:
-    "@sinonjs/fake-timers": ^7.1.0
+    "@sinonjs/fake-timers": "npm:^7.1.0"
   checksum: aeb9a3aab6c17d1349736e7167ccf059d2aecff395a3075cf3e59395eff30ac0ea008fb29a413801662648a4b6f6bd4b8b16d5c481cd82083dc63f8eb97c7bda
   languageName: node
   linkType: hard
@@ -1658,7 +1658,7 @@ __metadata:
   version: 9.0.11
   resolution: "@types/sinon@npm:9.0.11"
   dependencies:
-    "@types/sinonjs__fake-timers": "*"
+    "@types/sinonjs__fake-timers": "npm:*"
   checksum: 859f338fb1ee869b1a2d017e35af5c71bc3beb85d82646fa283865265db5def3352a8282e3246878e87e26d11bc4b3b3f362e934878476e012cbe66e72d691d9
   languageName: node
   linkType: hard
@@ -1681,7 +1681,7 @@ __metadata:
   version: 15.0.14
   resolution: "@types/yargs@npm:15.0.14"
   dependencies:
-    "@types/yargs-parser": "*"
+    "@types/yargs-parser": "npm:*"
   checksum: 49eb8ad456c218a6dc8abd90a6f635a3ef44bb59161fbee2e9208f86fcb931668bb3559cad8cfe9a84d9c32b98034e37fefc2d728c3a077784b51971f0766b2e
   languageName: node
   linkType: hard
@@ -1690,10 +1690,10 @@ __metadata:
   version: 2.34.0
   resolution: "@typescript-eslint/eslint-plugin@npm:2.34.0"
   dependencies:
-    "@typescript-eslint/experimental-utils": 2.34.0
-    functional-red-black-tree: ^1.0.1
-    regexpp: ^3.0.0
-    tsutils: ^3.17.1
+    "@typescript-eslint/experimental-utils": "npm:2.34.0"
+    functional-red-black-tree: "npm:^1.0.1"
+    regexpp: "npm:^3.0.0"
+    tsutils: "npm:^3.17.1"
   peerDependencies:
     "@typescript-eslint/parser": ^2.0.0
     eslint: ^5.0.0 || ^6.0.0
@@ -1708,10 +1708,10 @@ __metadata:
   version: 2.34.0
   resolution: "@typescript-eslint/experimental-utils@npm:2.34.0"
   dependencies:
-    "@types/json-schema": ^7.0.3
-    "@typescript-eslint/typescript-estree": 2.34.0
-    eslint-scope: ^5.0.0
-    eslint-utils: ^2.0.0
+    "@types/json-schema": "npm:^7.0.3"
+    "@typescript-eslint/typescript-estree": "npm:2.34.0"
+    eslint-scope: "npm:^5.0.0"
+    eslint-utils: "npm:^2.0.0"
   peerDependencies:
     eslint: "*"
   checksum: c6296f021b23510d6ff3745a6b3b0fa43e79c383405042d5003cc82f69d5fd44ed7353f072b28ec8acafb5a2d16c5063b5a6c2d7fe89f10d629a23d2c9dbacd8
@@ -1722,10 +1722,10 @@ __metadata:
   version: 2.34.0
   resolution: "@typescript-eslint/parser@npm:2.34.0"
   dependencies:
-    "@types/eslint-visitor-keys": ^1.0.0
-    "@typescript-eslint/experimental-utils": 2.34.0
-    "@typescript-eslint/typescript-estree": 2.34.0
-    eslint-visitor-keys: ^1.1.0
+    "@types/eslint-visitor-keys": "npm:^1.0.0"
+    "@typescript-eslint/experimental-utils": "npm:2.34.0"
+    "@typescript-eslint/typescript-estree": "npm:2.34.0"
+    eslint-visitor-keys: "npm:^1.1.0"
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0
   peerDependenciesMeta:
@@ -1739,13 +1739,13 @@ __metadata:
   version: 2.34.0
   resolution: "@typescript-eslint/typescript-estree@npm:2.34.0"
   dependencies:
-    debug: ^4.1.1
-    eslint-visitor-keys: ^1.1.0
-    glob: ^7.1.6
-    is-glob: ^4.0.1
-    lodash: ^4.17.15
-    semver: ^7.3.2
-    tsutils: ^3.17.1
+    debug: "npm:^4.1.1"
+    eslint-visitor-keys: "npm:^1.1.0"
+    glob: "npm:^7.1.6"
+    is-glob: "npm:^4.0.1"
+    lodash: "npm:^4.17.15"
+    semver: "npm:^7.3.2"
+    tsutils: "npm:^3.17.1"
   peerDependenciesMeta:
     typescript:
       optional: true
@@ -1764,9 +1764,9 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/ast@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/helper-module-context": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/wast-parser": 1.9.0
+    "@webassemblyjs/helper-module-context": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/wast-parser": "npm:1.9.0"
   checksum: 8246c714346cdcd3ab204a2b09904d9d36c4f7da8f30cc217b0b7272a3ef57a3c21e95d51b26601641133fb66fea5cc46c357cf897808512f13b3d1c2efe88e4
   languageName: node
   linkType: hard
@@ -1796,7 +1796,7 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/helper-code-frame@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/wast-printer": 1.9.0
+    "@webassemblyjs/wast-printer": "npm:1.9.0"
   checksum: 010969a6c8b016680a9b1383ff4b8147c363608dd1e29602154e5460954af4fd48daed518a76b232ca43935d4b6bebf54fba38da56f809e2bd12f063d84013ec
   languageName: node
   linkType: hard
@@ -1812,7 +1812,7 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/helper-module-context@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
+    "@webassemblyjs/ast": "npm:1.9.0"
   checksum: 130a9ac1141770b9f70ad568ec2dc769e92c756f91b06ece9cda2c2a5e80e21ec9c8c2a945a5839bf379e52fa921ae134245a7492e1b9ae0e8c557bb9b4953c3
   languageName: node
   linkType: hard
@@ -1828,10 +1828,10 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/helper-wasm-section@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-buffer": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/wasm-gen": 1.9.0
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-buffer": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/wasm-gen": "npm:1.9.0"
   checksum: 2a5baa7749c50a4a428f372ab88b7e52956b48798d44e7291b4aa8558b247337dba791112ce8a4f5b2281e1b9014e6d44d0141476a5fcde6016fac2e009671e8
   languageName: node
   linkType: hard
@@ -1840,7 +1840,7 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/ieee754@npm:1.9.0"
   dependencies:
-    "@xtuc/ieee754": ^1.2.0
+    "@xtuc/ieee754": "npm:^1.2.0"
   checksum: 0eff34ec7048400b30282ab9af6ad19d2852dab2f5ffaec8bdc697b8380bc2c9dbe6cadf65f49e68242c82ee3caa8aa6e46c89dbfdab37615189b4da2eab3819
   languageName: node
   linkType: hard
@@ -1849,7 +1849,7 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/leb128@npm:1.9.0"
   dependencies:
-    "@xtuc/long": 4.2.2
+    "@xtuc/long": "npm:4.2.2"
   checksum: 441be8634733b33b710f44d4394552d6290bb1a0a8311b384b1865b58c3549d0ddeaf1c3985bbee024a8df12c597be3580fc1cde2ae003dcbf26762b493a7a2f
   languageName: node
   linkType: hard
@@ -1865,14 +1865,14 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/wasm-edit@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-buffer": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/helper-wasm-section": 1.9.0
-    "@webassemblyjs/wasm-gen": 1.9.0
-    "@webassemblyjs/wasm-opt": 1.9.0
-    "@webassemblyjs/wasm-parser": 1.9.0
-    "@webassemblyjs/wast-printer": 1.9.0
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-buffer": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-section": "npm:1.9.0"
+    "@webassemblyjs/wasm-gen": "npm:1.9.0"
+    "@webassemblyjs/wasm-opt": "npm:1.9.0"
+    "@webassemblyjs/wasm-parser": "npm:1.9.0"
+    "@webassemblyjs/wast-printer": "npm:1.9.0"
   checksum: 07f4cb4a73989622c524f9264b6afe664d33354f081499f04db675aed2b79498bd43600c3d7bebcb9f93ccce6a094b3c28f3f7b11ea62e9e82074c2ae68dc058
   languageName: node
   linkType: hard
@@ -1881,11 +1881,11 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/wasm-gen@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/ieee754": 1.9.0
-    "@webassemblyjs/leb128": 1.9.0
-    "@webassemblyjs/utf8": 1.9.0
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/ieee754": "npm:1.9.0"
+    "@webassemblyjs/leb128": "npm:1.9.0"
+    "@webassemblyjs/utf8": "npm:1.9.0"
   checksum: 876826bef91f3af9e48118fb269c348871d5b6f019e071065556da56a3a5818630b00133e07c9dd2cc767e7f2c70934f3ed0060330ce3e37910e9c9df25f1600
   languageName: node
   linkType: hard
@@ -1894,10 +1894,10 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/wasm-opt@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-buffer": 1.9.0
-    "@webassemblyjs/wasm-gen": 1.9.0
-    "@webassemblyjs/wasm-parser": 1.9.0
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-buffer": "npm:1.9.0"
+    "@webassemblyjs/wasm-gen": "npm:1.9.0"
+    "@webassemblyjs/wasm-parser": "npm:1.9.0"
   checksum: 3d5558e078b660cd9777950f2df60f005f3cbdbcfa6c8c19dc0cf012f44f5bfa97c991d7ac26b3e78596bad0538e92dd00b5db4b51ebc373da8e329a03639190
   languageName: node
   linkType: hard
@@ -1906,12 +1906,12 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/wasm-parser@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-api-error": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/ieee754": 1.9.0
-    "@webassemblyjs/leb128": 1.9.0
-    "@webassemblyjs/utf8": 1.9.0
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-api-error": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/ieee754": "npm:1.9.0"
+    "@webassemblyjs/leb128": "npm:1.9.0"
+    "@webassemblyjs/utf8": "npm:1.9.0"
   checksum: 1e8615b9f9c3c431c9635c9a9884bca89eff1ab2383ad849341c23e09899454482a8f8813d33bf86ee1b0acc97c7c83926961a9b34d4804fa5d559610ab0a4a2
   languageName: node
   linkType: hard
@@ -1920,12 +1920,12 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/wast-parser@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/floating-point-hex-parser": 1.9.0
-    "@webassemblyjs/helper-api-error": 1.9.0
-    "@webassemblyjs/helper-code-frame": 1.9.0
-    "@webassemblyjs/helper-fsm": 1.9.0
-    "@xtuc/long": 4.2.2
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/floating-point-hex-parser": "npm:1.9.0"
+    "@webassemblyjs/helper-api-error": "npm:1.9.0"
+    "@webassemblyjs/helper-code-frame": "npm:1.9.0"
+    "@webassemblyjs/helper-fsm": "npm:1.9.0"
+    "@xtuc/long": "npm:4.2.2"
   checksum: c79952466fdf7816be527b1db102952b777b12318eabb5c40df074cd8361e3a7b0179a985534fa8b5a7b93668b07ba46875ffeb5da03ca5177c80ba960ebdffc
   languageName: node
   linkType: hard
@@ -1934,9 +1934,9 @@ __metadata:
   version: 1.9.0
   resolution: "@webassemblyjs/wast-printer@npm:1.9.0"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/wast-parser": 1.9.0
-    "@xtuc/long": 4.2.2
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/wast-parser": "npm:1.9.0"
+    "@xtuc/long": "npm:4.2.2"
   checksum: f3d106aa884cbb7687307db7adeb3b98abff9de81b9ba8c1065267340b5e9de64ffc533044ab916b1f4ce8a67fb03efa54b29b61c8e908abe4c07edf82f614cd
   languageName: node
   linkType: hard
@@ -1980,7 +1980,7 @@ __metadata:
   version: 1.0.9
   resolution: "acorn-globals@npm:1.0.9"
   dependencies:
-    acorn: ^2.1.0
+    acorn: "npm:^2.1.0"
   checksum: 6b22564a37e0fc1fe3bb8c9005406b688092227e639144568dd60928f3621907923bf0611d06f207474013b6ed332e6f59addc7c1a8d46be635e362f56b748ee
   languageName: node
   linkType: hard
@@ -2034,7 +2034,7 @@ __metadata:
   version: 6.0.2
   resolution: "agent-base@npm:6.0.2"
   dependencies:
-    debug: 4
+    debug: "npm:4"
   checksum: dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
   languageName: node
   linkType: hard
@@ -2043,9 +2043,9 @@ __metadata:
   version: 4.2.0
   resolution: "agentkeepalive@npm:4.2.0"
   dependencies:
-    debug: ^4.1.0
-    depd: ^1.1.2
-    humanize-ms: ^1.2.1
+    debug: "npm:^4.1.0"
+    depd: "npm:^1.1.2"
+    humanize-ms: "npm:^1.2.1"
   checksum: b62bbae7c4154a9caf32fd3fac5787ba4289d4cec122f8c6ed236f3469c4b1c098ac0f3fc5dc97e89a234cdb27f9c9a627e19a67ccfb50e007b5c9854adcfb28
   languageName: node
   linkType: hard
@@ -2054,8 +2054,8 @@ __metadata:
   version: 3.1.0
   resolution: "aggregate-error@npm:3.1.0"
   dependencies:
-    clean-stack: ^2.0.0
-    indent-string: ^4.0.0
+    clean-stack: "npm:^2.0.0"
+    indent-string: "npm:^4.0.0"
   checksum: a42f67faa79e3e6687a4923050e7c9807db3848a037076f791d10e092677d65c1d2d863b7848560699f40fc0502c19f40963fb1cd1fb3d338a7423df8e45e039
   languageName: node
   linkType: hard
@@ -2073,10 +2073,10 @@ __metadata:
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
-    fast-deep-equal: ^3.1.1
-    fast-json-stable-stringify: ^2.0.0
-    json-schema-traverse: ^0.4.1
-    uri-js: ^4.2.2
+    fast-deep-equal: "npm:^3.1.1"
+    fast-json-stable-stringify: "npm:^2.0.0"
+    json-schema-traverse: "npm:^0.4.1"
+    uri-js: "npm:^4.2.2"
   checksum: 41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
   languageName: node
   linkType: hard
@@ -2085,17 +2085,10 @@ __metadata:
   version: 0.1.4
   resolution: "align-text@npm:0.1.4"
   dependencies:
-    kind-of: ^3.0.2
-    longest: ^1.0.1
-    repeat-string: ^1.5.2
+    kind-of: "npm:^3.0.2"
+    longest: "npm:^1.0.1"
+    repeat-string: "npm:^1.5.2"
   checksum: c0fc03fe5de15cda89f9babb91e77a255013b49912031e86e79f25547aa666622f0a68be3da47fc834ab2c97cfb6b0a967509b2ce883f5306d9c78f6069ced7a
-  languageName: node
-  linkType: hard
-
-"amdefine@npm:>=0.0.4":
-  version: 1.0.1
-  resolution: "amdefine@npm:1.0.1"
-  checksum: ba8aa5d4ff5248b2ed067111e72644b36b5b7ae88d9a5a2c4223dddb3bdc9102db67291e0b414f59f12c6479ac6a365886bac72c7965e627cbc732e0962dd1ab
   languageName: node
   linkType: hard
 
@@ -2103,7 +2096,7 @@ __metadata:
   version: 3.0.1
   resolution: "ansi-align@npm:3.0.1"
   dependencies:
-    string-width: ^4.1.0
+    string-width: "npm:^4.1.0"
   checksum: ad8b755a253a1bc8234eb341e0cec68a857ab18bf97ba2bda529e86f6e30460416523e0ec58c32e5c21f0ca470d779503244892873a5895dbd0c39c788e82467
   languageName: node
   linkType: hard
@@ -2126,7 +2119,7 @@ __metadata:
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
-    type-fest: ^0.21.3
+    type-fest: "npm:^0.21.3"
   checksum: da917be01871525a3dfcf925ae2977bc59e8c513d4423368645634bf5d4ceba5401574eb705c1e92b79f7292af5a656f78c5725a4b0e1cec97c4b413705c1d50
   languageName: node
   linkType: hard
@@ -2177,7 +2170,7 @@ __metadata:
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
   dependencies:
-    color-convert: ^1.9.0
+    color-convert: "npm:^1.9.0"
   checksum: ece5a8ef069fcc5298f67e3f4771a663129abd174ea2dfa87923a2be2abf6cd367ef72ac87942da00ce85bd1d651d4cd8595aebdb1b385889b89b205860e977b
   languageName: node
   linkType: hard
@@ -2186,7 +2179,7 @@ __metadata:
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
-    color-convert: ^2.0.1
+    color-convert: "npm:^2.0.1"
   checksum: 895a23929da416f2bd3de7e9cb4eabd340949328ab85ddd6e484a637d8f6820d485f53933446f5291c3b760cbc488beb8e88573dd0f9c7daf83dccc8fe81b041
   languageName: node
   linkType: hard
@@ -2230,8 +2223,8 @@ __metadata:
   version: 3.1.1
   resolution: "anymatch@npm:3.1.1"
   dependencies:
-    normalize-path: ^3.0.0
-    picomatch: ^2.0.4
+    normalize-path: "npm:^3.0.0"
+    picomatch: "npm:^2.0.4"
   checksum: cddd4998188a9ad48d95181e8d502559ac81484d7c3dbe67a5fcf76abd3255e87906b8ff0a63c7c09a5226bfe5511b3ab42755acf0e44546d94733077577b435
   languageName: node
   linkType: hard
@@ -2240,8 +2233,8 @@ __metadata:
   version: 1.3.2
   resolution: "anymatch@npm:1.3.2"
   dependencies:
-    micromatch: ^2.1.5
-    normalize-path: ^2.0.0
+    micromatch: "npm:^2.1.5"
+    normalize-path: "npm:^2.0.0"
   checksum: aa1eae8ef5076cfecefef1983811b4666b365513d60dfcb30756556cc7e8547fae2654328509beedb812b211da4785df5d42ca720aa24d52e745509ad3a4b2a8
   languageName: node
   linkType: hard
@@ -2250,8 +2243,8 @@ __metadata:
   version: 3.1.2
   resolution: "anymatch@npm:3.1.2"
   dependencies:
-    normalize-path: ^3.0.0
-    picomatch: ^2.0.4
+    normalize-path: "npm:^3.0.0"
+    picomatch: "npm:^2.0.4"
   checksum: 900645535aee46ed7958f4f5b5e38abcbf474b5230406e913de15fc9a1310f0d5322775deb609688efe31010fa57831e55d36040b19826c22ce61d537e9b9759
   languageName: node
   linkType: hard
@@ -2260,7 +2253,7 @@ __metadata:
   version: 1.0.0
   resolution: "append-transform@npm:1.0.0"
   dependencies:
-    default-require-extensions: ^2.0.0
+    default-require-extensions: "npm:^2.0.0"
   checksum: 13ef9e9d1ea60836a7b1255e07f44746539ba1a0efea1cfa602964f383b69582e7d728c7ec12b439147f16aff90da4cd7b9a8b06da80739699a093e4013114e9
   languageName: node
   linkType: hard
@@ -2297,8 +2290,8 @@ __metadata:
   version: 2.0.0
   resolution: "are-we-there-yet@npm:2.0.0"
   dependencies:
-    delegates: ^1.0.0
-    readable-stream: ^3.6.0
+    delegates: "npm:^1.0.0"
+    readable-stream: "npm:^3.6.0"
   checksum: 375f753c10329153c8d66dc95e8f8b6c7cc2aa66e05cb0960bd69092b10dae22900cacc7d653ad11d26b3ecbdbfe1e8bfb6ccf0265ba8077a7d979970f16b99c
   languageName: node
   linkType: hard
@@ -2307,8 +2300,8 @@ __metadata:
   version: 1.1.7
   resolution: "are-we-there-yet@npm:1.1.7"
   dependencies:
-    delegates: ^1.0.0
-    readable-stream: ^2.0.6
+    delegates: "npm:^1.0.0"
+    readable-stream: "npm:^2.0.6"
   checksum: 03cb45f2892767773c86a616205fc67feb8dfdd56685d1b34999cfa6c0d2aebe73ec0e6ba88a406422b998dea24138337fdb9a3f9b172d7c2a7f75d02f3df088
   languageName: node
   linkType: hard
@@ -2324,7 +2317,7 @@ __metadata:
   version: 2.0.0
   resolution: "arr-diff@npm:2.0.0"
   dependencies:
-    arr-flatten: ^1.0.1
+    arr-flatten: "npm:^1.0.1"
   checksum: d79592bf2b621b9c038e7a697357174409fceb63658529ea3b2d2d53a2918160e6bebb2e6ae756eb53330f07c11b052752377905d743a8928f9d3858598cafa2
   languageName: node
   linkType: hard
@@ -2368,11 +2361,11 @@ __metadata:
   version: 3.1.4
   resolution: "array-includes@npm:3.1.4"
   dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.1
-    get-intrinsic: ^1.1.1
-    is-string: ^1.0.7
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.1"
+    get-intrinsic: "npm:^1.1.1"
+    is-string: "npm:^1.0.7"
   checksum: 04c05682b45c1d58b9ad91296b3b91550c66196aae3076a42a0bb9094c00a9c3e4178520d13b093baab3313d862725a4596554da31989b12882be2073df038ac
   languageName: node
   linkType: hard
@@ -2381,8 +2374,8 @@ __metadata:
   version: 1.0.0
   resolution: "array-index@npm:1.0.0"
   dependencies:
-    debug: ^2.2.0
-    es6-symbol: ^3.0.2
+    debug: "npm:^2.2.0"
+    es6-symbol: "npm:^3.0.2"
   checksum: 4a20de6fc32113ad41857050fa0f126f8797aaacec18b611b76783e84744d0eaa2473ced6a66386229b6405b660d41ff1851cd510580a59930fa1164006097f3
   languageName: node
   linkType: hard
@@ -2391,7 +2384,7 @@ __metadata:
   version: 1.0.2
   resolution: "array-union@npm:1.0.2"
   dependencies:
-    array-uniq: ^1.0.1
+    array-uniq: "npm:^1.0.1"
   checksum: 18686767c0cfdae8dc4acf5ac119b0f0eacad82b7fcc0aa62cc41f93c5ad406d494b6a6e53d85e52e8f0349b67a4fec815feeb537e95c02510d747bc9a4157c7
   languageName: node
   linkType: hard
@@ -2428,9 +2421,9 @@ __metadata:
   version: 1.2.5
   resolution: "array.prototype.flat@npm:1.2.5"
   dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.0
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.0"
   checksum: 91f3a8f8a74552ffb8f001ff26aaacf2baedf8bf9334cee9ac440ffb095f05df40f88c78384d004d4999b5876b30a6520a77dd9e5bccf065d68d7f3910e5ed6e
   languageName: node
   linkType: hard
@@ -2453,8 +2446,8 @@ __metadata:
   version: 1.5.5-1
   resolution: "asciidoctor.js@npm:1.5.5-1"
   dependencies:
-    opal-npm-wrapper: ^0.9.0-beta2
-    xmlhttprequest: ~1.7.0
+    opal-npm-wrapper: "npm:^0.9.0-beta2"
+    xmlhttprequest: "npm:~1.7.0"
   checksum: 39dfe05d8fcca428e380a6ebfac1d06e7eaffd02794d4965d94f159e53a6f1373acb9d27c1e1bccfc8ad12d42eac6802654904bcae6dc667f35d5df87724db69
   languageName: node
   linkType: hard
@@ -2463,7 +2456,7 @@ __metadata:
   version: 0.2.6
   resolution: "asn1@npm:0.2.6"
   dependencies:
-    safer-buffer: ~2.1.0
+    safer-buffer: "npm:~2.1.0"
   checksum: 00c8a06c37e548762306bcb1488388d2f76c74c36f70c803f0c081a01d3bdf26090fc088cd812afc5e56a6d49e33765d451a5f8a68ab9c2b087eba65d2e980e0
   languageName: node
   linkType: hard
@@ -2486,10 +2479,10 @@ __metadata:
   version: 2.0.0
   resolution: "assert@npm:2.0.0"
   dependencies:
-    es6-object-assign: ^1.1.0
-    is-nan: ^1.2.1
-    object-is: ^1.0.1
-    util: ^0.12.0
+    es6-object-assign: "npm:^1.1.0"
+    is-nan: "npm:^1.2.1"
+    object-is: "npm:^1.0.1"
+    util: "npm:^0.12.0"
   checksum: a25c7ebc07b52cc4dadd5c46d73472e7d4b86e40eb7ebaa12f78c1ba954dbe83612be5dea314b862fc364c305ab3bdbcd1c9d4ec2d92bc37214ae7d5596347f3
   languageName: node
   linkType: hard
@@ -2519,7 +2512,7 @@ __metadata:
   version: 1.3.0
   resolution: "astw@npm:1.3.0"
   dependencies:
-    esprima: ^2.1.0
+    esprima: "npm:^2.1.0"
   checksum: 6b231a9cf0a15ce0428563d8c74d1c6ca75263ed91b63ea6f322e75f33c401317d1ef043642fb7e42ab18c9ecdba54f567cd888694f6b626940df3dafd1b1580
   languageName: node
   linkType: hard
@@ -2538,18 +2531,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async-foreach@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "async-foreach@npm:0.1.3"
-  checksum: ec2fcfd23e55ab088356a69a98b5f1ae9199c428a010500254ffdc0a7b51fdce9ae6eaa8bae2ef8670095078b711a1609b130d3b1a96252442b591bbc7d5b417
-  languageName: node
-  linkType: hard
-
 "async@npm:2.6.1":
   version: 2.6.1
   resolution: "async@npm:2.6.1"
   dependencies:
-    lodash: ^4.17.10
+    lodash: "npm:^4.17.10"
   checksum: 26978f3802ae726ccd09b4015c02a848f5b81fa9700403b155bf21c8c279ff6a641add604044c7f46d58481573144c115462f6aa9d595df9807cb998ce4b9e86
   languageName: node
   linkType: hard
@@ -2565,7 +2551,7 @@ __metadata:
   version: 2.6.3
   resolution: "async@npm:2.6.3"
   dependencies:
-    lodash: ^4.17.14
+    lodash: "npm:^4.17.14"
   checksum: 06c917c74a55f9036ff79dedfc51dfc9c52c2dee2f80866b600495d2fd3037251dbcfde6592f23fc47398c44d844174004e0ee532f94c32a888bb89fd1cf0f25
   languageName: node
   linkType: hard
@@ -2618,9 +2604,9 @@ __metadata:
   version: 6.26.0
   resolution: "babel-code-frame@npm:6.26.0"
   dependencies:
-    chalk: ^1.1.3
-    esutils: ^2.0.2
-    js-tokens: ^3.0.2
+    chalk: "npm:^1.1.3"
+    esutils: "npm:^2.0.2"
+    js-tokens: "npm:^3.0.2"
   checksum: 7fecc128e87578cf1b96e78d2b25e0b260e202bdbbfcefa2eac23b7f8b7b2f7bc9276a14599cde14403cc798cc2a38e428e2cab50b77658ab49228b09ae92473
   languageName: node
   linkType: hard
@@ -2629,12 +2615,12 @@ __metadata:
   version: 9.0.0
   resolution: "babel-eslint@npm:9.0.0"
   dependencies:
-    "@babel/code-frame": ^7.0.0
-    "@babel/parser": ^7.0.0
-    "@babel/traverse": ^7.0.0
-    "@babel/types": ^7.0.0
-    eslint-scope: 3.7.1
-    eslint-visitor-keys: ^1.0.0
+    "@babel/code-frame": "npm:^7.0.0"
+    "@babel/parser": "npm:^7.0.0"
+    "@babel/traverse": "npm:^7.0.0"
+    "@babel/types": "npm:^7.0.0"
+    eslint-scope: "npm:3.7.1"
+    eslint-visitor-keys: "npm:^1.0.0"
   checksum: c3cb76fcbdd75df47f26bfd5e27a666cd8244f56b4c21a53d5c5bd16303c2c6eec1f62e270e016d60fa37b915376d7a67fd45c6735c330b2bbcc248a572a5977
   languageName: node
   linkType: hard
@@ -2643,14 +2629,14 @@ __metadata:
   version: 6.26.1
   resolution: "babel-generator@npm:6.26.1"
   dependencies:
-    babel-messages: ^6.23.0
-    babel-runtime: ^6.26.0
-    babel-types: ^6.26.0
-    detect-indent: ^4.0.0
-    jsesc: ^1.3.0
-    lodash: ^4.17.4
-    source-map: ^0.5.7
-    trim-right: ^1.0.1
+    babel-messages: "npm:^6.23.0"
+    babel-runtime: "npm:^6.26.0"
+    babel-types: "npm:^6.26.0"
+    detect-indent: "npm:^4.0.0"
+    jsesc: "npm:^1.3.0"
+    lodash: "npm:^4.17.4"
+    source-map: "npm:^0.5.7"
+    trim-right: "npm:^1.0.1"
   checksum: d5f9d20c6f7d8644dc41ee57d48c98a78d24d5b74dc305cc518d6e0872d4fa73c5fd8d47ec00e3515858eaf3c3e512a703cdbc184ff0061af5979bc206618555
   languageName: node
   linkType: hard
@@ -2659,10 +2645,10 @@ __metadata:
   version: 8.2.3
   resolution: "babel-loader@npm:8.2.3"
   dependencies:
-    find-cache-dir: ^3.3.1
-    loader-utils: ^1.4.0
-    make-dir: ^3.1.0
-    schema-utils: ^2.6.5
+    find-cache-dir: "npm:^3.3.1"
+    loader-utils: "npm:^1.4.0"
+    make-dir: "npm:^3.1.0"
+    schema-utils: "npm:^2.6.5"
   peerDependencies:
     "@babel/core": ^7.0.0
     webpack: ">=2"
@@ -2674,7 +2660,7 @@ __metadata:
   version: 6.23.0
   resolution: "babel-messages@npm:6.23.0"
   dependencies:
-    babel-runtime: ^6.22.0
+    babel-runtime: "npm:^6.22.0"
   checksum: d4fd6414ee5bb1aa0dad6d8d2c4ffaa66331ec5a507959e11f56b19a683566e2c1e7a4d0b16cfef58ea4cc07db8acf5ff3dc8b25c585407cff2e09ac60553401
   languageName: node
   linkType: hard
@@ -2683,7 +2669,7 @@ __metadata:
   version: 2.3.3
   resolution: "babel-plugin-dynamic-import-node@npm:2.3.3"
   dependencies:
-    object.assign: ^4.1.0
+    object.assign: "npm:^4.1.0"
   checksum: 1bd80df981e1fc1aff0cd4e390cf27aaa34f95f7620cd14dff07ba3bad56d168c098233a7d2deb2c9b1dc13643e596a6b94fc608a3412ee3c56e74a25cd2167e
   languageName: node
   linkType: hard
@@ -2692,10 +2678,10 @@ __metadata:
   version: 4.1.6
   resolution: "babel-plugin-istanbul@npm:4.1.6"
   dependencies:
-    babel-plugin-syntax-object-rest-spread: ^6.13.0
-    find-up: ^2.1.0
-    istanbul-lib-instrument: ^1.10.1
-    test-exclude: ^4.2.1
+    babel-plugin-syntax-object-rest-spread: "npm:^6.13.0"
+    find-up: "npm:^2.1.0"
+    istanbul-lib-instrument: "npm:^1.10.1"
+    test-exclude: "npm:^4.2.1"
   checksum: f7e8572dab836ecbaac70bed9c9234f3dbe00284f3ca24e9c225fe44993e91b6633a5510a06b2f3e10a73be621143884f05e659c48dbf391e5a247b25abe9d2f
   languageName: node
   linkType: hard
@@ -2704,11 +2690,11 @@ __metadata:
   version: 3.3.4
   resolution: "babel-plugin-lodash@npm:3.3.4"
   dependencies:
-    "@babel/helper-module-imports": ^7.0.0-beta.49
-    "@babel/types": ^7.0.0-beta.49
-    glob: ^7.1.1
-    lodash: ^4.17.10
-    require-package-name: ^2.0.1
+    "@babel/helper-module-imports": "npm:^7.0.0-beta.49"
+    "@babel/types": "npm:^7.0.0-beta.49"
+    glob: "npm:^7.1.1"
+    lodash: "npm:^4.17.10"
+    require-package-name: "npm:^2.0.1"
   checksum: 1a1db624f70c1e9badd3ca112bc6819157e75768aab949c424cfabe562765d7f22cf93e5e088e820d5d5b1da7b2bd9d045cb54a5790616b65da1f84eda2ecc08
   languageName: node
   linkType: hard
@@ -2717,9 +2703,9 @@ __metadata:
   version: 0.3.1
   resolution: "babel-plugin-polyfill-corejs2@npm:0.3.1"
   dependencies:
-    "@babel/compat-data": ^7.13.11
-    "@babel/helper-define-polyfill-provider": ^0.3.1
-    semver: ^6.1.1
+    "@babel/compat-data": "npm:^7.13.11"
+    "@babel/helper-define-polyfill-provider": "npm:^0.3.1"
+    semver: "npm:^6.1.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 55b9394c954eed189b43b2c92c8fa1a0f811bcfced63aee741d26e9df8c8f4e18ec278a5353015afb66b47833d2dd2597e5e1c54310774416ebc67ec34ae8410
@@ -2730,8 +2716,8 @@ __metadata:
   version: 0.5.1
   resolution: "babel-plugin-polyfill-corejs3@npm:0.5.1"
   dependencies:
-    "@babel/helper-define-polyfill-provider": ^0.3.1
-    core-js-compat: ^3.20.0
+    "@babel/helper-define-polyfill-provider": "npm:^0.3.1"
+    core-js-compat: "npm:^3.20.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1331408d94fff19cc54151b7e5f1433135a4ac620f4f08104c0405eaf4c8f178fd2381f413a2751156a490c14684660d8af1741de5fec154dd9ab046ce5ecac7
@@ -2742,7 +2728,7 @@ __metadata:
   version: 0.3.1
   resolution: "babel-plugin-polyfill-regenerator@npm:0.3.1"
   dependencies:
-    "@babel/helper-define-polyfill-provider": ^0.3.1
+    "@babel/helper-define-polyfill-provider": "npm:^0.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 88f7b488bbb29636370954c048f08bdf61c5f1ffbee0b627817bf80e99a46b06660f54266cff93affb8ab5831d8edcaab271f9a80b8a090d4fd409a13023a61d
@@ -2760,8 +2746,8 @@ __metadata:
   version: 6.26.0
   resolution: "babel-runtime@npm:6.26.0"
   dependencies:
-    core-js: ^2.4.0
-    regenerator-runtime: ^0.11.0
+    core-js: "npm:^2.4.0"
+    regenerator-runtime: "npm:^0.11.0"
   checksum: caa752004936b1463765ed3199c52f6a55d0613b9bed108743d6f13ca532b821d4ea9decc4be1b583193164462b1e3e7eefdfa36b15c72e7daac58dd72c1772f
   languageName: node
   linkType: hard
@@ -2770,11 +2756,11 @@ __metadata:
   version: 6.26.0
   resolution: "babel-template@npm:6.26.0"
   dependencies:
-    babel-runtime: ^6.26.0
-    babel-traverse: ^6.26.0
-    babel-types: ^6.26.0
-    babylon: ^6.18.0
-    lodash: ^4.17.4
+    babel-runtime: "npm:^6.26.0"
+    babel-traverse: "npm:^6.26.0"
+    babel-types: "npm:^6.26.0"
+    babylon: "npm:^6.18.0"
+    lodash: "npm:^4.17.4"
   checksum: 67bc875f19d289dabb1830a1cde93d7f1e187e4599dac9b1d16392fd47f1d12b53fea902dacf7be360acd09807d440faafe0f7907758c13275b1a14d100b68e4
   languageName: node
   linkType: hard
@@ -2783,15 +2769,15 @@ __metadata:
   version: 6.26.0
   resolution: "babel-traverse@npm:6.26.0"
   dependencies:
-    babel-code-frame: ^6.26.0
-    babel-messages: ^6.23.0
-    babel-runtime: ^6.26.0
-    babel-types: ^6.26.0
-    babylon: ^6.18.0
-    debug: ^2.6.8
-    globals: ^9.18.0
-    invariant: ^2.2.2
-    lodash: ^4.17.4
+    babel-code-frame: "npm:^6.26.0"
+    babel-messages: "npm:^6.23.0"
+    babel-runtime: "npm:^6.26.0"
+    babel-types: "npm:^6.26.0"
+    babylon: "npm:^6.18.0"
+    debug: "npm:^2.6.8"
+    globals: "npm:^9.18.0"
+    invariant: "npm:^2.2.2"
+    lodash: "npm:^4.17.4"
   checksum: dca71b23d07e3c00833c3222d7998202e687105f461048107afeb2b4a7aa2507efab1bd5a6e3e724724ebb9b1e0b14f0113621e1d8c25b4ffdb829392b54b8de
   languageName: node
   linkType: hard
@@ -2800,10 +2786,10 @@ __metadata:
   version: 6.26.0
   resolution: "babel-types@npm:6.26.0"
   dependencies:
-    babel-runtime: ^6.26.0
-    esutils: ^2.0.2
-    lodash: ^4.17.4
-    to-fast-properties: ^1.0.3
+    babel-runtime: "npm:^6.26.0"
+    esutils: "npm:^2.0.2"
+    lodash: "npm:^4.17.4"
+    to-fast-properties: "npm:^1.0.3"
   checksum: cabe371de1b32c4bbb1fd4ed0fe8a8726d42e5ad7d5cefb83cdae6de0f0a152dce591e4026719743fdf3aa45f84fea2c8851fb822fbe29b0c78a1f0094b67418
   languageName: node
   linkType: hard
@@ -2828,13 +2814,13 @@ __metadata:
   version: 0.11.2
   resolution: "base@npm:0.11.2"
   dependencies:
-    cache-base: ^1.0.1
-    class-utils: ^0.3.5
-    component-emitter: ^1.2.1
-    define-property: ^1.0.0
-    isobject: ^3.0.1
-    mixin-deep: ^1.2.0
-    pascalcase: ^0.1.1
+    cache-base: "npm:^1.0.1"
+    class-utils: "npm:^0.3.5"
+    component-emitter: "npm:^1.2.1"
+    define-property: "npm:^1.0.0"
+    isobject: "npm:^3.0.1"
+    mixin-deep: "npm:^1.2.0"
+    pascalcase: "npm:^0.1.1"
   checksum: 30a2c0675eb52136b05ef496feb41574d9f0bb2d6d677761da579c00a841523fccf07f1dbabec2337b5f5750f428683b8ca60d89e56a1052c4ae1c0cd05de64d
   languageName: node
   linkType: hard
@@ -2857,7 +2843,7 @@ __metadata:
   version: 1.0.2
   resolution: "bcrypt-pbkdf@npm:1.0.2"
   dependencies:
-    tweetnacl: ^0.14.3
+    tweetnacl: "npm:^0.14.3"
   checksum: ddfe85230b32df25aeebfdccfbc61d3bc493ace49c884c9c68575de1f5dcf733a5d7de9def3b0f318b786616b8d85bad50a28b1da1750c43e0012c93badcc148
   languageName: node
   linkType: hard
@@ -2908,7 +2894,7 @@ __metadata:
   version: 1.5.0
   resolution: "bindings@npm:1.5.0"
   dependencies:
-    file-uri-to-path: 1.0.0
+    file-uri-to-path: "npm:1.0.0"
   checksum: 3dab2491b4bb24124252a91e656803eac24292473e56554e35bbfe3cc1875332cfa77600c3bac7564049dc95075bf6fcc63a4609920ff2d64d0fe405fcf0d4ba
   languageName: node
   linkType: hard
@@ -2917,7 +2903,7 @@ __metadata:
   version: 1.1.2
   resolution: "bl@npm:1.1.2"
   dependencies:
-    readable-stream: ~2.0.5
+    readable-stream: "npm:~2.0.5"
   checksum: 34cd431ef6701ae70d931c1a929ec2838bafd0e20049178557f74fa8e730b7353665992d2d29e98b3d36da999fc6ca34068abf463fcd8478805bb2a1d33de93e
   languageName: node
   linkType: hard
@@ -2926,7 +2912,7 @@ __metadata:
   version: 0.0.9
   resolution: "block-stream@npm:0.0.9"
   dependencies:
-    inherits: ~2.0.0
+    inherits: "npm:~2.0.0"
   checksum: b39b281c01cc5424e47d9433ac499b0c0cccf55bf72b3998ca5b88a8c479dfaab4d311e1a3544d3ed8f745744b0f393a7984e5e7e581d631eecefccf8012ae95
   languageName: node
   linkType: hard
@@ -2935,16 +2921,16 @@ __metadata:
   version: 1.14.2
   resolution: "body-parser@npm:1.14.2"
   dependencies:
-    bytes: 2.2.0
-    content-type: ~1.0.1
-    debug: ~2.2.0
-    depd: ~1.1.0
-    http-errors: ~1.3.1
-    iconv-lite: 0.4.13
-    on-finished: ~2.3.0
-    qs: 5.2.0
-    raw-body: ~2.1.5
-    type-is: ~1.6.10
+    bytes: "npm:2.2.0"
+    content-type: "npm:~1.0.1"
+    debug: "npm:~2.2.0"
+    depd: "npm:~1.1.0"
+    http-errors: "npm:~1.3.1"
+    iconv-lite: "npm:0.4.13"
+    on-finished: "npm:~2.3.0"
+    qs: "npm:5.2.0"
+    raw-body: "npm:~2.1.5"
+    type-is: "npm:~1.6.10"
   checksum: 2b881a7eb528d080eafc97979665f96f320b2e1d9dceb6cd32b17e93392e8670f5f12e7843e478abe67b33b86d23f59cec63353912e705a1143dbd7d31d9fb4b
   languageName: node
   linkType: hard
@@ -2960,7 +2946,7 @@ __metadata:
   version: 2.10.1
   resolution: "boom@npm:2.10.1"
   dependencies:
-    hoek: 2.x.x
+    hoek: "npm:2.x.x"
   checksum: aa291dac701bab75ec58d3cf567440e7d33f7fe3c931f01a7d70163d4fddd3a8f06a29fee313c61728474f9082d31c53b44af4012f2cea5e5a634828f784b4ce
   languageName: node
   linkType: hard
@@ -2969,7 +2955,7 @@ __metadata:
   version: 7.3.0
   resolution: "boom@npm:7.3.0"
   dependencies:
-    hoek: 6.x.x
+    hoek: "npm:6.x.x"
   checksum: 509906d889d86bdf2972d9428e5ca0fd0f31f3518347ccfde66291d7937292b45a2a09fbe7f2681428dfb2b94796fe04cd11ca476602af54e6298204cc85b58a
   languageName: node
   linkType: hard
@@ -2978,14 +2964,14 @@ __metadata:
   version: 3.2.0
   resolution: "boxen@npm:3.2.0"
   dependencies:
-    ansi-align: ^3.0.0
-    camelcase: ^5.3.1
-    chalk: ^2.4.2
-    cli-boxes: ^2.2.0
-    string-width: ^3.0.0
-    term-size: ^1.2.0
-    type-fest: ^0.3.0
-    widest-line: ^2.0.0
+    ansi-align: "npm:^3.0.0"
+    camelcase: "npm:^5.3.1"
+    chalk: "npm:^2.4.2"
+    cli-boxes: "npm:^2.2.0"
+    string-width: "npm:^3.0.0"
+    term-size: "npm:^1.2.0"
+    type-fest: "npm:^0.3.0"
+    widest-line: "npm:^2.0.0"
   checksum: beaf5e9ea1bd0c63ee36553f91ef5a1f3d2c47b6a20b0a18e48fd4ee1f3369fdf9e5e29d8c65ed693865cd9bcf6685268cf956e385eef854eb3297eb7bd58292
   languageName: node
   linkType: hard
@@ -2994,8 +2980,8 @@ __metadata:
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
   dependencies:
-    balanced-match: ^1.0.0
-    concat-map: 0.0.1
+    balanced-match: "npm:^1.0.0"
+    concat-map: "npm:0.0.1"
   checksum: 695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
   languageName: node
   linkType: hard
@@ -3004,9 +2990,9 @@ __metadata:
   version: 1.8.5
   resolution: "braces@npm:1.8.5"
   dependencies:
-    expand-range: ^1.8.1
-    preserve: ^0.2.0
-    repeat-element: ^1.1.2
+    expand-range: "npm:^1.8.1"
+    preserve: "npm:^0.2.0"
+    repeat-element: "npm:^1.1.2"
   checksum: 41092fe0f5dbb522f013963fa4432fbef3323a92ee8c1a6b9b6681fc05525b8541968b525632aa9df217daa6307fe526e9ce994054d4308abd0627a7d26e4745
   languageName: node
   linkType: hard
@@ -3015,16 +3001,16 @@ __metadata:
   version: 2.3.2
   resolution: "braces@npm:2.3.2"
   dependencies:
-    arr-flatten: ^1.1.0
-    array-unique: ^0.3.2
-    extend-shallow: ^2.0.1
-    fill-range: ^4.0.0
-    isobject: ^3.0.1
-    repeat-element: ^1.1.2
-    snapdragon: ^0.8.1
-    snapdragon-node: ^2.0.1
-    split-string: ^3.0.2
-    to-regex: ^3.0.1
+    arr-flatten: "npm:^1.1.0"
+    array-unique: "npm:^0.3.2"
+    extend-shallow: "npm:^2.0.1"
+    fill-range: "npm:^4.0.0"
+    isobject: "npm:^3.0.1"
+    repeat-element: "npm:^1.1.2"
+    snapdragon: "npm:^0.8.1"
+    snapdragon-node: "npm:^2.0.1"
+    split-string: "npm:^3.0.2"
+    to-regex: "npm:^3.0.1"
   checksum: 72b27ea3ea2718f061c29e70fd6e17606e37c65f5801abddcf0b0052db1de7d60f3bf92cfc220ab57b44bd0083a5f69f9d03b3461d2816cfe9f9398207acc728
   languageName: node
   linkType: hard
@@ -3033,7 +3019,7 @@ __metadata:
   version: 3.0.2
   resolution: "braces@npm:3.0.2"
   dependencies:
-    fill-range: ^7.0.1
+    fill-range: "npm:^7.0.1"
   checksum: 321b4d675791479293264019156ca322163f02dc06e3c4cab33bb15cd43d80b51efef69b0930cfde3acd63d126ebca24cd0544fa6f261e093a0fb41ab9dda381
   languageName: node
   linkType: hard
@@ -3049,11 +3035,11 @@ __metadata:
   version: 4.19.1
   resolution: "browserslist@npm:4.19.1"
   dependencies:
-    caniuse-lite: ^1.0.30001286
-    electron-to-chromium: ^1.4.17
-    escalade: ^3.1.1
-    node-releases: ^2.0.1
-    picocolors: ^1.0.0
+    caniuse-lite: "npm:^1.0.30001286"
+    electron-to-chromium: "npm:^1.4.17"
+    escalade: "npm:^3.1.1"
+    node-releases: "npm:^2.0.1"
+    picocolors: "npm:^1.0.0"
   bin:
     browserslist: cli.js
   checksum: 0a5f88a895a95e612439a893dbb869ce52a211e186c0c2894326a27a9881f2ca6d7f8a4a15c24410b9f144b7ee6e8a91db4ece24738d1a63f7cdd5acc55271ae
@@ -3113,24 +3099,24 @@ __metadata:
   version: 15.3.0
   resolution: "cacache@npm:15.3.0"
   dependencies:
-    "@npmcli/fs": ^1.0.0
-    "@npmcli/move-file": ^1.0.1
-    chownr: ^2.0.0
-    fs-minipass: ^2.0.0
-    glob: ^7.1.4
-    infer-owner: ^1.0.4
-    lru-cache: ^6.0.0
-    minipass: ^3.1.1
-    minipass-collect: ^1.0.2
-    minipass-flush: ^1.0.5
-    minipass-pipeline: ^1.2.2
-    mkdirp: ^1.0.3
-    p-map: ^4.0.0
-    promise-inflight: ^1.0.1
-    rimraf: ^3.0.2
-    ssri: ^8.0.1
-    tar: ^6.0.2
-    unique-filename: ^1.1.1
+    "@npmcli/fs": "npm:^1.0.0"
+    "@npmcli/move-file": "npm:^1.0.1"
+    chownr: "npm:^2.0.0"
+    fs-minipass: "npm:^2.0.0"
+    glob: "npm:^7.1.4"
+    infer-owner: "npm:^1.0.4"
+    lru-cache: "npm:^6.0.0"
+    minipass: "npm:^3.1.1"
+    minipass-collect: "npm:^1.0.2"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.2"
+    mkdirp: "npm:^1.0.3"
+    p-map: "npm:^4.0.0"
+    promise-inflight: "npm:^1.0.1"
+    rimraf: "npm:^3.0.2"
+    ssri: "npm:^8.0.1"
+    tar: "npm:^6.0.2"
+    unique-filename: "npm:^1.1.1"
   checksum: 886fcc0acc4f6fd5cd142d373d8276267bc6d655d7c4ce60726fbbec10854de3395ee19bbf9e7e73308cdca9fdad0ad55060ff3bd16c6d4165c5b8d21515e1d8
   languageName: node
   linkType: hard
@@ -3139,15 +3125,15 @@ __metadata:
   version: 1.0.1
   resolution: "cache-base@npm:1.0.1"
   dependencies:
-    collection-visit: ^1.0.0
-    component-emitter: ^1.2.1
-    get-value: ^2.0.6
-    has-value: ^1.0.0
-    isobject: ^3.0.1
-    set-value: ^2.0.0
-    to-object-path: ^0.3.0
-    union-value: ^1.0.0
-    unset-value: ^1.0.0
+    collection-visit: "npm:^1.0.0"
+    component-emitter: "npm:^1.2.1"
+    get-value: "npm:^2.0.6"
+    has-value: "npm:^1.0.0"
+    isobject: "npm:^3.0.1"
+    set-value: "npm:^2.0.0"
+    to-object-path: "npm:^0.3.0"
+    union-value: "npm:^1.0.0"
+    unset-value: "npm:^1.0.0"
   checksum: a7142e25c73f767fa520957dcd179b900b86eac63b8cfeaa3b2a35e18c9ca5968aa4e2d2bed7a3e7efd10f13be404344cfab3a4156217e71f9bdb95940bb9c8c
   languageName: node
   linkType: hard
@@ -3156,13 +3142,13 @@ __metadata:
   version: 6.1.0
   resolution: "cacheable-request@npm:6.1.0"
   dependencies:
-    clone-response: ^1.0.2
-    get-stream: ^5.1.0
-    http-cache-semantics: ^4.0.0
-    keyv: ^3.0.0
-    lowercase-keys: ^2.0.0
-    normalize-url: ^4.1.0
-    responselike: ^1.0.2
+    clone-response: "npm:^1.0.2"
+    get-stream: "npm:^5.1.0"
+    http-cache-semantics: "npm:^4.0.0"
+    keyv: "npm:^3.0.0"
+    lowercase-keys: "npm:^2.0.0"
+    normalize-url: "npm:^4.1.0"
+    responselike: "npm:^1.0.2"
   checksum: e92f2b2078c014ba097647ab4ff6a6149dc2974a65670ee97ec593ec9f4148ecc988e86b9fcd8ebf7fe255774a53d5dc3db6b01065d44f09a7452c7a7d8e4844
   languageName: node
   linkType: hard
@@ -3171,10 +3157,10 @@ __metadata:
   version: 3.0.2
   resolution: "caching-transform@npm:3.0.2"
   dependencies:
-    hasha: ^3.0.0
-    make-dir: ^2.0.0
-    package-hash: ^3.0.0
-    write-file-atomic: ^2.4.2
+    hasha: "npm:^3.0.0"
+    make-dir: "npm:^2.0.0"
+    package-hash: "npm:^3.0.0"
+    write-file-atomic: "npm:^2.4.2"
   checksum: e40a2c8739f9215ad35bcdc7a1b840f146d685ef08ad59242a0c5809bb01b1716d164fd610a51f87edf515e28266b37de7af7443343731fa81e38546965acd44
   languageName: node
   linkType: hard
@@ -3183,8 +3169,8 @@ __metadata:
   version: 1.0.2
   resolution: "call-bind@npm:1.0.2"
   dependencies:
-    function-bind: ^1.1.1
-    get-intrinsic: ^1.0.2
+    function-bind: "npm:^1.1.1"
+    get-intrinsic: "npm:^1.0.2"
   checksum: 74ba3f31e715456e22e451d8d098779b861eba3c7cac0d9b510049aced70d75c231ba05071f97e1812c98e34e2bee734c0c6126653e0088c2d9819ca047f4073
   languageName: node
   linkType: hard
@@ -3193,7 +3179,7 @@ __metadata:
   version: 2.0.0
   resolution: "caller-callsite@npm:2.0.0"
   dependencies:
-    callsites: ^2.0.0
+    callsites: "npm:^2.0.0"
   checksum: a00ca91280e10ee2321de21dda6c168e427df7a63aeaca027ea45e3e466ac5e1a5054199f6547ba1d5a513d3b6b5933457266daaa47f8857fb532a343ee6b5e1
   languageName: node
   linkType: hard
@@ -3202,7 +3188,7 @@ __metadata:
   version: 2.0.0
   resolution: "caller-path@npm:2.0.0"
   dependencies:
-    caller-callsite: ^2.0.0
+    caller-callsite: "npm:^2.0.0"
   checksum: 029b5b2c557d831216305c3218e9ff30fa668be31d58dd08088f74c8eabc8362c303e0908b3a93abb25ba10e3a5bfc9cff5eb7fab6ab9cf820e3b160ccb67581
   languageName: node
   linkType: hard
@@ -3221,23 +3207,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase-keys@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "camelcase-keys@npm:2.1.0"
-  dependencies:
-    camelcase: ^2.0.0
-    map-obj: ^1.0.0
-  checksum: d9431f8b5ac52644cfc45377c0d3897f045137d645c8890bd2bfb48c282d22e76644974198dbba3a2d96b33f9bf3af07aacb712b0dd6d2671330a7e2531b72f9
-  languageName: node
-  linkType: hard
-
 "camelcase-keys@npm:^4.0.0":
   version: 4.2.0
   resolution: "camelcase-keys@npm:4.2.0"
   dependencies:
-    camelcase: ^4.1.0
-    map-obj: ^2.0.0
-    quick-lru: ^1.0.0
+    camelcase: "npm:^4.1.0"
+    map-obj: "npm:^2.0.0"
+    quick-lru: "npm:^1.0.0"
   checksum: f62198805fbd99fad523e6a4bead1d23c9be9b1e60024fe855631fb978001f39571930f94a7a81f0cd6d2e6b110356847488e88b120475def1ffad5cf34a9758
   languageName: node
   linkType: hard
@@ -3249,7 +3225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^2.0.0, camelcase@npm:^2.0.1":
+"camelcase@npm:^2.0.1":
   version: 2.1.1
   resolution: "camelcase@npm:2.1.1"
   checksum: 610db65fa7dd50a400525ec2188fd65a1939dda4afe5de7d08608670013269c3743c3737fb0f138d1df8aa74e257cc83e3b756e776b604af16dac297b4a0d054
@@ -3302,8 +3278,8 @@ __metadata:
   version: 0.1.3
   resolution: "center-align@npm:0.1.3"
   dependencies:
-    align-text: ^0.1.3
-    lazy-cache: ^1.0.3
+    align-text: "npm:^0.1.3"
+    lazy-cache: "npm:^1.0.3"
   checksum: d12d17b53c4ffce900ecddeb87b781e65af9fe197973015bc2d8fb114fcccdd6457995df26bfe156ffe44573ffbabbba7c67653d92cfc8e1b2e7ec88404cbb61
   languageName: node
   linkType: hard
@@ -3312,12 +3288,12 @@ __metadata:
   version: 4.3.4
   resolution: "chai@npm:4.3.4"
   dependencies:
-    assertion-error: ^1.1.0
-    check-error: ^1.0.2
-    deep-eql: ^3.0.1
-    get-func-name: ^2.0.0
-    pathval: ^1.1.1
-    type-detect: ^4.0.5
+    assertion-error: "npm:^1.1.0"
+    check-error: "npm:^1.0.2"
+    deep-eql: "npm:^3.0.1"
+    get-func-name: "npm:^2.0.0"
+    pathval: "npm:^1.1.1"
+    type-detect: "npm:^4.0.5"
   checksum: e8be63a3ce412cc35f0209799c96b1f67397c4829489bd1604f9639f291b697f9a8c1ee129f5d502663332691950b278d2be7e8f19d753b86ea1876e99771a8e
   languageName: node
   linkType: hard
@@ -3326,11 +3302,11 @@ __metadata:
   version: 1.1.3
   resolution: "chalk@npm:1.1.3"
   dependencies:
-    ansi-styles: ^2.2.1
-    escape-string-regexp: ^1.0.2
-    has-ansi: ^2.0.0
-    strip-ansi: ^3.0.0
-    supports-color: ^2.0.0
+    ansi-styles: "npm:^2.2.1"
+    escape-string-regexp: "npm:^1.0.2"
+    has-ansi: "npm:^2.0.0"
+    strip-ansi: "npm:^3.0.0"
+    supports-color: "npm:^2.0.0"
   checksum: 28c3e399ec286bb3a7111fd4225ebedb0d7b813aef38a37bca7c498d032459c265ef43404201d5fbb8d888d29090899c95335b4c0cda13e8b126ff15c541cef8
   languageName: node
   linkType: hard
@@ -3339,9 +3315,9 @@ __metadata:
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
-    ansi-styles: ^3.2.1
-    escape-string-regexp: ^1.0.5
-    supports-color: ^5.3.0
+    ansi-styles: "npm:^3.2.1"
+    escape-string-regexp: "npm:^1.0.5"
+    supports-color: "npm:^5.3.0"
   checksum: e6543f02ec877732e3a2d1c3c3323ddb4d39fbab687c23f526e25bd4c6a9bf3b83a696e8c769d078e04e5754921648f7821b2a2acfd16c550435fd630026e073
   languageName: node
   linkType: hard
@@ -3350,8 +3326,8 @@ __metadata:
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
   checksum: 4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
   languageName: node
   linkType: hard
@@ -3381,12 +3357,12 @@ __metadata:
   version: 0.20.0
   resolution: "cheerio@npm:0.20.0"
   dependencies:
-    css-select: ~1.2.0
-    dom-serializer: ~0.1.0
-    entities: ~1.1.1
-    htmlparser2: ~3.8.1
-    jsdom: ^7.0.2
-    lodash: ^4.1.0
+    css-select: "npm:~1.2.0"
+    dom-serializer: "npm:~0.1.0"
+    entities: "npm:~1.1.1"
+    htmlparser2: "npm:~3.8.1"
+    jsdom: "npm:^7.0.2"
+    lodash: "npm:^4.1.0"
   dependenciesMeta:
     jsdom:
       optional: true
@@ -3398,15 +3374,15 @@ __metadata:
   version: 1.5.0
   resolution: "chokidar@npm:1.5.0"
   dependencies:
-    anymatch: ^1.3.0
-    async-each: ^1.0.0
-    fsevents: ^1.0.0
-    glob-parent: ^2.0.0
-    inherits: ^2.0.1
-    is-binary-path: ^1.0.0
-    is-glob: ^2.0.0
-    path-is-absolute: ^1.0.0
-    readdirp: ^2.0.0
+    anymatch: "npm:^1.3.0"
+    async-each: "npm:^1.0.0"
+    fsevents: "npm:^1.0.0"
+    glob-parent: "npm:^2.0.0"
+    inherits: "npm:^2.0.1"
+    is-binary-path: "npm:^1.0.0"
+    is-glob: "npm:^2.0.0"
+    path-is-absolute: "npm:^1.0.0"
+    readdirp: "npm:^2.0.0"
   dependenciesMeta:
     fsevents:
       optional: true
@@ -3418,14 +3394,14 @@ __metadata:
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
-    anymatch: ~3.1.2
-    braces: ~3.0.2
-    fsevents: ~2.3.2
-    glob-parent: ~5.1.2
-    is-binary-path: ~2.1.0
-    is-glob: ~4.0.1
-    normalize-path: ~3.0.0
-    readdirp: ~3.6.0
+    anymatch: "npm:~3.1.2"
+    braces: "npm:~3.0.2"
+    fsevents: "npm:~2.3.2"
+    glob-parent: "npm:~5.1.2"
+    is-binary-path: "npm:~2.1.0"
+    is-glob: "npm:~4.0.1"
+    normalize-path: "npm:~3.0.0"
+    readdirp: "npm:~3.6.0"
   dependenciesMeta:
     fsevents:
       optional: true
@@ -3437,15 +3413,15 @@ __metadata:
   version: 1.7.0
   resolution: "chokidar@npm:1.7.0"
   dependencies:
-    anymatch: ^1.3.0
-    async-each: ^1.0.0
-    fsevents: ^1.0.0
-    glob-parent: ^2.0.0
-    inherits: ^2.0.1
-    is-binary-path: ^1.0.0
-    is-glob: ^2.0.0
-    path-is-absolute: ^1.0.0
-    readdirp: ^2.0.0
+    anymatch: "npm:^1.3.0"
+    async-each: "npm:^1.0.0"
+    fsevents: "npm:^1.0.0"
+    glob-parent: "npm:^2.0.0"
+    inherits: "npm:^2.0.1"
+    is-binary-path: "npm:^1.0.0"
+    is-glob: "npm:^2.0.0"
+    path-is-absolute: "npm:^1.0.0"
+    readdirp: "npm:^2.0.0"
   dependenciesMeta:
     fsevents:
       optional: true
@@ -3492,10 +3468,10 @@ __metadata:
   version: 0.3.6
   resolution: "class-utils@npm:0.3.6"
   dependencies:
-    arr-union: ^3.1.0
-    define-property: ^0.2.5
-    isobject: ^3.0.0
-    static-extend: ^0.1.1
+    arr-union: "npm:^3.1.0"
+    define-property: "npm:^0.2.5"
+    isobject: "npm:^3.0.0"
+    static-extend: "npm:^0.1.1"
   checksum: d44f4afc7a3e48dba4c2d3fada5f781a1adeeff371b875c3b578bc33815c6c29d5d06483c2abfd43a32d35b104b27b67bfa39c2e8a422fa858068bd756cfbd42
   languageName: node
   linkType: hard
@@ -3504,7 +3480,7 @@ __metadata:
   version: 1.1.7
   resolution: "clean-css@npm:1.1.7"
   dependencies:
-    commander: 2.0.x
+    commander: "npm:2.0.x"
   bin:
     cleancss: ./bin/cleancss
   checksum: 2a7891572a6d300ee7a787535ece1376e95bddac1d0a06ef7469f97b322eee95d0022064291fcc119cd18d446f8acb01d6ac30a3ed003dd2c8e414df7ea00db8
@@ -3529,10 +3505,10 @@ __metadata:
   version: 0.3.3
   resolution: "cli-color@npm:0.3.3"
   dependencies:
-    d: ~0.1.1
-    es5-ext: ~0.10.6
-    memoizee: ~0.3.8
-    timers-ext: 0.1
+    d: "npm:~0.1.1"
+    es5-ext: "npm:~0.10.6"
+    memoizee: "npm:~0.3.8"
+    timers-ext: "npm:0.1"
   checksum: ad16a880755f95bbd1d9936053f05bed2918ccff05beccaa6c1ee181c19840430a11ac3de59658f626d3dc58d7839bd64a6b162df6a6b1ca49536a4c5cdbf7e6
   languageName: node
   linkType: hard
@@ -3541,7 +3517,7 @@ __metadata:
   version: 2.1.0
   resolution: "cli-cursor@npm:2.1.0"
   dependencies:
-    restore-cursor: ^2.0.0
+    restore-cursor: "npm:^2.0.0"
   checksum: 09ee6d8b5b818d840bf80ec9561eaf696672197d3a02a7daee2def96d5f52ce6e0bbe7afca754ccf14f04830b5a1b4556273e983507d5029f95bba3016618eda
   languageName: node
   linkType: hard
@@ -3550,7 +3526,7 @@ __metadata:
   version: 3.1.0
   resolution: "cli-cursor@npm:3.1.0"
   dependencies:
-    restore-cursor: ^3.1.0
+    restore-cursor: "npm:^3.1.0"
   checksum: 92a2f98ff9037d09be3dfe1f0d749664797fb674bf388375a2207a1203b69d41847abf16434203e0089212479e47a358b13a0222ab9fccfe8e2644a7ccebd111
   languageName: node
   linkType: hard
@@ -3559,8 +3535,8 @@ __metadata:
   version: 0.2.1
   resolution: "cli-truncate@npm:0.2.1"
   dependencies:
-    slice-ansi: 0.0.4
-    string-width: ^1.0.1
+    slice-ansi: "npm:0.0.4"
+    string-width: "npm:^1.0.1"
   checksum: c6caa5e2b70d841c42f4a2270d6fc7129df915f8911e4afa90c79231ccc857cd819a2c90e0707fde04e51ce56b4d71646b843f6cbaff4f7cdcb3b91ed51f6e89
   languageName: node
   linkType: hard
@@ -3583,9 +3559,9 @@ __metadata:
   version: 2.1.0
   resolution: "cliui@npm:2.1.0"
   dependencies:
-    center-align: ^0.1.1
-    right-align: ^0.1.1
-    wordwrap: 0.0.2
+    center-align: "npm:^0.1.1"
+    right-align: "npm:^0.1.1"
+    wordwrap: "npm:0.0.2"
   checksum: a5e7a3c1f354f3dd4cdea613822633a3c73604d4852ab2f5ac24fb7e10a2bef4475b4064e1bdd3db61e9527130a634ca4cef7e18666d03519611e70213606245
   languageName: node
   linkType: hard
@@ -3594,9 +3570,9 @@ __metadata:
   version: 3.2.0
   resolution: "cliui@npm:3.2.0"
   dependencies:
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-    wrap-ansi: ^2.0.0
+    string-width: "npm:^1.0.1"
+    strip-ansi: "npm:^3.0.1"
+    wrap-ansi: "npm:^2.0.0"
   checksum: 07b121fac7fd33ff8dbf3523f0d3dca0329d4e457e57dee54502aa5f27a33cbd9e66aa3e248f0260d8a1431b65b2bad8f510cd97fb8ab6a8e0506310a92e18d5
   languageName: node
   linkType: hard
@@ -3605,9 +3581,9 @@ __metadata:
   version: 5.0.0
   resolution: "cliui@npm:5.0.0"
   dependencies:
-    string-width: ^3.1.0
-    strip-ansi: ^5.2.0
-    wrap-ansi: ^5.1.0
+    string-width: "npm:^3.1.0"
+    strip-ansi: "npm:^5.2.0"
+    wrap-ansi: "npm:^5.1.0"
   checksum: 76142bf306965850a71efd10c9755bd7f447c7c20dd652e1c1ce27d987f862a3facb3cceb2909cef6f0cb363646ee7a1735e3dfdd49f29ed16d733d33e15e2f8
   languageName: node
   linkType: hard
@@ -3616,9 +3592,9 @@ __metadata:
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
   dependencies:
-    string-width: ^4.2.0
-    strip-ansi: ^6.0.0
-    wrap-ansi: ^7.0.0
+    string-width: "npm:^4.2.0"
+    strip-ansi: "npm:^6.0.0"
+    wrap-ansi: "npm:^7.0.0"
   checksum: 6035f5daf7383470cef82b3d3db00bec70afb3423538c50394386ffbbab135e26c3689c41791f911fa71b62d13d3863c712fdd70f0fbdffd938a1e6fd09aac00
   languageName: node
   linkType: hard
@@ -3627,9 +3603,9 @@ __metadata:
   version: 4.0.1
   resolution: "clone-deep@npm:4.0.1"
   dependencies:
-    is-plain-object: ^2.0.4
-    kind-of: ^6.0.2
-    shallow-clone: ^3.0.0
+    is-plain-object: "npm:^2.0.4"
+    kind-of: "npm:^6.0.2"
+    shallow-clone: "npm:^3.0.0"
   checksum: 637753615aa24adf0f2d505947a1bb75e63964309034a1cf56ba4b1f30af155201edd38d26ffe26911adaae267a3c138b344a4947d39f5fc1b6d6108125aa758
   languageName: node
   linkType: hard
@@ -3638,7 +3614,7 @@ __metadata:
   version: 1.0.2
   resolution: "clone-response@npm:1.0.2"
   dependencies:
-    mimic-response: ^1.0.0
+    mimic-response: "npm:^1.0.0"
   checksum: 96f3527ef86d0c322e0a5188d929ab78ddbc3238d47ccbb00f8abb02b02e4ef70339646ec73d657383ffbdb1f0cfef6a937062d4f701ca6f84cee7a37114007f
   languageName: node
   linkType: hard
@@ -3654,8 +3630,8 @@ __metadata:
   version: 2.0.2
   resolution: "cmd-shim@npm:2.0.2"
   dependencies:
-    graceful-fs: ^4.1.2
-    mkdirp: ~0.5.0
+    graceful-fs: "npm:^4.1.2"
+    mkdirp: "npm:~0.5.0"
   checksum: 5344e8ac4950ec64e0fe06435cd51213cf038930fff0e434cd721049b1add81e94de3f5bb88d50d11593e67ae871cc9d1a958cd008e082a73f589cb9b7c9e2ac
   languageName: node
   linkType: hard
@@ -3681,8 +3657,8 @@ __metadata:
   version: 1.0.0
   resolution: "collection-visit@npm:1.0.0"
   dependencies:
-    map-visit: ^1.0.0
-    object-visit: ^1.0.0
+    map-visit: "npm:^1.0.0"
+    object-visit: "npm:^1.0.0"
   checksum: add72a8d1c37cb90e53b1aaa2c31bf1989bfb733f0b02ce82c9fa6828c7a14358dba2e4f8e698c02f69e424aeccae1ffb39acdeaf872ade2f41369e84a2fcf8a
   languageName: node
   linkType: hard
@@ -3691,7 +3667,7 @@ __metadata:
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
-    color-name: 1.1.3
+    color-name: "npm:1.1.3"
   checksum: 5ad3c534949a8c68fca8fbc6f09068f435f0ad290ab8b2f76841b9e6af7e0bb57b98cb05b0e19fe33f5d91e5a8611ad457e5f69e0a484caad1f7487fd0e8253c
   languageName: node
   linkType: hard
@@ -3700,7 +3676,7 @@ __metadata:
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
   dependencies:
-    color-name: ~1.1.4
+    color-name: "npm:~1.1.4"
   checksum: 37e1150172f2e311fe1b2df62c6293a342ee7380da7b9cfdba67ea539909afbd74da27033208d01d6d5cfc65ee7868a22e18d7e7648e004425441c0f8a15a7d7
   languageName: node
   linkType: hard
@@ -3732,8 +3708,8 @@ __metadata:
   version: 1.5.4
   resolution: "columnify@npm:1.5.4"
   dependencies:
-    strip-ansi: ^3.0.0
-    wcwidth: ^1.0.0
+    strip-ansi: "npm:^3.0.0"
+    wcwidth: "npm:^1.0.0"
   checksum: bed7041413afab966f6c478730a1617764065c6cee598b6ba8d7400fb95974b857682a721b7edd7358e10ab3e47512930208903707f7f806fa887f9ee6ca5946
   languageName: node
   linkType: hard
@@ -3742,7 +3718,7 @@ __metadata:
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
-    delayed-stream: ~1.0.0
+    delayed-stream: "npm:~1.0.0"
   checksum: 0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
   languageName: node
   linkType: hard
@@ -3772,7 +3748,7 @@ __metadata:
   version: 2.9.0
   resolution: "commander@npm:2.9.0"
   dependencies:
-    graceful-readlink: ">= 1.0.0"
+    graceful-readlink: "npm:>= 1.0.0"
   checksum: 56bcda1e47f453016ed25d9f300bed9e622842a5515802658adb62792fa2ff9af6ee3f9ff16e058d7b20aacc78fb3baa3e02f982414bae1fb5f198c7cb41d5ad
   languageName: node
   linkType: hard
@@ -3816,10 +3792,10 @@ __metadata:
   version: 1.6.2
   resolution: "concat-stream@npm:1.6.2"
   dependencies:
-    buffer-from: ^1.0.0
-    inherits: ^2.0.3
-    readable-stream: ^2.2.2
-    typedarray: ^0.0.6
+    buffer-from: "npm:^1.0.0"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^2.2.2"
+    typedarray: "npm:^0.0.6"
   checksum: 2e9864e18282946dabbccb212c5c7cec0702745e3671679eb8291812ca7fd12023f7d8cb36493942a62f770ac96a7f90009dc5c82ad69893438371720fa92617
   languageName: node
   linkType: hard
@@ -3828,8 +3804,8 @@ __metadata:
   version: 1.1.13
   resolution: "config-chain@npm:1.1.13"
   dependencies:
-    ini: ^1.3.4
-    proto-list: ~1.2.1
+    ini: "npm:^1.3.4"
+    proto-list: "npm:~1.2.1"
   checksum: 39d1df18739d7088736cc75695e98d7087aea43646351b028dfabd5508d79cf6ef4c5bcd90471f52cd87ae470d1c5490c0a8c1a292fbe6ee9ff688061ea0963e
   languageName: node
   linkType: hard
@@ -3838,12 +3814,12 @@ __metadata:
   version: 4.0.0
   resolution: "configstore@npm:4.0.0"
   dependencies:
-    dot-prop: ^4.1.0
-    graceful-fs: ^4.1.2
-    make-dir: ^1.0.0
-    unique-string: ^1.0.0
-    write-file-atomic: ^2.0.0
-    xdg-basedir: ^3.0.0
+    dot-prop: "npm:^4.1.0"
+    graceful-fs: "npm:^4.1.2"
+    make-dir: "npm:^1.0.0"
+    unique-string: "npm:^1.0.0"
+    write-file-atomic: "npm:^2.0.0"
+    xdg-basedir: "npm:^3.0.0"
   checksum: d140cee2a84bb2fc1a49e3aeeb6dda4c359537625bda2c7929311cc5900b17d8c551ab1744367346a2c2d7b483a094e6756e0c30641e411b44fbf5011f558240
   languageName: node
   linkType: hard
@@ -3873,7 +3849,7 @@ __metadata:
   version: 1.8.0
   resolution: "convert-source-map@npm:1.8.0"
   dependencies:
-    safe-buffer: ~5.1.1
+    safe-buffer: "npm:~5.1.1"
   checksum: da4649990b633c070c0dab1680b89a67b9315dd2b1168d143536f667214c97e4eb4a49e5b7ff912f0196fe303e31fc16a529457436d25b2b5a89613eaf4f27fa
   languageName: node
   linkType: hard
@@ -3889,8 +3865,8 @@ __metadata:
   version: 3.20.3
   resolution: "core-js-compat@npm:3.20.3"
   dependencies:
-    browserslist: ^4.19.1
-    semver: 7.0.0
+    browserslist: "npm:^4.19.1"
+    semver: "npm:7.0.0"
   checksum: 9336368c6e92dcedeb27640194c8364140cd324d77dca07d77768d81204ed1a79ccd310ae17e9270db6a5c30a1c93c5bd6b8c0dbd4f077777831b13a42a68d79
   languageName: node
   linkType: hard
@@ -3920,10 +3896,10 @@ __metadata:
   version: 5.2.1
   resolution: "cosmiconfig@npm:5.2.1"
   dependencies:
-    import-fresh: ^2.0.0
-    is-directory: ^0.3.1
-    js-yaml: ^3.13.1
-    parse-json: ^4.0.0
+    import-fresh: "npm:^2.0.0"
+    is-directory: "npm:^0.3.1"
+    js-yaml: "npm:^3.13.1"
+    parse-json: "npm:^4.0.0"
   checksum: ae9ba309cdbb42d0c9d63dad5c1dfa1c56bb8f818cb8633eea14fd2dbdc9f33393b77658ba96fdabda497bc943afed8c3371d1222afe613c518ba676fa624645
   languageName: node
   linkType: hard
@@ -3932,11 +3908,11 @@ __metadata:
   version: 6.2.0
   resolution: "cp-file@npm:6.2.0"
   dependencies:
-    graceful-fs: ^4.1.2
-    make-dir: ^2.0.0
-    nested-error-stacks: ^2.0.0
-    pify: ^4.0.1
-    safe-buffer: ^5.0.1
+    graceful-fs: "npm:^4.1.2"
+    make-dir: "npm:^2.0.0"
+    nested-error-stacks: "npm:^2.0.0"
+    pify: "npm:^4.0.1"
+    safe-buffer: "npm:^5.0.1"
   checksum: 7abac1d5608d21433171a9706380e6c226c7cd03f40b14a1b9b3e0977a7a4e54da0c325bc7f298983a695d8e184d17d6a2415b855935142bc195232fdf96d983
   languageName: node
   linkType: hard
@@ -3952,9 +3928,9 @@ __metadata:
   version: 1.1.1
   resolution: "cpr@npm:1.1.1"
   dependencies:
-    graceful-fs: ~4.1.2
-    mkdirp: ~0.5.0
-    rimraf: ~2.4.3
+    graceful-fs: "npm:~4.1.2"
+    mkdirp: "npm:~0.5.0"
+    rimraf: "npm:~2.4.3"
   bin:
     cpr: ./bin/cpr
   checksum: 09d80cfd9ead38cfb161271aadd7b0d3cd936a864a16d55abf2d66bdd1490e03775028af94556f86ca47c370f00503127d792ddb5a936d4edc9bb33cfe3816a1
@@ -3972,7 +3948,7 @@ __metadata:
   version: 6.0.3
   resolution: "cross-env@npm:6.0.3"
   dependencies:
-    cross-spawn: ^7.0.0
+    cross-spawn: "npm:^7.0.0"
   bin:
     cross-env: src/bin/cross-env.js
     cross-env-shell: src/bin/cross-env-shell.js
@@ -3984,19 +3960,9 @@ __metadata:
   version: 2.2.5
   resolution: "cross-spawn-async@npm:2.2.5"
   dependencies:
-    lru-cache: ^4.0.0
-    which: ^1.2.8
+    lru-cache: "npm:^4.0.0"
+    which: "npm:^1.2.8"
   checksum: 2d7324afbcbb677e6717b10dec6e3cd8f746e622ded91ebc7f2d9e6e65dc3e0ab72f5d9793c78e52f33bebf6650c7f113fe44e5cecff486e7adaba7d6d29a00f
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "cross-spawn@npm:3.0.1"
-  dependencies:
-    lru-cache: ^4.0.1
-    which: ^1.2.9
-  checksum: cbd3d9a9ba1b3125d8ac60430847bd9eb0297fee39be016f98a73232b21a6299718432793477376bd39dea1a2dd14962f38ef3830db1243e5d0033a1d7eea5cc
   languageName: node
   linkType: hard
 
@@ -4004,8 +3970,8 @@ __metadata:
   version: 4.0.2
   resolution: "cross-spawn@npm:4.0.2"
   dependencies:
-    lru-cache: ^4.0.1
-    which: ^1.2.9
+    lru-cache: "npm:^4.0.1"
+    which: "npm:^1.2.9"
   checksum: 4de7254653b658776be8e1050473349723d2ac8bc10b912fbeb159ad32d06c7fa2135b04b896b7cbe0141d274dae9d7543cc6e5c9c919e2062e44a66c2184665
   languageName: node
   linkType: hard
@@ -4014,9 +3980,9 @@ __metadata:
   version: 5.1.0
   resolution: "cross-spawn@npm:5.1.0"
   dependencies:
-    lru-cache: ^4.0.1
-    shebang-command: ^1.2.0
-    which: ^1.2.9
+    lru-cache: "npm:^4.0.1"
+    shebang-command: "npm:^1.2.0"
+    which: "npm:^1.2.9"
   checksum: 1918621fddb9f8c61e02118b2dbf81f611ccd1544ceaca0d026525341832b8511ce2504c60f935dbc06b35e5ef156fe8c1e72708c27dd486f034e9c0e1e07201
   languageName: node
   linkType: hard
@@ -4025,11 +3991,11 @@ __metadata:
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
   dependencies:
-    nice-try: ^1.0.4
-    path-key: ^2.0.1
-    semver: ^5.5.0
-    shebang-command: ^1.2.0
-    which: ^1.2.9
+    nice-try: "npm:^1.0.4"
+    path-key: "npm:^2.0.1"
+    semver: "npm:^5.5.0"
+    shebang-command: "npm:^1.2.0"
+    which: "npm:^1.2.9"
   checksum: e05544722e9d7189b4292c66e42b7abeb21db0d07c91b785f4ae5fefceb1f89e626da2703744657b287e86dcd4af57b54567cef75159957ff7a8a761d9055012
   languageName: node
   linkType: hard
@@ -4038,9 +4004,9 @@ __metadata:
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
-    path-key: ^3.1.0
-    shebang-command: ^2.0.0
-    which: ^2.0.1
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
   checksum: 5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
   languageName: node
   linkType: hard
@@ -4049,7 +4015,7 @@ __metadata:
   version: 4.1.3
   resolution: "cryptiles@npm:4.1.3"
   dependencies:
-    boom: 7.x.x
+    boom: "npm:7.x.x"
   checksum: 6fe75435ec91f6d322b1be00ee30d735c25ca0a6e821427cbd767a5ac2a920f7a02a0ce63f3353b2ef90c8ba83de6730cedc8c64e057a80f02fb8b7e59197e68
   languageName: node
   linkType: hard
@@ -4065,16 +4031,16 @@ __metadata:
   version: 5.2.7
   resolution: "css-loader@npm:5.2.7"
   dependencies:
-    icss-utils: ^5.1.0
-    loader-utils: ^2.0.0
-    postcss: ^8.2.15
-    postcss-modules-extract-imports: ^3.0.0
-    postcss-modules-local-by-default: ^4.0.0
-    postcss-modules-scope: ^3.0.0
-    postcss-modules-values: ^4.0.0
-    postcss-value-parser: ^4.1.0
-    schema-utils: ^3.0.0
-    semver: ^7.3.5
+    icss-utils: "npm:^5.1.0"
+    loader-utils: "npm:^2.0.0"
+    postcss: "npm:^8.2.15"
+    postcss-modules-extract-imports: "npm:^3.0.0"
+    postcss-modules-local-by-default: "npm:^4.0.0"
+    postcss-modules-scope: "npm:^3.0.0"
+    postcss-modules-values: "npm:^4.0.0"
+    postcss-value-parser: "npm:^4.1.0"
+    schema-utils: "npm:^3.0.0"
+    semver: "npm:^7.3.5"
   peerDependencies:
     webpack: ^4.27.0 || ^5.0.0
   checksum: 02fbdb0dca92e4a4d2aa27b2817ea51d0af3d662d3295c61f2aa37537b29f9a46a9c2e87d8f5e40a1a97159f35d5c7b9a325f27761b59a38c8e15e8ca3988d2b
@@ -4085,10 +4051,10 @@ __metadata:
   version: 1.2.0
   resolution: "css-select@npm:1.2.0"
   dependencies:
-    boolbase: ~1.0.0
-    css-what: 2.1
-    domutils: 1.5.1
-    nth-check: ~1.0.1
+    boolbase: "npm:~1.0.0"
+    css-what: "npm:2.1"
+    domutils: "npm:1.5.1"
+    nth-check: "npm:~1.0.1"
   checksum: 16e91cd4a8606e76eb2d93ded43e2d20fe315effa7e1dedf16e81fab5c6bbd18b394f78cb59c04e2dddc7d4c68e31a0617b7f4f196dff48398cf3ac83e78475c
   languageName: node
   linkType: hard
@@ -4127,7 +4093,7 @@ __metadata:
   version: 0.2.37
   resolution: "cssstyle@npm:0.2.37"
   dependencies:
-    cssom: 0.3.x
+    cssom: "npm:0.3.x"
   checksum: a85e96eb2cf8169215c871c6bc7772880fe12d0ef047f1a4b045d9c95f54448c24a41f413f9c75ba918ee12fe3523f5f19da897474b9edee07b8b449b7410a88
   languageName: node
   linkType: hard
@@ -4136,7 +4102,7 @@ __metadata:
   version: 0.4.1
   resolution: "currently-unhandled@npm:0.4.1"
   dependencies:
-    array-find-index: ^1.0.1
+    array-find-index: "npm:^1.0.1"
   checksum: 32d197689ec32f035910202c1abb0dc6424dce01d7b51779c685119b380d98535c110ffff67a262fc7e367612a7dfd30d3d3055f9a6634b5a9dd1302de7ef11c
   languageName: node
   linkType: hard
@@ -4145,8 +4111,8 @@ __metadata:
   version: 1.0.1
   resolution: "d@npm:1.0.1"
   dependencies:
-    es5-ext: ^0.10.50
-    type: ^1.0.1
+    es5-ext: "npm:^0.10.50"
+    type: "npm:^1.0.1"
   checksum: 1fedcb3b956a461f64d86b94b347441beff5cef8910b6ac4ec509a2c67eeaa7093660a98b26601ac91f91260238add73bdf25867a9c0cb783774642bc4c1523f
   languageName: node
   linkType: hard
@@ -4155,7 +4121,7 @@ __metadata:
   version: 0.1.1
   resolution: "d@npm:0.1.1"
   dependencies:
-    es5-ext: ~0.10.2
+    es5-ext: "npm:~0.10.2"
   checksum: 16d5104cedba68dbe69e5be6ee06896db1fb89333467436dfdd3eb5fb5e2cc2e9b5ada927f375ddd3d3b51d3c22f02c43c5d5e89f71bfc2c05d9f38e5ef0e38b
   languageName: node
   linkType: hard
@@ -4164,7 +4130,7 @@ __metadata:
   version: 1.14.1
   resolution: "dashdash@npm:1.14.1"
   dependencies:
-    assert-plus: ^1.0.0
+    assert-plus: "npm:^1.0.0"
   checksum: 64589a15c5bd01fa41ff7007e0f2c6552c5ef2028075daa16b188a3721f4ba001841bf306dfc2eee6e2e6e7f76b38f5f17fb21fa847504192290ffa9e150118a
   languageName: node
   linkType: hard
@@ -4173,8 +4139,8 @@ __metadata:
   version: 0.2.1
   resolution: "datauri@npm:0.2.1"
   dependencies:
-    mimer: "*"
-    templayed: "*"
+    mimer: "npm:*"
+    templayed: "npm:*"
   bin:
     datauri: ./bin/datauri
   checksum: 8bed386cd0dac487f26a839862162df81cb2b784fd86acc7f8f939b543a4b0fada5e77f74ec8df474555d930e9114e05e7973b041617485a266a926415d20a35
@@ -4192,7 +4158,7 @@ __metadata:
   version: 4.3.3
   resolution: "debug@npm:4.3.3"
   dependencies:
-    ms: 2.1.2
+    ms: "npm:2.1.2"
   peerDependenciesMeta:
     supports-color:
       optional: true
@@ -4204,7 +4170,7 @@ __metadata:
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
-    ms: 2.0.0
+    ms: "npm:2.0.0"
   checksum: 121908fb839f7801180b69a7e218a40b5a0b718813b886b7d6bdb82001b931c938e2941d1e4450f33a1b1df1da653f5f7a0440c197f29fbf8a6e9d45ff6ef589
   languageName: node
   linkType: hard
@@ -4213,7 +4179,7 @@ __metadata:
   version: 3.2.7
   resolution: "debug@npm:3.2.7"
   dependencies:
-    ms: ^2.1.1
+    ms: "npm:^2.1.1"
   checksum: 37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
   languageName: node
   linkType: hard
@@ -4222,7 +4188,7 @@ __metadata:
   version: 2.2.0
   resolution: "debug@npm:2.2.0"
   dependencies:
-    ms: 0.7.1
+    ms: "npm:0.7.1"
   checksum: d24d6200c9d9bef20e1dcb823a9895193a45c39505606468735f387bdd850a21baf4c7841df1787f9a02596cbf0f111d60726ba3fa7511e22198b91b33440fe9
   languageName: node
   linkType: hard
@@ -4238,13 +4204,13 @@ __metadata:
   version: 1.1.0
   resolution: "decamelize-keys@npm:1.1.0"
   dependencies:
-    decamelize: ^1.1.0
-    map-obj: ^1.0.0
+    decamelize: "npm:^1.1.0"
+    map-obj: "npm:^1.0.0"
   checksum: 95d4e3692cf7cf6568042658b780f16475a2145910a3d4e996a8d1686c2328c061365643b67b19fee5ea4a03448afc65c9fbb844400c0ecd7dadad175a72e6ef
   languageName: node
   linkType: hard
 
-"decamelize@npm:^1.0.0, decamelize@npm:^1.1.0, decamelize@npm:^1.1.1, decamelize@npm:^1.1.2, decamelize@npm:^1.2.0":
+"decamelize@npm:^1.0.0, decamelize@npm:^1.1.0, decamelize@npm:^1.1.1, decamelize@npm:^1.2.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 85c39fe8fbf0482d4a1e224ef0119db5c1897f8503bcef8b826adff7a1b11414972f6fef2d7dec2ee0b4be3863cf64ac1439137ae9e6af23a3d8dcbe26a5b4b2
@@ -4269,7 +4235,7 @@ __metadata:
   version: 3.3.0
   resolution: "decompress-response@npm:3.3.0"
   dependencies:
-    mimic-response: ^1.0.0
+    mimic-response: "npm:^1.0.0"
   checksum: 5ffaf1d744277fd51c68c94ddc3081cd011b10b7de06637cccc6ecba137d45304a09ba1a776dee1c47fccc60b4a056c4bc74468eeea798ff1f1fca0024b45c9d
   languageName: node
   linkType: hard
@@ -4278,7 +4244,7 @@ __metadata:
   version: 3.0.1
   resolution: "deep-eql@npm:3.0.1"
   dependencies:
-    type-detect: ^4.0.0
+    type-detect: "npm:^4.0.0"
   checksum: 80b33c1c7713b3d5db89e6b5e9b22050f39c8a88e12a015616da8391e013988790d045a5c612b0c6dc43cc4bec51eadbe0fcf6075cc9717f8f56efdb305b6e6f
   languageName: node
   linkType: hard
@@ -4308,7 +4274,7 @@ __metadata:
   version: 2.0.0
   resolution: "default-require-extensions@npm:2.0.0"
   dependencies:
-    strip-bom: ^3.0.0
+    strip-bom: "npm:^3.0.0"
   checksum: 654b789c62c347b308254e2d0d27c125b40b9ad251ce1fd96e1b41ddcca747a9c9c38ada04ba1310bd0c14189cbfef3b38448a9fef83a154375adac34c94391a
   languageName: node
   linkType: hard
@@ -4317,7 +4283,7 @@ __metadata:
   version: 1.0.3
   resolution: "defaults@npm:1.0.3"
   dependencies:
-    clone: ^1.0.2
+    clone: "npm:^1.0.2"
   checksum: c9ba6718eb293fa701652e28967b87102fc13d8e33997748191ad8ed3b2235714bd3661e8505bed06994e6b4604a1281c35462ec328c2bbedd79ebbf7e82adb2
   languageName: node
   linkType: hard
@@ -4333,7 +4299,7 @@ __metadata:
   version: 1.1.3
   resolution: "define-properties@npm:1.1.3"
   dependencies:
-    object-keys: ^1.0.12
+    object-keys: "npm:^1.0.12"
   checksum: a2fa03d97ee44bb7c679bac7c3b3e63431a2efd83c12c0d61c7f5adf4fa1cf0a669c77afd274babbc5400926bdc2befb25679e4bf687140b078c0fe14f782e4f
   languageName: node
   linkType: hard
@@ -4342,7 +4308,7 @@ __metadata:
   version: 0.2.5
   resolution: "define-property@npm:0.2.5"
   dependencies:
-    is-descriptor: ^0.1.0
+    is-descriptor: "npm:^0.1.0"
   checksum: 9986915c0893818dedc9ca23eaf41370667762fd83ad8aa4bf026a28563120dbaacebdfbfbf2b18d3b929026b9c6ee972df1dbf22de8fafb5fe6ef18361e4750
   languageName: node
   linkType: hard
@@ -4351,7 +4317,7 @@ __metadata:
   version: 1.0.0
   resolution: "define-property@npm:1.0.0"
   dependencies:
-    is-descriptor: ^1.0.0
+    is-descriptor: "npm:^1.0.0"
   checksum: d7cf09db10d55df305f541694ed51dafc776ad9bb8a24428899c9f2d36b11ab38dce5527a81458d1b5e7c389f8cbe803b4abad6e91a0037a329d153b84fc975e
   languageName: node
   linkType: hard
@@ -4360,8 +4326,8 @@ __metadata:
   version: 2.0.2
   resolution: "define-property@npm:2.0.2"
   dependencies:
-    is-descriptor: ^1.0.2
-    isobject: ^3.0.1
+    is-descriptor: "npm:^1.0.2"
+    isobject: "npm:^3.0.1"
   checksum: f91a08ad008fa764172a2c072adc7312f10217ade89ddaea23018321c6d71b2b68b8c229141ed2064179404e345c537f1a2457c379824813695b51a6ad3e4969
   languageName: node
   linkType: hard
@@ -4370,8 +4336,8 @@ __metadata:
   version: 3.0.0
   resolution: "del-cli@npm:3.0.0"
   dependencies:
-    del: ^5.1.0
-    meow: ^5.0.0
+    del: "npm:^5.1.0"
+    meow: "npm:^5.0.0"
   bin:
     del: cli.js
     del-cli: cli.js
@@ -4383,14 +4349,14 @@ __metadata:
   version: 5.1.0
   resolution: "del@npm:5.1.0"
   dependencies:
-    globby: ^10.0.1
-    graceful-fs: ^4.2.2
-    is-glob: ^4.0.1
-    is-path-cwd: ^2.2.0
-    is-path-inside: ^3.0.1
-    p-map: ^3.0.0
-    rimraf: ^3.0.0
-    slash: ^3.0.0
+    globby: "npm:^10.0.1"
+    graceful-fs: "npm:^4.2.2"
+    is-glob: "npm:^4.0.1"
+    is-path-cwd: "npm:^2.2.0"
+    is-path-inside: "npm:^3.0.1"
+    p-map: "npm:^3.0.0"
+    rimraf: "npm:^3.0.0"
+    slash: "npm:^3.0.0"
   checksum: 1c25de7ff7cf4a8ee017190e39e05d2c4e19774802213d210daaa627228b50e0f5b04e7ce8cceaf03647b238732f78dc303ec5a9d54d5104de33a13fb5a899cf
   languageName: node
   linkType: hard
@@ -4399,13 +4365,13 @@ __metadata:
   version: 4.1.1
   resolution: "del@npm:4.1.1"
   dependencies:
-    "@types/glob": ^7.1.1
-    globby: ^6.1.0
-    is-path-cwd: ^2.0.0
-    is-path-in-cwd: ^2.0.0
-    p-map: ^2.0.0
-    pify: ^4.0.1
-    rimraf: ^2.6.3
+    "@types/glob": "npm:^7.1.1"
+    globby: "npm:^6.1.0"
+    is-path-cwd: "npm:^2.0.0"
+    is-path-in-cwd: "npm:^2.0.0"
+    p-map: "npm:^2.0.0"
+    pify: "npm:^4.0.1"
+    rimraf: "npm:^2.6.3"
   checksum: ed3233e86e39c0a6a7ea85d8ad0ebc00603078ad408b9c34b4742f707c20028c5731dce2e8aa9a6eb5ae6bee30ccc5405cf7b5d457306520e37c92d0410b6061
   languageName: node
   linkType: hard
@@ -4442,7 +4408,7 @@ __metadata:
   version: 4.0.0
   resolution: "detect-indent@npm:4.0.0"
   dependencies:
-    repeating: ^2.0.0
+    repeating: "npm:^2.0.0"
   checksum: 066a0d13eadebb1e7d2ba395fdf9f3956f31f8383a6db263320108c283e2230250a102f4871f54926cc8a77c6323ac7103f30550a4ac3d6518aa1b934c041295
   languageName: node
   linkType: hard
@@ -4451,8 +4417,8 @@ __metadata:
   version: 1.0.3
   resolution: "dezalgo@npm:1.0.3"
   dependencies:
-    asap: ^2.0.0
-    wrappy: 1
+    asap: "npm:^2.0.0"
+    wrappy: "npm:1"
   checksum: 6e59d007653be156b2d9da758cc86f5f3efbe7c97a84262ae3562a308145cde11e4152fd3c4b527632cd7c499abd2dabb1cf3d5ef84d8f3e23e9cb149408a45b
   languageName: node
   linkType: hard
@@ -4482,7 +4448,7 @@ __metadata:
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
   dependencies:
-    path-type: ^4.0.0
+    path-type: "npm:^4.0.0"
   checksum: dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
   languageName: node
   linkType: hard
@@ -4500,7 +4466,7 @@ __metadata:
   version: 2.1.0
   resolution: "doctrine@npm:2.1.0"
   dependencies:
-    esutils: ^2.0.2
+    esutils: "npm:^2.0.2"
   checksum: b6416aaff1f380bf56c3b552f31fdf7a69b45689368deca72d28636f41c16bb28ec3ebc40ace97db4c1afc0ceeb8120e8492fe0046841c94c2933b2e30a7d5ac
   languageName: node
   linkType: hard
@@ -4509,7 +4475,7 @@ __metadata:
   version: 3.0.0
   resolution: "doctrine@npm:3.0.0"
   dependencies:
-    esutils: ^2.0.2
+    esutils: "npm:^2.0.2"
   checksum: c96bdccabe9d62ab6fea9399fdff04a66e6563c1d6fb3a3a063e8d53c3bb136ba63e84250bbf63d00086a769ad53aef92d2bd483f03f837fc97b71cbee6b2520
   languageName: node
   linkType: hard
@@ -4518,8 +4484,8 @@ __metadata:
   version: 0.2.2
   resolution: "dom-serializer@npm:0.2.2"
   dependencies:
-    domelementtype: ^2.0.1
-    entities: ^2.0.0
+    domelementtype: "npm:^2.0.1"
+    entities: "npm:^2.0.0"
   checksum: 5cb595fb77e1a23eca56742f47631e6f4af66ce1982c7ed28b3d0ef21f1f50304c067adc29d3eaf824c572be022cee88627d0ac9b929408f24e923f3c7bed37b
   languageName: node
   linkType: hard
@@ -4528,8 +4494,8 @@ __metadata:
   version: 0.1.0
   resolution: "dom-serializer@npm:0.1.0"
   dependencies:
-    domelementtype: ~1.1.1
-    entities: ~1.1.1
+    domelementtype: "npm:~1.1.1"
+    entities: "npm:~1.1.1"
   checksum: a5b2670a3ddbb7d5aed9f617b034992ce228de8b5aa5038b1b5aaebc506280a134eb720ca6e612ca48bb1dd2677f46c3c27ab5646a42fffd8f3762e37c34eef8
   languageName: node
   linkType: hard
@@ -4538,8 +4504,8 @@ __metadata:
   version: 0.1.1
   resolution: "dom-serializer@npm:0.1.1"
   dependencies:
-    domelementtype: ^1.3.0
-    entities: ^1.1.1
+    domelementtype: "npm:^1.3.0"
+    entities: "npm:^1.1.1"
   checksum: bb710d0a49dbe7b1019e8bf314102495e8894b9da188d00187c0ac52939ded630bc5f9eacc97bfa462d535cd321c734c0b02fefd5e4d93162ab886dccc6666f3
   languageName: node
   linkType: hard
@@ -4569,7 +4535,7 @@ __metadata:
   version: 2.3.0
   resolution: "domhandler@npm:2.3.0"
   dependencies:
-    domelementtype: 1
+    domelementtype: "npm:1"
   checksum: f434a1c08392821751b85081fd8ff11b17d7fd6e5da59335af87ee038b816be24d35a12f45d85034e3e137158beb031d5a3df21fcd05a7dd4490e2f01a6d0e82
   languageName: node
   linkType: hard
@@ -4578,7 +4544,7 @@ __metadata:
   version: 2.4.2
   resolution: "domhandler@npm:2.4.2"
   dependencies:
-    domelementtype: 1
+    domelementtype: "npm:1"
   checksum: 6670cab73e97e3c6771dcf22b537db3f6a0be0ad6b370f03bb5f1b585d3b563d326787fdabe1190b7ca9d81c804e9b3f8a1431159c27c44f6c05f94afa92be2d
   languageName: node
   linkType: hard
@@ -4587,8 +4553,8 @@ __metadata:
   version: 1.5.1
   resolution: "domutils@npm:1.5.1"
   dependencies:
-    dom-serializer: 0
-    domelementtype: 1
+    dom-serializer: "npm:0"
+    domelementtype: "npm:1"
   checksum: 8707a18c974be54d33fd846d174d523ddf4955b2fcc1ec713cbe6ff490f60da22106b153fea6269332477eb81dc1a25a83f5b2afaf78b6dc9e2161fd7b80f7ba
   languageName: node
   linkType: hard
@@ -4597,8 +4563,8 @@ __metadata:
   version: 1.7.0
   resolution: "domutils@npm:1.7.0"
   dependencies:
-    dom-serializer: 0
-    domelementtype: 1
+    dom-serializer: "npm:0"
+    domelementtype: "npm:1"
   checksum: 437fcd2d6d6be03f488152e73c6f953e289c58496baa22be9626b2b46f9cfd40486ae77d144487ff6b102929a3231cdb9a8bf8ef485fb7b7c30c985daedc77eb
   languageName: node
   linkType: hard
@@ -4607,7 +4573,7 @@ __metadata:
   version: 4.2.1
   resolution: "dot-prop@npm:4.2.1"
   dependencies:
-    is-obj: ^1.0.0
+    is-obj: "npm:^1.0.0"
   checksum: ea0a98871ef4de0cce05325979517a43b70eb3a3671254fce78f2629c125d5ddb69cfdd5570ace4e41d9f02ced06374ea0444d1aeae70290a19f73e02093318e
   languageName: node
   linkType: hard
@@ -4623,8 +4589,8 @@ __metadata:
   version: 0.1.2
   resolution: "ecc-jsbn@npm:0.1.2"
   dependencies:
-    jsbn: ~0.1.0
-    safer-buffer: ^2.1.0
+    jsbn: "npm:~0.1.0"
+    safer-buffer: "npm:^2.1.0"
   checksum: 6cf168bae1e2dad2e46561d9af9cbabfbf5ff592176ad4e9f0f41eaaf5fe5e10bb58147fe0a804de62b1ee9dad42c28810c88d652b21b6013c47ba8efa274ca1
   languageName: node
   linkType: hard
@@ -4682,7 +4648,7 @@ __metadata:
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
   dependencies:
-    iconv-lite: ^0.6.2
+    iconv-lite: "npm:^0.6.2"
   checksum: 36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
   languageName: node
   linkType: hard
@@ -4691,7 +4657,7 @@ __metadata:
   version: 1.4.4
   resolution: "end-of-stream@npm:1.4.4"
   dependencies:
-    once: ^1.4.0
+    once: "npm:^1.4.0"
   checksum: 870b423afb2d54bb8d243c63e07c170409d41e20b47eeef0727547aea5740bd6717aca45597a9f2745525667a6b804c1e7bede41f856818faee5806dd9ff3975
   languageName: node
   linkType: hard
@@ -4700,8 +4666,8 @@ __metadata:
   version: 5.8.3
   resolution: "enhanced-resolve@npm:5.8.3"
   dependencies:
-    graceful-fs: ^4.2.4
-    tapable: ^2.2.0
+    graceful-fs: "npm:^4.2.4"
+    tapable: "npm:^2.2.0"
   checksum: c50de36c067359833577fb031de6a3b3d0eeb0627cb81fea1e132116d0b5a4fc746e0c8525f683de0a656f25aad08d3da773775b27608db1695ac47ac64ff673
   languageName: node
   linkType: hard
@@ -4745,7 +4711,7 @@ __metadata:
   version: 0.1.8
   resolution: "errno@npm:0.1.8"
   dependencies:
-    prr: ~1.0.1
+    prr: "npm:~1.0.1"
   bin:
     errno: cli.js
   checksum: 83758951967ec57bf00b5f5b7dc797e6d65a6171e57ea57adcf1bd1a0b477fd9b5b35fae5be1ff18f4090ed156bce1db749fe7e317aac19d485a5d150f6a4936
@@ -4756,7 +4722,7 @@ __metadata:
   version: 1.3.2
   resolution: "error-ex@npm:1.3.2"
   dependencies:
-    is-arrayish: ^0.2.1
+    is-arrayish: "npm:^0.2.1"
   checksum: ba827f89369b4c93382cfca5a264d059dfefdaa56ecc5e338ffa58a6471f5ed93b71a20add1d52290a4873d92381174382658c885ac1a2305f7baca363ce9cce
   languageName: node
   linkType: hard
@@ -4765,8 +4731,8 @@ __metadata:
   version: 7.0.2
   resolution: "error@npm:7.0.2"
   dependencies:
-    string-template: ~0.2.1
-    xtend: ~4.0.0
+    string-template: "npm:~0.2.1"
+    xtend: "npm:~4.0.0"
   checksum: abee95f258f34490278bfb5f5852420e23f9d7dd7754215144391a731c2e7f68ccb5367497ca7cc20459d1eb7ae5d119d6c82f620a9340150034ddd2e3603178
   languageName: node
   linkType: hard
@@ -4775,26 +4741,26 @@ __metadata:
   version: 1.19.1
   resolution: "es-abstract@npm:1.19.1"
   dependencies:
-    call-bind: ^1.0.2
-    es-to-primitive: ^1.2.1
-    function-bind: ^1.1.1
-    get-intrinsic: ^1.1.1
-    get-symbol-description: ^1.0.0
-    has: ^1.0.3
-    has-symbols: ^1.0.2
-    internal-slot: ^1.0.3
-    is-callable: ^1.2.4
-    is-negative-zero: ^2.0.1
-    is-regex: ^1.1.4
-    is-shared-array-buffer: ^1.0.1
-    is-string: ^1.0.7
-    is-weakref: ^1.0.1
-    object-inspect: ^1.11.0
-    object-keys: ^1.1.1
-    object.assign: ^4.1.2
-    string.prototype.trimend: ^1.0.4
-    string.prototype.trimstart: ^1.0.4
-    unbox-primitive: ^1.0.1
+    call-bind: "npm:^1.0.2"
+    es-to-primitive: "npm:^1.2.1"
+    function-bind: "npm:^1.1.1"
+    get-intrinsic: "npm:^1.1.1"
+    get-symbol-description: "npm:^1.0.0"
+    has: "npm:^1.0.3"
+    has-symbols: "npm:^1.0.2"
+    internal-slot: "npm:^1.0.3"
+    is-callable: "npm:^1.2.4"
+    is-negative-zero: "npm:^2.0.1"
+    is-regex: "npm:^1.1.4"
+    is-shared-array-buffer: "npm:^1.0.1"
+    is-string: "npm:^1.0.7"
+    is-weakref: "npm:^1.0.1"
+    object-inspect: "npm:^1.11.0"
+    object-keys: "npm:^1.1.1"
+    object.assign: "npm:^4.1.2"
+    string.prototype.trimend: "npm:^1.0.4"
+    string.prototype.trimstart: "npm:^1.0.4"
+    unbox-primitive: "npm:^1.0.1"
   checksum: 24ed66dfa682f1bbcfa70cd95581c29a6ba88baf579619bff5690ac383b8612f3f5fcebf30dec8df634d507b633ef1ed9f09b010b07e17e3975d4ce674e3059c
   languageName: node
   linkType: hard
@@ -4803,9 +4769,9 @@ __metadata:
   version: 1.2.1
   resolution: "es-to-primitive@npm:1.2.1"
   dependencies:
-    is-callable: ^1.1.4
-    is-date-object: ^1.0.1
-    is-symbol: ^1.0.2
+    is-callable: "npm:^1.1.4"
+    is-date-object: "npm:^1.0.1"
+    is-symbol: "npm:^1.0.2"
   checksum: 0886572b8dc075cb10e50c0af62a03d03a68e1e69c388bd4f10c0649ee41b1fbb24840a1b7e590b393011b5cdbe0144b776da316762653685432df37d6de60f1
   languageName: node
   linkType: hard
@@ -4814,9 +4780,9 @@ __metadata:
   version: 0.10.53
   resolution: "es5-ext@npm:0.10.53"
   dependencies:
-    es6-iterator: ~2.0.3
-    es6-symbol: ~3.1.3
-    next-tick: ~1.0.0
+    es6-iterator: "npm:~2.0.3"
+    es6-symbol: "npm:~3.1.3"
+    next-tick: "npm:~1.0.0"
   checksum: 02989b89e777264756696baf64b6daf54e0be631b09870dfab8473e81129303c2791a001bf1f06bb38bf008403a0daad02e8001cb419ad8e4430452400ecd771
   languageName: node
   linkType: hard
@@ -4832,9 +4798,9 @@ __metadata:
   version: 0.1.3
   resolution: "es6-iterator@npm:0.1.3"
   dependencies:
-    d: ~0.1.1
-    es5-ext: ~0.10.5
-    es6-symbol: ~2.0.1
+    d: "npm:~0.1.1"
+    es5-ext: "npm:~0.10.5"
+    es6-symbol: "npm:~2.0.1"
   checksum: 8eb353f57e35b504b4156586900c191ab89f077635e79498b2e0934bfab4b3e9eab8873b73f7f9d9bcfcd753fce43aeb1c8e8473f7354c932b19cf648d385ce8
   languageName: node
   linkType: hard
@@ -4843,9 +4809,9 @@ __metadata:
   version: 2.0.3
   resolution: "es6-iterator@npm:2.0.3"
   dependencies:
-    d: 1
-    es5-ext: ^0.10.35
-    es6-symbol: ^3.1.1
+    d: "npm:1"
+    es5-ext: "npm:^0.10.35"
+    es6-symbol: "npm:^3.1.1"
   checksum: 91f20b799dba28fb05bf623c31857fc1524a0f1c444903beccaf8929ad196c8c9ded233e5ac7214fc63a92b3f25b64b7f2737fcca8b1f92d2d96cf3ac902f5d8
   languageName: node
   linkType: hard
@@ -4861,8 +4827,8 @@ __metadata:
   version: 3.1.3
   resolution: "es6-symbol@npm:3.1.3"
   dependencies:
-    d: ^1.0.1
-    ext: ^1.1.2
+    d: "npm:^1.0.1"
+    ext: "npm:^1.1.2"
   checksum: 22982f815f00df553a89f4fb74c5048fed85df598482b4bd38dbd173174247949c72982a7d7132a58b147525398400e5f182db59b0916cb49f1e245fb0e22233
   languageName: node
   linkType: hard
@@ -4871,8 +4837,8 @@ __metadata:
   version: 2.0.1
   resolution: "es6-symbol@npm:2.0.1"
   dependencies:
-    d: ~0.1.1
-    es5-ext: ~0.10.5
+    d: "npm:~0.1.1"
+    es5-ext: "npm:~0.10.5"
   checksum: 579a61542d60129df7e401ad4237c4d614161c02a690b93644dbc9a7a4e3f99c8421f3474c5ddbe6a76d63f1fd9243b58f515a20d2c6e3e1a761d31e8db745e9
   languageName: node
   linkType: hard
@@ -4881,10 +4847,10 @@ __metadata:
   version: 0.1.4
   resolution: "es6-weak-map@npm:0.1.4"
   dependencies:
-    d: ~0.1.1
-    es5-ext: ~0.10.6
-    es6-iterator: ~0.1.3
-    es6-symbol: ~2.0.1
+    d: "npm:~0.1.1"
+    es5-ext: "npm:~0.10.6"
+    es6-iterator: "npm:~0.1.3"
+    es6-symbol: "npm:~2.0.1"
   checksum: 2f6eff82b437b10f7fca84469e040ee4b801044ccfd05d849832a361f44d481f831c49a2308d5f860e3f2422d27a76c998067ef731db2168d232064739e51e7c
   languageName: node
   linkType: hard
@@ -4928,11 +4894,11 @@ __metadata:
   version: 1.14.3
   resolution: "escodegen@npm:1.14.3"
   dependencies:
-    esprima: ^4.0.1
-    estraverse: ^4.2.0
-    esutils: ^2.0.2
-    optionator: ^0.8.1
-    source-map: ~0.6.1
+    esprima: "npm:^4.0.1"
+    estraverse: "npm:^4.2.0"
+    esutils: "npm:^2.0.2"
+    optionator: "npm:^0.8.1"
+    source-map: "npm:~0.6.1"
   dependenciesMeta:
     source-map:
       optional: true
@@ -4947,9 +4913,9 @@ __metadata:
   version: 14.2.1
   resolution: "eslint-config-airbnb-base@npm:14.2.1"
   dependencies:
-    confusing-browser-globals: ^1.0.10
-    object.assign: ^4.1.2
-    object.entries: ^1.1.2
+    confusing-browser-globals: "npm:^1.0.10"
+    object.assign: "npm:^4.1.2"
+    object.entries: "npm:^1.1.2"
   peerDependencies:
     eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
     eslint-plugin-import: ^2.22.1
@@ -4961,7 +4927,7 @@ __metadata:
   version: 6.15.0
   resolution: "eslint-config-prettier@npm:6.15.0"
   dependencies:
-    get-stdin: ^6.0.0
+    get-stdin: "npm:^6.0.0"
   peerDependencies:
     eslint: ">=3.14.1"
   bin:
@@ -4974,8 +4940,8 @@ __metadata:
   version: 0.3.6
   resolution: "eslint-import-resolver-node@npm:0.3.6"
   dependencies:
-    debug: ^3.2.7
-    resolve: ^1.20.0
+    debug: "npm:^3.2.7"
+    resolve: "npm:^1.20.0"
   checksum: 20e06f3fa27b49de7159c8db54b4d7f82c156498e0050c491fcf7395922f927765b8296bf857c3b487da361bd65c1dcc68203832ef8e9179b461aa4192406535
   languageName: node
   linkType: hard
@@ -4984,8 +4950,8 @@ __metadata:
   version: 2.7.2
   resolution: "eslint-module-utils@npm:2.7.2"
   dependencies:
-    debug: ^3.2.7
-    find-up: ^2.1.0
+    debug: "npm:^3.2.7"
+    find-up: "npm:^2.1.0"
   checksum: 8d1658980d16cc529c9191351f033682f8a621b0246f5c6a8cc81bdf5dcff7893209ce204c6ff2b309c4be52d0370f8fb871071742b3ffb65e71756bebdde5f9
   languageName: node
   linkType: hard
@@ -4994,19 +4960,19 @@ __metadata:
   version: 2.25.4
   resolution: "eslint-plugin-import@npm:2.25.4"
   dependencies:
-    array-includes: ^3.1.4
-    array.prototype.flat: ^1.2.5
-    debug: ^2.6.9
-    doctrine: ^2.1.0
-    eslint-import-resolver-node: ^0.3.6
-    eslint-module-utils: ^2.7.2
-    has: ^1.0.3
-    is-core-module: ^2.8.0
-    is-glob: ^4.0.3
-    minimatch: ^3.0.4
-    object.values: ^1.1.5
-    resolve: ^1.20.0
-    tsconfig-paths: ^3.12.0
+    array-includes: "npm:^3.1.4"
+    array.prototype.flat: "npm:^1.2.5"
+    debug: "npm:^2.6.9"
+    doctrine: "npm:^2.1.0"
+    eslint-import-resolver-node: "npm:^0.3.6"
+    eslint-module-utils: "npm:^2.7.2"
+    has: "npm:^1.0.3"
+    is-core-module: "npm:^2.8.0"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^3.0.4"
+    object.values: "npm:^1.1.5"
+    resolve: "npm:^1.20.0"
+    tsconfig-paths: "npm:^3.12.0"
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
   checksum: 1119fbe50339a3977ae95b9696afb334ea78805c99c3652969f0262aae7d8735884d84c6fadb1da0ed8ed238c2474de2f38b68104d08b8e288915d7824869f44
@@ -5017,8 +4983,8 @@ __metadata:
   version: 3.7.1
   resolution: "eslint-scope@npm:3.7.1"
   dependencies:
-    esrecurse: ^4.1.0
-    estraverse: ^4.1.1
+    esrecurse: "npm:^4.1.0"
+    estraverse: "npm:^4.1.1"
   checksum: dc9e602fb146258952da683b47ff365ded2c55d2be4076ead2c73ab1aac6a7f5d451bfd90cadca1f28900f79ba89530a00f8d7062e0f5c3e72cd86df312b17dc
   languageName: node
   linkType: hard
@@ -5027,8 +4993,8 @@ __metadata:
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
   dependencies:
-    esrecurse: ^4.3.0
-    estraverse: ^4.1.1
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^4.1.1"
   checksum: d30ef9dc1c1cbdece34db1539a4933fe3f9b14e1ffb27ecc85987902ee663ad7c9473bbd49a9a03195a373741e62e2f807c4938992e019b511993d163450e70a
   languageName: node
   linkType: hard
@@ -5037,7 +5003,7 @@ __metadata:
   version: 1.4.3
   resolution: "eslint-utils@npm:1.4.3"
   dependencies:
-    eslint-visitor-keys: ^1.1.0
+    eslint-visitor-keys: "npm:^1.1.0"
   checksum: ba19a817177d5fc54ae89cd80ecc8bc24eefd640bd8b0db204f29dc79cf9621bb42d68bf31eae6c89ca1f52d748b6583214f57288f9a78d2bd368a2340abe41c
   languageName: node
   linkType: hard
@@ -5046,7 +5012,7 @@ __metadata:
   version: 2.1.0
   resolution: "eslint-utils@npm:2.1.0"
   dependencies:
-    eslint-visitor-keys: ^1.1.0
+    eslint-visitor-keys: "npm:^1.1.0"
   checksum: 69521c5d6569384b24093125d037ba238d3d6e54367f7143af9928f5286369e912c26cad5016d730c0ffb9797ac9e83831059d7f1d863f7dc84330eb02414611
   languageName: node
   linkType: hard
@@ -5062,43 +5028,43 @@ __metadata:
   version: 6.8.0
   resolution: "eslint@npm:6.8.0"
   dependencies:
-    "@babel/code-frame": ^7.0.0
-    ajv: ^6.10.0
-    chalk: ^2.1.0
-    cross-spawn: ^6.0.5
-    debug: ^4.0.1
-    doctrine: ^3.0.0
-    eslint-scope: ^5.0.0
-    eslint-utils: ^1.4.3
-    eslint-visitor-keys: ^1.1.0
-    espree: ^6.1.2
-    esquery: ^1.0.1
-    esutils: ^2.0.2
-    file-entry-cache: ^5.0.1
-    functional-red-black-tree: ^1.0.1
-    glob-parent: ^5.0.0
-    globals: ^12.1.0
-    ignore: ^4.0.6
-    import-fresh: ^3.0.0
-    imurmurhash: ^0.1.4
-    inquirer: ^7.0.0
-    is-glob: ^4.0.0
-    js-yaml: ^3.13.1
-    json-stable-stringify-without-jsonify: ^1.0.1
-    levn: ^0.3.0
-    lodash: ^4.17.14
-    minimatch: ^3.0.4
-    mkdirp: ^0.5.1
-    natural-compare: ^1.4.0
-    optionator: ^0.8.3
-    progress: ^2.0.0
-    regexpp: ^2.0.1
-    semver: ^6.1.2
-    strip-ansi: ^5.2.0
-    strip-json-comments: ^3.0.1
-    table: ^5.2.3
-    text-table: ^0.2.0
-    v8-compile-cache: ^2.0.3
+    "@babel/code-frame": "npm:^7.0.0"
+    ajv: "npm:^6.10.0"
+    chalk: "npm:^2.1.0"
+    cross-spawn: "npm:^6.0.5"
+    debug: "npm:^4.0.1"
+    doctrine: "npm:^3.0.0"
+    eslint-scope: "npm:^5.0.0"
+    eslint-utils: "npm:^1.4.3"
+    eslint-visitor-keys: "npm:^1.1.0"
+    espree: "npm:^6.1.2"
+    esquery: "npm:^1.0.1"
+    esutils: "npm:^2.0.2"
+    file-entry-cache: "npm:^5.0.1"
+    functional-red-black-tree: "npm:^1.0.1"
+    glob-parent: "npm:^5.0.0"
+    globals: "npm:^12.1.0"
+    ignore: "npm:^4.0.6"
+    import-fresh: "npm:^3.0.0"
+    imurmurhash: "npm:^0.1.4"
+    inquirer: "npm:^7.0.0"
+    is-glob: "npm:^4.0.0"
+    js-yaml: "npm:^3.13.1"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    levn: "npm:^0.3.0"
+    lodash: "npm:^4.17.14"
+    minimatch: "npm:^3.0.4"
+    mkdirp: "npm:^0.5.1"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.8.3"
+    progress: "npm:^2.0.0"
+    regexpp: "npm:^2.0.1"
+    semver: "npm:^6.1.2"
+    strip-ansi: "npm:^5.2.0"
+    strip-json-comments: "npm:^3.0.1"
+    table: "npm:^5.2.3"
+    text-table: "npm:^0.2.0"
+    v8-compile-cache: "npm:^2.0.3"
   bin:
     eslint: ./bin/eslint.js
   checksum: 95cd68b3bee8fcabf4468d3fcdfe74baefa878556312ad9ffd25715fe0dc96d6a7d381133bd9307dc24604a14c74fd86ce4fa3851b10783bb69a456b2d7a4acb
@@ -5116,9 +5082,9 @@ __metadata:
   version: 6.2.1
   resolution: "espree@npm:6.2.1"
   dependencies:
-    acorn: ^7.1.1
-    acorn-jsx: ^5.2.0
-    eslint-visitor-keys: ^1.1.0
+    acorn: "npm:^7.1.1"
+    acorn-jsx: "npm:^5.2.0"
+    eslint-visitor-keys: "npm:^1.1.0"
   checksum: 499b47bc599ac3515598072ca787016bdaf0d463467ee1c7113061949359a26d74b8fb344afdad63e38b0e81c7b068013125f7a123d0776e0d75fffe2fc9cfac
   languageName: node
   linkType: hard
@@ -5147,7 +5113,7 @@ __metadata:
   version: 1.4.0
   resolution: "esquery@npm:1.4.0"
   dependencies:
-    estraverse: ^5.1.0
+    estraverse: "npm:^5.1.0"
   checksum: b9b18178d33c4335210c76e062de979dc38ee6b49deea12bff1b2315e6cfcca1fd7f8bc49f899720ad8ff25967ac95b5b182e81a8b7b59ff09dbd0d978c32f64
   languageName: node
   linkType: hard
@@ -5156,7 +5122,7 @@ __metadata:
   version: 4.3.0
   resolution: "esrecurse@npm:4.3.0"
   dependencies:
-    estraverse: ^5.2.0
+    estraverse: "npm:^5.2.0"
   checksum: 81a37116d1408ded88ada45b9fb16dbd26fba3aadc369ce50fcaf82a0bac12772ebd7b24cd7b91fc66786bf2c1ac7b5f196bc990a473efff972f5cb338877cf5
   languageName: node
   linkType: hard
@@ -5193,8 +5159,8 @@ __metadata:
   version: 0.3.5
   resolution: "event-emitter@npm:0.3.5"
   dependencies:
-    d: 1
-    es5-ext: ~0.10.14
+    d: "npm:1"
+    es5-ext: "npm:~0.10.14"
   checksum: 75082fa8ffb3929766d0f0a063bfd6046bd2a80bea2666ebaa0cfd6f4a9116be6647c15667bea77222afc12f5b4071b68d393cf39fdaa0e8e81eda006160aff0
   languageName: node
   linkType: hard
@@ -5210,13 +5176,13 @@ __metadata:
   version: 0.7.0
   resolution: "execa@npm:0.7.0"
   dependencies:
-    cross-spawn: ^5.0.1
-    get-stream: ^3.0.0
-    is-stream: ^1.1.0
-    npm-run-path: ^2.0.0
-    p-finally: ^1.0.0
-    signal-exit: ^3.0.0
-    strip-eof: ^1.0.0
+    cross-spawn: "npm:^5.0.1"
+    get-stream: "npm:^3.0.0"
+    is-stream: "npm:^1.1.0"
+    npm-run-path: "npm:^2.0.0"
+    p-finally: "npm:^1.0.0"
+    signal-exit: "npm:^3.0.0"
+    strip-eof: "npm:^1.0.0"
   checksum: 812f1776e2a6b2226532e43c1af87d8a12e26de03a06e7e043f653acf5565e0656f5f6c64d66726fefa17178ac129caaa419a50905934e7c4a846417abb25d4a
   languageName: node
   linkType: hard
@@ -5225,15 +5191,15 @@ __metadata:
   version: 2.1.0
   resolution: "execa@npm:2.1.0"
   dependencies:
-    cross-spawn: ^7.0.0
-    get-stream: ^5.0.0
-    is-stream: ^2.0.0
-    merge-stream: ^2.0.0
-    npm-run-path: ^3.0.0
-    onetime: ^5.1.0
-    p-finally: ^2.0.0
-    signal-exit: ^3.0.2
-    strip-final-newline: ^2.0.0
+    cross-spawn: "npm:^7.0.0"
+    get-stream: "npm:^5.0.0"
+    is-stream: "npm:^2.0.0"
+    merge-stream: "npm:^2.0.0"
+    npm-run-path: "npm:^3.0.0"
+    onetime: "npm:^5.1.0"
+    p-finally: "npm:^2.0.0"
+    signal-exit: "npm:^3.0.2"
+    strip-final-newline: "npm:^2.0.0"
   checksum: 6578db04a18a9d166a2de6f85be2f1130315fe5917d8163fdbbeaaec39f89cc20448e243dffe833f58b93c210fb3b19e3612c155c81853722497100b8230c34c
   languageName: node
   linkType: hard
@@ -5242,7 +5208,7 @@ __metadata:
   version: 0.1.5
   resolution: "expand-brackets@npm:0.1.5"
   dependencies:
-    is-posix-bracket: ^0.1.0
+    is-posix-bracket: "npm:^0.1.0"
   checksum: 49b7fc1250f5f60ffe640be03777471ce63420eaa9850ce897b32bcf874e7be16b00917c7e2266a310e674ddb4ffe499ca964115bbc3f8c881288a280740aa6f
   languageName: node
   linkType: hard
@@ -5251,13 +5217,13 @@ __metadata:
   version: 2.1.4
   resolution: "expand-brackets@npm:2.1.4"
   dependencies:
-    debug: ^2.3.3
-    define-property: ^0.2.5
-    extend-shallow: ^2.0.1
-    posix-character-classes: ^0.1.0
-    regex-not: ^1.0.0
-    snapdragon: ^0.8.1
-    to-regex: ^3.0.1
+    debug: "npm:^2.3.3"
+    define-property: "npm:^0.2.5"
+    extend-shallow: "npm:^2.0.1"
+    posix-character-classes: "npm:^0.1.0"
+    regex-not: "npm:^1.0.0"
+    snapdragon: "npm:^0.8.1"
+    to-regex: "npm:^3.0.1"
   checksum: 3e2fb95d2d7d7231486493fd65db913927b656b6fcdfcce41e139c0991a72204af619ad4acb1be75ed994ca49edb7995ef241dbf8cf44dc3c03d211328428a87
   languageName: node
   linkType: hard
@@ -5266,7 +5232,7 @@ __metadata:
   version: 1.8.2
   resolution: "expand-range@npm:1.8.2"
   dependencies:
-    fill-range: ^2.1.0
+    fill-range: "npm:^2.1.0"
   checksum: ad7911af12f026953c57e3d7b7fe9f750ce2a1d45f7f7d717de890ed6429baf5e8a7224540cd648eeb603d409be0b7a7df09f951693cc83e98dcdc1e0043c23e
   languageName: node
   linkType: hard
@@ -5275,7 +5241,7 @@ __metadata:
   version: 1.6.0
   resolution: "ext@npm:1.6.0"
   dependencies:
-    type: ^2.5.0
+    type: "npm:^2.5.0"
   checksum: d6ff29ca86fbe4e69743d10702ece124e0239faa435a6c3b2833282787b9eace2c8cbf5d8439d0c85312255d5472d251bf3cd4c4d1b9de8f8a8090e6b43db948
   languageName: node
   linkType: hard
@@ -5284,7 +5250,7 @@ __metadata:
   version: 2.0.1
   resolution: "extend-shallow@npm:2.0.1"
   dependencies:
-    is-extendable: ^0.1.0
+    is-extendable: "npm:^0.1.0"
   checksum: ee1cb0a18c9faddb42d791b2d64867bd6cfd0f3affb711782eb6e894dd193e2934a7f529426aac7c8ddb31ac5d38000a00aa2caf08aa3dfc3e1c8ff6ba340bd9
   languageName: node
   linkType: hard
@@ -5293,8 +5259,8 @@ __metadata:
   version: 3.0.2
   resolution: "extend-shallow@npm:3.0.2"
   dependencies:
-    assign-symbols: ^1.0.0
-    is-extendable: ^1.0.1
+    assign-symbols: "npm:^1.0.0"
+    is-extendable: "npm:^1.0.1"
   checksum: f39581b8f98e3ad94995e33214fff725b0297cf09f2725b6f624551cfb71e0764accfd0af80becc0182af5014d2a57b31b85ec999f9eb8a6c45af81752feac9a
   languageName: node
   linkType: hard
@@ -5310,9 +5276,9 @@ __metadata:
   version: 2.2.0
   resolution: "external-editor@npm:2.2.0"
   dependencies:
-    chardet: ^0.4.0
-    iconv-lite: ^0.4.17
-    tmp: ^0.0.33
+    chardet: "npm:^0.4.0"
+    iconv-lite: "npm:^0.4.17"
+    tmp: "npm:^0.0.33"
   checksum: 5440df6ab809467485b3b15557d301e9fa3dda2892d6eaddd036ea337e0ced3e369c319507a123e34749cfce89c51f891848d249c713f54bcfaf95296663ff49
   languageName: node
   linkType: hard
@@ -5321,9 +5287,9 @@ __metadata:
   version: 3.1.0
   resolution: "external-editor@npm:3.1.0"
   dependencies:
-    chardet: ^0.7.0
-    iconv-lite: ^0.4.24
-    tmp: ^0.0.33
+    chardet: "npm:^0.7.0"
+    iconv-lite: "npm:^0.4.24"
+    tmp: "npm:^0.0.33"
   checksum: c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
   languageName: node
   linkType: hard
@@ -5332,7 +5298,7 @@ __metadata:
   version: 0.3.2
   resolution: "extglob@npm:0.3.2"
   dependencies:
-    is-extglob: ^1.0.0
+    is-extglob: "npm:^1.0.0"
   checksum: 9fcca7651e5c50fc970ec402476fb7a150e27cc2d8b415de8a6719fc111b2e03a9fabbff4fbed51221853f720ad734e842dfaef087ef57bdeb2456dcf0369029
   languageName: node
   linkType: hard
@@ -5341,14 +5307,14 @@ __metadata:
   version: 2.0.4
   resolution: "extglob@npm:2.0.4"
   dependencies:
-    array-unique: ^0.3.2
-    define-property: ^1.0.0
-    expand-brackets: ^2.1.4
-    extend-shallow: ^2.0.1
-    fragment-cache: ^0.2.1
-    regex-not: ^1.0.0
-    snapdragon: ^0.8.1
-    to-regex: ^3.0.1
+    array-unique: "npm:^0.3.2"
+    define-property: "npm:^1.0.0"
+    expand-brackets: "npm:^2.1.4"
+    extend-shallow: "npm:^2.0.1"
+    fragment-cache: "npm:^0.2.1"
+    regex-not: "npm:^1.0.0"
+    snapdragon: "npm:^0.8.1"
+    to-regex: "npm:^3.0.1"
   checksum: e1a891342e2010d046143016c6c03d58455c2c96c30bf5570ea07929984ee7d48fad86b363aee08f7a8a638f5c3a66906429b21ecb19bc8e90df56a001cd282c
   languageName: node
   linkType: hard
@@ -5378,11 +5344,11 @@ __metadata:
   version: 3.2.11
   resolution: "fast-glob@npm:3.2.11"
   dependencies:
-    "@nodelib/fs.stat": ^2.0.2
-    "@nodelib/fs.walk": ^1.2.3
-    glob-parent: ^5.1.2
-    merge2: ^1.3.0
-    micromatch: ^4.0.4
+    "@nodelib/fs.stat": "npm:^2.0.2"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    glob-parent: "npm:^5.1.2"
+    merge2: "npm:^1.3.0"
+    micromatch: "npm:^4.0.4"
   checksum: f726d4d6545ae9ade242eba78ae418cd8beac6c9291cdc36fc6b3b4e54f04fa0ecde5767256f2a600d6e14dc49a841adb3aa4b5f3f0c06b35dd4f3954965443d
   languageName: node
   linkType: hard
@@ -5405,7 +5371,7 @@ __metadata:
   version: 1.13.0
   resolution: "fastq@npm:1.13.0"
   dependencies:
-    reusify: ^1.0.4
+    reusify: "npm:^1.0.4"
   checksum: 76c7b5dafb93c7e74359a3e6de834ce7a7c2e3a3184050ed4cb652661de55cf8d4895178d8d3ccd23069395056c7bb15450660d38fb382ca88c142b22694d7c9
   languageName: node
   linkType: hard
@@ -5414,7 +5380,7 @@ __metadata:
   version: 0.10.0
   resolution: "faye-websocket@npm:0.10.0"
   dependencies:
-    websocket-driver: ">=0.5.1"
+    websocket-driver: "npm:>=0.5.1"
   checksum: aa82ed4a5895ae2019658858c7179921179ce546dc227594fae55896bfe2deddf080d44eaaab882afb878987f35fce57a77b6bae66524fb584fbba73d17d63af
   languageName: node
   linkType: hard
@@ -5423,8 +5389,8 @@ __metadata:
   version: 1.7.0
   resolution: "figures@npm:1.7.0"
   dependencies:
-    escape-string-regexp: ^1.0.5
-    object-assign: ^4.1.0
+    escape-string-regexp: "npm:^1.0.5"
+    object-assign: "npm:^4.1.0"
   checksum: a10942b0eec3372bf61822ab130d2bbecdf527d551b0b013fbe7175b7a0238ead644ee8930a1a3cb872fb9ab2ec27df30e303765a3b70b97852e2e9ee43bdff3
   languageName: node
   linkType: hard
@@ -5433,7 +5399,7 @@ __metadata:
   version: 2.0.0
   resolution: "figures@npm:2.0.0"
   dependencies:
-    escape-string-regexp: ^1.0.5
+    escape-string-regexp: "npm:^1.0.5"
   checksum: 5dc5a75fec3e7e04ae65d6ce51d28b3e70d4656c51b06996b6fdb2cb5b542df512e3b3c04482f5193a964edddafa5521479ff948fa84e12ff556e53e094ab4ce
   languageName: node
   linkType: hard
@@ -5442,7 +5408,7 @@ __metadata:
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
   dependencies:
-    escape-string-regexp: ^1.0.5
+    escape-string-regexp: "npm:^1.0.5"
   checksum: 9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
   languageName: node
   linkType: hard
@@ -5451,7 +5417,7 @@ __metadata:
   version: 5.0.1
   resolution: "file-entry-cache@npm:5.0.1"
   dependencies:
-    flat-cache: ^2.0.1
+    flat-cache: "npm:^2.0.1"
   checksum: 2480fb523a0342b8ede8b17717517f69ce6b775083d06e50e2e10ca45f16c94f1d4d95976ae627735716174033374a2d6717ba4b58569e1fea8564a1b1f2e4c1
   languageName: node
   linkType: hard
@@ -5481,8 +5447,8 @@ __metadata:
   version: 1.0.0
   resolution: "filenamify-url@npm:1.0.0"
   dependencies:
-    filenamify: ^1.0.0
-    humanize-url: ^1.0.0
+    filenamify: "npm:^1.0.0"
+    humanize-url: "npm:^1.0.0"
   checksum: 99ec4e2b898e477f1c21992659caa51ea709a42a6bf37bf427bc8f5e7921dfa2b23cec47d87ab43921fe553f2e329bcbd52f03b019684a8f3cb79f06c8162533
   languageName: node
   linkType: hard
@@ -5491,9 +5457,9 @@ __metadata:
   version: 1.2.1
   resolution: "filenamify@npm:1.2.1"
   dependencies:
-    filename-reserved-regex: ^1.0.0
-    strip-outer: ^1.0.0
-    trim-repeated: ^1.0.0
+    filename-reserved-regex: "npm:^1.0.0"
+    strip-outer: "npm:^1.0.0"
+    trim-repeated: "npm:^1.0.0"
   checksum: 3a5f0140bfc1ae6eff1f0bce042089e38d49e70cbc7d96a0403495e993735af68bec1777a6e10b4219e0e4991e6434f989bf4c4e95c653cdea89b0b4ab512b6b
   languageName: node
   linkType: hard
@@ -5502,11 +5468,11 @@ __metadata:
   version: 2.2.4
   resolution: "fill-range@npm:2.2.4"
   dependencies:
-    is-number: ^2.1.0
-    isobject: ^2.0.0
-    randomatic: ^3.0.0
-    repeat-element: ^1.1.2
-    repeat-string: ^1.5.2
+    is-number: "npm:^2.1.0"
+    isobject: "npm:^2.0.0"
+    randomatic: "npm:^3.0.0"
+    repeat-element: "npm:^1.1.2"
+    repeat-string: "npm:^1.5.2"
   checksum: 1cfd1329311d778a844d5806bd06a5d297047e5ff352c45b4f9fadcda68eb272c8ef2196f1c44224f3fe66c672234453ce89aca94fb00122874bdb3978de5f71
   languageName: node
   linkType: hard
@@ -5515,10 +5481,10 @@ __metadata:
   version: 4.0.0
   resolution: "fill-range@npm:4.0.0"
   dependencies:
-    extend-shallow: ^2.0.1
-    is-number: ^3.0.0
-    repeat-string: ^1.6.1
-    to-regex-range: ^2.1.0
+    extend-shallow: "npm:^2.0.1"
+    is-number: "npm:^3.0.0"
+    repeat-string: "npm:^1.6.1"
+    to-regex-range: "npm:^2.1.0"
   checksum: ccd57b7c43d7e28a1f8a60adfa3c401629c08e2f121565eece95e2386ebc64dedc7128d8c3448342aabf19db0c55a34f425f148400c7a7be9a606ba48749e089
   languageName: node
   linkType: hard
@@ -5527,7 +5493,7 @@ __metadata:
   version: 7.0.1
   resolution: "fill-range@npm:7.0.1"
   dependencies:
-    to-regex-range: ^5.0.1
+    to-regex-range: "npm:^5.0.1"
   checksum: 7cdad7d426ffbaadf45aeb5d15ec675bbd77f7597ad5399e3d2766987ed20bda24d5fac64b3ee79d93276f5865608bb22344a26b9b1ae6c4d00bd94bf611623f
   languageName: node
   linkType: hard
@@ -5536,9 +5502,9 @@ __metadata:
   version: 2.1.0
   resolution: "find-cache-dir@npm:2.1.0"
   dependencies:
-    commondir: ^1.0.1
-    make-dir: ^2.0.0
-    pkg-dir: ^3.0.0
+    commondir: "npm:^1.0.1"
+    make-dir: "npm:^2.0.0"
+    pkg-dir: "npm:^3.0.0"
   checksum: 556117fd0af14eb88fb69250f4bba9e905e7c355c6136dff0e161b9cbd1f5285f761b778565a278da73a130f42eccc723d7ad4c002ae547ed1d698d39779dabb
   languageName: node
   linkType: hard
@@ -5547,9 +5513,9 @@ __metadata:
   version: 3.3.2
   resolution: "find-cache-dir@npm:3.3.2"
   dependencies:
-    commondir: ^1.0.1
-    make-dir: ^3.0.2
-    pkg-dir: ^4.1.0
+    commondir: "npm:^1.0.1"
+    make-dir: "npm:^3.0.2"
+    pkg-dir: "npm:^4.1.0"
   checksum: 92747cda42bff47a0266b06014610981cfbb71f55d60f2c8216bc3108c83d9745507fb0b14ecf6ab71112bed29cd6fb1a137ee7436179ea36e11287e3159e587
   languageName: node
   linkType: hard
@@ -5558,8 +5524,8 @@ __metadata:
   version: 5.0.0
   resolution: "find-up@npm:5.0.0"
   dependencies:
-    locate-path: ^6.0.0
-    path-exists: ^4.0.0
+    locate-path: "npm:^6.0.0"
+    path-exists: "npm:^4.0.0"
   checksum: 062c5a83a9c02f53cdd6d175a37ecf8f87ea5bbff1fdfb828f04bfa021441bc7583e8ebc0872a4c1baab96221fb8a8a275a19809fb93fbc40bd69ec35634069a
   languageName: node
   linkType: hard
@@ -5568,8 +5534,8 @@ __metadata:
   version: 1.1.2
   resolution: "find-up@npm:1.1.2"
   dependencies:
-    path-exists: ^2.0.0
-    pinkie-promise: ^2.0.0
+    path-exists: "npm:^2.0.0"
+    pinkie-promise: "npm:^2.0.0"
   checksum: 51e35c62d9b7efe82d7d5cce966bfe10c2eaa78c769333f8114627e3a8a4a4f50747f5f50bff50b1094cbc6527776f0d3b9ff74d3561ef714a5290a17c80c2bc
   languageName: node
   linkType: hard
@@ -5578,7 +5544,7 @@ __metadata:
   version: 2.1.0
   resolution: "find-up@npm:2.1.0"
   dependencies:
-    locate-path: ^2.0.0
+    locate-path: "npm:^2.0.0"
   checksum: c080875c9fe28eb1962f35cbe83c683796a0321899f1eed31a37577800055539815de13d53495049697d3ba313013344f843bb9401dd337a1b832be5edfc6840
   languageName: node
   linkType: hard
@@ -5587,7 +5553,7 @@ __metadata:
   version: 3.0.0
   resolution: "find-up@npm:3.0.0"
   dependencies:
-    locate-path: ^3.0.0
+    locate-path: "npm:^3.0.0"
   checksum: 2c2e7d0a26db858e2f624f39038c74739e38306dee42b45f404f770db357947be9d0d587f1cac72d20c114deb38aa57316e879eb0a78b17b46da7dab0a3bd6e3
   languageName: node
   linkType: hard
@@ -5596,8 +5562,8 @@ __metadata:
   version: 4.1.0
   resolution: "find-up@npm:4.1.0"
   dependencies:
-    locate-path: ^5.0.0
-    path-exists: ^4.0.0
+    locate-path: "npm:^5.0.0"
+    path-exists: "npm:^4.0.0"
   checksum: 0406ee89ebeefa2d507feb07ec366bebd8a6167ae74aa4e34fb4c4abd06cf782a3ce26ae4194d70706f72182841733f00551c209fe575cb00bd92104056e78c1
   languageName: node
   linkType: hard
@@ -5606,9 +5572,9 @@ __metadata:
   version: 2.0.1
   resolution: "flat-cache@npm:2.0.1"
   dependencies:
-    flatted: ^2.0.0
-    rimraf: 2.6.3
-    write: 1.0.3
+    flatted: "npm:^2.0.0"
+    rimraf: "npm:2.6.3"
+    write: "npm:1.0.3"
   checksum: 09e4d2300d05734eb2ac39ea0bb9cc6d64c0c856f6b77d2bdc7734490b4a8f860d721f59ffd5508f6938c577f8394fe7b5f6acf99a5ec4af6478d7c5c8390bcb
   languageName: node
   linkType: hard
@@ -5640,7 +5606,7 @@ __metadata:
   version: 0.1.5
   resolution: "for-own@npm:0.1.5"
   dependencies:
-    for-in: ^1.0.1
+    for-in: "npm:^1.0.1"
   checksum: 3f82c2ea489ce2eb74c0eb8634d89b30a620801c2cb5f2a83d2d797fe6990d40c1aeac8968783e157b1404cf35bac9acb0a6c46065ec37b38a21b5d896e500bd
   languageName: node
   linkType: hard
@@ -5656,8 +5622,8 @@ __metadata:
   version: 1.5.6
   resolution: "foreground-child@npm:1.5.6"
   dependencies:
-    cross-spawn: ^4
-    signal-exit: ^3.0.0
+    cross-spawn: "npm:^4"
+    signal-exit: "npm:^3.0.0"
   checksum: 6f6b5f0254381de8c1aa8d5488b35d7fdebec3020d97c5f5ed01a1bfd6112594149b703bf43526531bafef10afe0983bf8165f5f32372b4dc08591f05017e185
   languageName: node
   linkType: hard
@@ -5673,9 +5639,9 @@ __metadata:
   version: 1.0.1
   resolution: "form-data@npm:1.0.1"
   dependencies:
-    async: ^2.0.1
-    combined-stream: ^1.0.5
-    mime-types: ^2.1.11
+    async: "npm:^2.0.1"
+    combined-stream: "npm:^1.0.5"
+    mime-types: "npm:^2.1.11"
   checksum: e54ae12671c1db703d719599f6a6e27e0d8b5288cfc7cad6443253def455d38bf359e75cf850ded7567beecc370f6c5fb7a4aef73548c24c53e68adc4b770cb3
   languageName: node
   linkType: hard
@@ -5684,9 +5650,9 @@ __metadata:
   version: 2.0.0
   resolution: "form-data@npm:2.0.0"
   dependencies:
-    asynckit: ^0.4.0
-    combined-stream: ^1.0.5
-    mime-types: ^2.1.11
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.5"
+    mime-types: "npm:^2.1.11"
   checksum: bb70419e078b0f2f22dc21a159acefa622a38e3cc04d11d24eeeb8a8924bfbe5f798c41546ed14758072450dd82c8385ab50fc056af0bb3472b3c478324e86f2
   languageName: node
   linkType: hard
@@ -5695,9 +5661,9 @@ __metadata:
   version: 2.3.3
   resolution: "form-data@npm:2.3.3"
   dependencies:
-    asynckit: ^0.4.0
-    combined-stream: ^1.0.6
-    mime-types: ^2.1.12
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.6"
+    mime-types: "npm:^2.1.12"
   checksum: 706ef1e5649286b6a61e5bb87993a9842807fd8f149cd2548ee807ea4fb882247bdf7f6e64ac4720029c0cd5c80343de0e22eee1dc9e9882e12db9cc7bc016a4
   languageName: node
   linkType: hard
@@ -5706,7 +5672,7 @@ __metadata:
   version: 0.2.1
   resolution: "fragment-cache@npm:0.2.1"
   dependencies:
-    map-cache: ^0.2.2
+    map-cache: "npm:^0.2.2"
   checksum: 5891d1c1d1d5e1a7fb3ccf28515c06731476fa88f7a50f4ede8a0d8d239a338448e7f7cc8b73db48da19c229fa30066104fe6489862065a4f1ed591c42fbeabf
   languageName: node
   linkType: hard
@@ -5715,14 +5681,14 @@ __metadata:
   version: 1.0.3
   resolution: "fresh-require@npm:1.0.3"
   dependencies:
-    acorn: ^0.9.0
-    astw: ^1.2.0
-    escodegen: ^1.4.1
-    is-require: 0.0.1
-    resolve: ^1.0.0
-    shallow-copy: 0.0.1
-    sleuth: ^0.1.1
-    through2: ^0.6.3
+    acorn: "npm:^0.9.0"
+    astw: "npm:^1.2.0"
+    escodegen: "npm:^1.4.1"
+    is-require: "npm:0.0.1"
+    resolve: "npm:^1.0.0"
+    shallow-copy: "npm:0.0.1"
+    sleuth: "npm:^0.1.1"
+    through2: "npm:^0.6.3"
   checksum: 99d2daf68ca90355c8bcd944d2bb07cfa2c3bbae3eba89c967299a93b231838d3eadc070a018fc90d129c28c1410e983f6796788a471b0e5f3922b3f86c3da40
   languageName: node
   linkType: hard
@@ -5738,7 +5704,7 @@ __metadata:
   version: 2.3.0
   resolution: "front-matter@npm:2.3.0"
   dependencies:
-    js-yaml: ^3.10.0
+    js-yaml: "npm:^3.10.0"
   checksum: aee029e942bf5bf43798a351258fb23679642c238854e9dcc3c3b28f01c61b7ed731bcdfe9e54ede6be7d46ea5fc9b0f55ba25de197a30e76f208a56d18b44be
   languageName: node
   linkType: hard
@@ -5747,9 +5713,9 @@ __metadata:
   version: 5.0.0
   resolution: "fs-extra@npm:5.0.0"
   dependencies:
-    graceful-fs: ^4.1.2
-    jsonfile: ^4.0.0
-    universalify: ^0.1.0
+    graceful-fs: "npm:^4.1.2"
+    jsonfile: "npm:^4.0.0"
+    universalify: "npm:^0.1.0"
   checksum: c67598fb6060101787b0389186db2fdcd8f706dc5dda450cac4f1d171f9a6118f390e7cf9af752fe1c3056ce554380a68fa7ed6a162199dc48087c74e0f96484
   languageName: node
   linkType: hard
@@ -5758,7 +5724,7 @@ __metadata:
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
   dependencies:
-    minipass: ^3.0.0
+    minipass: "npm:^3.0.0"
   checksum: 703d16522b8282d7299337539c3ed6edddd1afe82435e4f5b76e34a79cd74e488a8a0e26a636afc2440e1a23b03878e2122e3a2cfe375a5cf63c37d92b86a004
   languageName: node
   linkType: hard
@@ -5774,9 +5740,9 @@ __metadata:
   version: 1.2.10
   resolution: "fs-vacuum@npm:1.2.10"
   dependencies:
-    graceful-fs: ^4.1.2
-    path-is-inside: ^1.0.1
-    rimraf: ^2.5.2
+    graceful-fs: "npm:^4.1.2"
+    path-is-inside: "npm:^1.0.1"
+    rimraf: "npm:^2.5.2"
   checksum: 4a3e7c6dc35e5c64c6891e8258704631a91c83e07451b3de5252b5d394058fabac2b0060a11da6ab6d0ec2a4489ed6b312df2346569b4780aaaaf3997818aa5d
   languageName: node
   linkType: hard
@@ -5785,10 +5751,10 @@ __metadata:
   version: 1.0.10
   resolution: "fs-write-stream-atomic@npm:1.0.10"
   dependencies:
-    graceful-fs: ^4.1.2
-    iferr: ^0.1.5
-    imurmurhash: ^0.1.4
-    readable-stream: 1 || 2
+    graceful-fs: "npm:^4.1.2"
+    iferr: "npm:^0.1.5"
+    imurmurhash: "npm:^0.1.4"
+    readable-stream: "npm:1 || 2"
   checksum: 293b2b4ed346d35a28f8637a20cb2aef31be86503da501c42c2eda8fefed328bac16ce0e5daa7019f9329d73930c58031eaea2ce0c70f1680943fbfb7cff808b
   languageName: node
   linkType: hard
@@ -5804,8 +5770,8 @@ __metadata:
   version: 1.2.13
   resolution: "fsevents@npm:1.2.13"
   dependencies:
-    bindings: ^1.5.0
-    nan: ^2.12.1
+    bindings: "npm:^1.5.0"
+    nan: "npm:^2.12.1"
   checksum: 4427ff08db9ee7327f2c3ad58ec56f9096a917eed861bfffaa2e2be419479cdf37d00750869ab9ecbf5f59f32ad999bd59577d73fc639193e6c0ce52bb253e02
   conditions: os=darwin
   languageName: node
@@ -5815,27 +5781,27 @@ __metadata:
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
-    node-gyp: latest
+    node-gyp: "npm:latest"
   checksum: be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
   conditions: os=darwin
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^1.0.0#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^1.0.0#optional!builtin<compat/fsevents>":
   version: 1.2.13
-  resolution: "fsevents@patch:fsevents@npm%3A1.2.13#~builtin<compat/fsevents>::version=1.2.13&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A1.2.13#optional!builtin<compat/fsevents>::version=1.2.13&hash=d11327"
   dependencies:
-    bindings: ^1.5.0
-    nan: ^2.12.1
+    bindings: "npm:^1.5.0"
+    nan: "npm:^2.12.1"
   conditions: os=darwin
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
-    node-gyp: latest
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -5844,9 +5810,9 @@ __metadata:
   version: 1.0.5
   resolution: "fstream-ignore@npm:1.0.5"
   dependencies:
-    fstream: ^1.0.0
-    inherits: 2
-    minimatch: ^3.0.0
+    fstream: "npm:^1.0.0"
+    inherits: "npm:2"
+    minimatch: "npm:^3.0.0"
   checksum: f87b43332fd2f59a85e75ecc34eb41801e73cfb0d16c02531d3f3e46c86c04071bfac20abaf78d4d71332a855c8b6a973c1792cc7fbd51166963e7149a69bb2e
   languageName: node
   linkType: hard
@@ -5855,8 +5821,8 @@ __metadata:
   version: 1.0.7
   resolution: "fstream-npm@npm:1.0.7"
   dependencies:
-    fstream-ignore: ^1.0.0
-    inherits: 2
+    fstream-ignore: "npm:^1.0.0"
+    inherits: "npm:2"
   checksum: 9da27178195e92fba97d6013799ac62695ab45ad4ae27634ef19ab7ba79413d8b734bcbc6a429456eb0ebcab360ccb0bcf3ee651f2bb8f0ed42077d0237bcba2
   languageName: node
   linkType: hard
@@ -5865,8 +5831,8 @@ __metadata:
   version: 1.2.1
   resolution: "fstream-npm@npm:1.2.1"
   dependencies:
-    fstream-ignore: ^1.0.0
-    inherits: 2
+    fstream-ignore: "npm:^1.0.0"
+    inherits: "npm:2"
   checksum: 2d08d3c5085a4cf23c2c93fe5f82c10de947b51b553fe110519508ae17158243afc14a88da923711bb684bb15771c9c974c3d7ebe16a59070b104eff0eba5b44
   languageName: node
   linkType: hard
@@ -5875,10 +5841,10 @@ __metadata:
   version: 1.0.12
   resolution: "fstream@npm:1.0.12"
   dependencies:
-    graceful-fs: ^4.1.2
-    inherits: ~2.0.0
-    mkdirp: ">=0.5 0"
-    rimraf: 2
+    graceful-fs: "npm:^4.1.2"
+    inherits: "npm:~2.0.0"
+    mkdirp: "npm:>=0.5 0"
+    rimraf: "npm:2"
   checksum: f52a0687a0649c6b93973eb7f1d5495e445fa993f797ba1af186e666b6aebe53916a8c497dce7037c74d0d4a33c56b0ab1f98f10ad71cca84ba8661110d25ee2
   languageName: node
   linkType: hard
@@ -5901,15 +5867,15 @@ __metadata:
   version: 4.0.0
   resolution: "gauge@npm:4.0.0"
   dependencies:
-    ansi-regex: ^5.0.1
-    aproba: ^1.0.3 || ^2.0.0
-    color-support: ^1.1.2
-    console-control-strings: ^1.0.0
-    has-unicode: ^2.0.1
-    signal-exit: ^3.0.0
-    string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-    wide-align: ^1.1.2
+    ansi-regex: "npm:^5.0.1"
+    aproba: "npm:^1.0.3 || ^2.0.0"
+    color-support: "npm:^1.1.2"
+    console-control-strings: "npm:^1.0.0"
+    has-unicode: "npm:^2.0.1"
+    signal-exit: "npm:^3.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+    wide-align: "npm:^1.1.2"
   checksum: 88e8b0b70b7b6d02c34086fa62d7d2e25e1c5a8c77c0b631362808bc1ae773b00fba09f9e9c4e66a2ca36d0253443c370736f15f2a2a8a2f6c039ca3bc03205e
   languageName: node
   linkType: hard
@@ -5918,11 +5884,11 @@ __metadata:
   version: 1.2.7
   resolution: "gauge@npm:1.2.7"
   dependencies:
-    ansi: ^0.3.0
-    has-unicode: ^2.0.0
-    lodash.pad: ^4.1.0
-    lodash.padend: ^4.1.0
-    lodash.padstart: ^4.1.0
+    ansi: "npm:^0.3.0"
+    has-unicode: "npm:^2.0.0"
+    lodash.pad: "npm:^4.1.0"
+    lodash.padend: "npm:^4.1.0"
+    lodash.padstart: "npm:^4.1.0"
   checksum: 10e087b496edf3bff45ddcd31b8d7a571f5112dbe82be07479498774db46562dec0536272e12e0872ad4165131d13ccba4987af9c5ca93f640d6f1ec0429a644
   languageName: node
   linkType: hard
@@ -5931,41 +5897,32 @@ __metadata:
   version: 2.6.0
   resolution: "gauge@npm:2.6.0"
   dependencies:
-    aproba: ^1.0.3
-    console-control-strings: ^1.0.0
-    has-color: ^0.1.7
-    has-unicode: ^2.0.0
-    object-assign: ^4.1.0
-    signal-exit: ^3.0.0
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-    wide-align: ^1.1.0
+    aproba: "npm:^1.0.3"
+    console-control-strings: "npm:^1.0.0"
+    has-color: "npm:^0.1.7"
+    has-unicode: "npm:^2.0.0"
+    object-assign: "npm:^4.1.0"
+    signal-exit: "npm:^3.0.0"
+    string-width: "npm:^1.0.1"
+    strip-ansi: "npm:^3.0.1"
+    wide-align: "npm:^1.1.0"
   checksum: 2e983cd1c71c5ee9b6fbd3080f53b24307697170731f09b0bf794c4b2cadac093bc8bbe7eb9920a1ec85feec7f98c3a58a4cfa030cba4f89a65865bd1ed598b4
   languageName: node
   linkType: hard
 
-"gauge@npm:~2.7.1, gauge@npm:~2.7.3":
+"gauge@npm:~2.7.1":
   version: 2.7.4
   resolution: "gauge@npm:2.7.4"
   dependencies:
-    aproba: ^1.0.3
-    console-control-strings: ^1.0.0
-    has-unicode: ^2.0.0
-    object-assign: ^4.1.0
-    signal-exit: ^3.0.0
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-    wide-align: ^1.1.0
+    aproba: "npm:^1.0.3"
+    console-control-strings: "npm:^1.0.0"
+    has-unicode: "npm:^2.0.0"
+    object-assign: "npm:^4.1.0"
+    signal-exit: "npm:^3.0.0"
+    string-width: "npm:^1.0.1"
+    strip-ansi: "npm:^3.0.1"
+    wide-align: "npm:^1.1.0"
   checksum: d606346e2e47829e0bc855d0becb36c4ce492feabd61ae92884b89e07812dd8a67a860ca30ece3a4c2e9f2c73bd68ba2b8e558ed362432ffd86de83c08847f84
-  languageName: node
-  linkType: hard
-
-"gaze@npm:^1.0.0":
-  version: 1.1.3
-  resolution: "gaze@npm:1.1.3"
-  dependencies:
-    globule: ^1.0.0
-  checksum: 5369619e23f6585e3a5efc4b8fad3b9f129fb4a88685bf0d6a98ca5ea0adb3868ede3d05643101deb03c42e15a0d36182d37f0122945935d05eddc82f4d79bfe
   languageName: node
   linkType: hard
 
@@ -5973,7 +5930,7 @@ __metadata:
   version: 2.3.1
   resolution: "generate-function@npm:2.3.1"
   dependencies:
-    is-property: ^1.0.2
+    is-property: "npm:^1.0.2"
   checksum: 4645cf1da90375e46a6f1dc51abc9933e5eafa4cd1a44c2f7e3909a30a4e9a1a08c14cd7d5b32da039da2dba2a085e1ed4597b580c196c3245b2d35d8bc0de5d
   languageName: node
   linkType: hard
@@ -5982,7 +5939,7 @@ __metadata:
   version: 1.2.0
   resolution: "generate-object-property@npm:1.2.0"
   dependencies:
-    is-property: ^1.0.0
+    is-property: "npm:^1.0.0"
   checksum: 0b30acb43283a489b1adf4655f3f413b448dbec750678cf70bfde92b04a22f85b286be004b66fd713e3060e418d7beb562f05431235ec95c044b63e324759e8c
   languageName: node
   linkType: hard
@@ -6012,17 +5969,10 @@ __metadata:
   version: 1.1.1
   resolution: "get-intrinsic@npm:1.1.1"
   dependencies:
-    function-bind: ^1.1.1
-    has: ^1.0.3
-    has-symbols: ^1.0.1
+    function-bind: "npm:^1.1.1"
+    has: "npm:^1.0.3"
+    has-symbols: "npm:^1.0.1"
   checksum: c01055578e9b8da37a7779b18b732436c55d93e5ffa56b0fc4d3da8468ad89a25ce2343ba1945f20c0e78119bc7bb296fb59a0da521b6e43fd632de73376e040
-  languageName: node
-  linkType: hard
-
-"get-stdin@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "get-stdin@npm:4.0.1"
-  checksum: 68fc39a0af6050bcad791fb3df72999e7636401f11f574bf24af07b1c640d30c01cf38aa39ee55665a93ee7a7753eeb6d1fce6c434dd1f458ee0f8fd02775809
   languageName: node
   linkType: hard
 
@@ -6044,7 +5994,7 @@ __metadata:
   version: 4.1.0
   resolution: "get-stream@npm:4.1.0"
   dependencies:
-    pump: ^3.0.0
+    pump: "npm:^3.0.0"
   checksum: 294d876f667694a5ca23f0ca2156de67da950433b6fb53024833733975d32582896dbc7f257842d331809979efccf04d5e0b6b75ad4d45744c45f193fd497539
   languageName: node
   linkType: hard
@@ -6053,7 +6003,7 @@ __metadata:
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
   dependencies:
-    pump: ^3.0.0
+    pump: "npm:^3.0.0"
   checksum: 43797ffd815fbb26685bf188c8cfebecb8af87b3925091dd7b9a9c915993293d78e3c9e1bce125928ff92f2d0796f3889b92b5ec6d58d1041b574682132e0a80
   languageName: node
   linkType: hard
@@ -6062,8 +6012,8 @@ __metadata:
   version: 1.0.0
   resolution: "get-symbol-description@npm:1.0.0"
   dependencies:
-    call-bind: ^1.0.2
-    get-intrinsic: ^1.1.1
+    call-bind: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.1.1"
   checksum: 23bc3b44c221cdf7669a88230c62f4b9e30393b61eb21ba4400cb3e346801bd8f95fe4330ee78dbae37aecd874646d53e3e76a17a654d0c84c77f6690526d6bb
   languageName: node
   linkType: hard
@@ -6079,7 +6029,7 @@ __metadata:
   version: 0.1.7
   resolution: "getpass@npm:0.1.7"
   dependencies:
-    assert-plus: ^1.0.0
+    assert-plus: "npm:^1.0.0"
   checksum: c13f8530ecf16fc509f3fa5cd8dd2129ffa5d0c7ccdf5728b6022d52954c2d24be3706b4cdf15333eec52f1fbb43feb70a01dabc639d1d10071e371da8aaa52f
   languageName: node
   linkType: hard
@@ -6088,13 +6038,13 @@ __metadata:
   version: 1.2.0
   resolution: "gh-pages@npm:1.2.0"
   dependencies:
-    async: 2.6.1
-    commander: 2.15.1
-    filenamify-url: ^1.0.0
-    fs-extra: ^5.0.0
-    globby: ^6.1.0
-    graceful-fs: 4.1.11
-    rimraf: ^2.6.2
+    async: "npm:2.6.1"
+    commander: "npm:2.15.1"
+    filenamify-url: "npm:^1.0.0"
+    fs-extra: "npm:^5.0.0"
+    globby: "npm:^6.1.0"
+    graceful-fs: "npm:4.1.11"
+    rimraf: "npm:^2.6.2"
   bin:
     gh-pages: bin/gh-pages.js
     gh-pages-clean: bin/gh-pages-clean.js
@@ -6106,9 +6056,9 @@ __metadata:
   version: 1.2.2
   resolution: "gitbook-asciidoc@npm:1.2.2"
   dependencies:
-    asciidoctor.js: 1.5.5-1
-    gitbook-html: 1.3.3
-    lodash: ^4.13.1
+    asciidoctor.js: "npm:1.5.5-1"
+    gitbook-html: "npm:1.3.3"
+    lodash: "npm:^4.13.1"
   checksum: d99b7904e428feb896b3ac8c866904fd70a80569f3887753224512ee17f88863f533d4cfc358b6aa6380e40e615477a481daf178b4ab90eb70ef338086ed3d8a
   languageName: node
   linkType: hard
@@ -6118,8 +6068,8 @@ __metadata:
   resolution: "gitbook-html@npm:1.3.3"
   dependencies:
     cheerio: ^0.20.0 && >=0.20.0
-    lodash: ^4.13.1
-    q: ^1.1.2
+    lodash: "npm:^4.13.1"
+    q: "npm:^1.1.2"
   checksum: ee68136c3499349da316547559bb58ec0e8b3c77a8407da03984d12ff97b69f19b82a04af2a2383f9a32ecbf5128a4d8c4cd70158c956ce92e8a6c215958ae9c
   languageName: node
   linkType: hard
@@ -6128,10 +6078,10 @@ __metadata:
   version: 1.3.2
   resolution: "gitbook-markdown@npm:1.3.2"
   dependencies:
-    gitbook-html: 1.3.3
-    kramed: 0.5.6
-    kramed-text-renderer: 0.2.1
-    lodash: ^4.13.1
+    gitbook-html: "npm:1.3.3"
+    kramed: "npm:0.5.6"
+    kramed-text-renderer: "npm:0.2.1"
+    lodash: "npm:^4.13.1"
   checksum: 035869c3e60bd101b1a75f90f57343ab957edabb84593c59ea3f30b1b6e9faaec46329aded703f6da09655af4ff669e271b47e14b32a68e4120718e7e2fc1f1c
   languageName: node
   linkType: hard
@@ -6140,8 +6090,8 @@ __metadata:
   version: 0.7.1
   resolution: "gitbook-plugin-anchors@npm:0.7.1"
   dependencies:
-    cheerio: "*"
-    github-slugid: 1.0.1
+    cheerio: "npm:*"
+    github-slugid: "npm:1.0.1"
   checksum: 3bae155dcf164ae0cfce60c3143dbc4def9b0930767e9840f3fd9526ff86112d1ff0048f39fd7e6e7674ab256ad6c0ebade1e1e202ba57a1194ca66d7087c0c3
   languageName: node
   linkType: hard
@@ -6171,7 +6121,7 @@ __metadata:
   version: 2.0.2
   resolution: "gitbook-plugin-highlight@npm:2.0.2"
   dependencies:
-    highlight.js: 9.2.0
+    highlight.js: "npm:9.2.0"
   checksum: 10246e3934b71b27f08100b46ee4fe80bb317ed541ef2ddda87530fa89477d4171a5660071d37a0eba89a83c0aca46de1607f829bc0ed8b485c7192ce5bee4dc
   languageName: node
   linkType: hard
@@ -6187,9 +6137,9 @@ __metadata:
   version: 1.2.0
   resolution: "gitbook-plugin-lunr@npm:1.2.0"
   dependencies:
-    gitbook-plugin-search: "*"
-    html-entities: 1.2.0
-    lunr: 0.5.12
+    gitbook-plugin-search: "npm:*"
+    html-entities: "npm:1.2.0"
+    lunr: "npm:0.5.12"
   checksum: 58db4b5b23ae0336c2fd03ed78f9a6dc1665368d7027c004317ba0e4396d1e33884be495a14603469c902d9e0a8282634309f320e39f853e854d9ac66b710d08
   languageName: node
   linkType: hard
@@ -6198,9 +6148,9 @@ __metadata:
   version: 2.4.0
   resolution: "gitbook-plugin-prism@npm:2.4.0"
   dependencies:
-    cheerio: 0.22.0
-    mkdirp: 0.5.1
-    prismjs: ^1.15.0
+    cheerio: "npm:0.22.0"
+    mkdirp: "npm:0.5.1"
+    prismjs: "npm:^1.15.0"
   checksum: f136de1a6d731d48f1cc4fbcf31895f46864767b32146c345b1a6d821d81232070912f3b7b2571266bd8d1074720ad181f4dc164cf8968666ea98b333c7de65e
   languageName: node
   linkType: hard
@@ -6216,7 +6166,7 @@ __metadata:
   version: 1.0.2
   resolution: "gitbook-plugin-sharing@npm:1.0.2"
   dependencies:
-    lodash: ^3.10.1
+    lodash: "npm:^3.10.1"
   checksum: 5fe39f8bd53427c53503f64e3658b66dd2d97d6a73a47fdb61ee8ad12fb3eeca9eb539e608d9d76910bc73aba34102e4388be65a1824b3b57a79a32c5c075934
   languageName: node
   linkType: hard
@@ -6232,60 +6182,60 @@ __metadata:
   version: 3.2.2
   resolution: "gitbook@npm:3.2.2"
   dependencies:
-    bash-color: 0.0.4
-    cheerio: 0.20.0
-    chokidar: 1.5.0
-    cp: 0.2.0
-    cpr: 1.1.1
-    crc: 3.4.0
-    destroy: 1.0.4
-    direction: 0.1.5
-    dom-serializer: 0.1.0
-    error: 7.0.2
-    escape-html: ^1.0.3
-    escape-string-regexp: 1.0.5
-    extend: ^3.0.0
-    fresh-require: 1.0.3
-    front-matter: ^2.1.0
-    gitbook-asciidoc: 1.2.2
-    gitbook-markdown: 1.3.2
-    gitbook-plugin-fontsettings: 2.0.0
-    gitbook-plugin-highlight: 2.0.2
-    gitbook-plugin-livereload: 0.0.1
-    gitbook-plugin-lunr: 1.2.0
-    gitbook-plugin-search: 2.2.1
-    gitbook-plugin-sharing: 1.0.2
-    gitbook-plugin-theme-default: 1.0.6
-    github-slugid: 1.0.1
-    graceful-fs: 4.1.4
-    i18n-t: 1.0.1
-    ignore: 3.1.2
-    immutable: ^3.8.1
-    is: ^3.1.0
-    js-yaml: ^3.6.1
-    json-schema-defaults: 0.1.1
-    jsonschema: 1.1.0
-    juice: 2.0.0
-    mkdirp: 0.5.1
-    moment: 2.13.0
-    npm: 3.9.2
-    npmi: 2.0.1
-    nunjucks: 2.5.2
-    nunjucks-do: 1.0.0
-    object-path: ^0.9.2
-    omit-keys: ^0.1.0
-    open: 0.0.5
-    q: 1.4.1
-    read-installed: ^4.0.3
-    request: 2.72.0
-    resolve: 1.1.7
-    rmdir: 1.2.0
-    semver: 5.1.0
-    send: 0.13.2
-    spawn-cmd: 0.0.2
-    tiny-lr: 0.2.1
-    tmp: 0.0.28
-    urijs: 1.18.0
+    bash-color: "npm:0.0.4"
+    cheerio: "npm:0.20.0"
+    chokidar: "npm:1.5.0"
+    cp: "npm:0.2.0"
+    cpr: "npm:1.1.1"
+    crc: "npm:3.4.0"
+    destroy: "npm:1.0.4"
+    direction: "npm:0.1.5"
+    dom-serializer: "npm:0.1.0"
+    error: "npm:7.0.2"
+    escape-html: "npm:^1.0.3"
+    escape-string-regexp: "npm:1.0.5"
+    extend: "npm:^3.0.0"
+    fresh-require: "npm:1.0.3"
+    front-matter: "npm:^2.1.0"
+    gitbook-asciidoc: "npm:1.2.2"
+    gitbook-markdown: "npm:1.3.2"
+    gitbook-plugin-fontsettings: "npm:2.0.0"
+    gitbook-plugin-highlight: "npm:2.0.2"
+    gitbook-plugin-livereload: "npm:0.0.1"
+    gitbook-plugin-lunr: "npm:1.2.0"
+    gitbook-plugin-search: "npm:2.2.1"
+    gitbook-plugin-sharing: "npm:1.0.2"
+    gitbook-plugin-theme-default: "npm:1.0.6"
+    github-slugid: "npm:1.0.1"
+    graceful-fs: "npm:4.1.4"
+    i18n-t: "npm:1.0.1"
+    ignore: "npm:3.1.2"
+    immutable: "npm:^3.8.1"
+    is: "npm:^3.1.0"
+    js-yaml: "npm:^3.6.1"
+    json-schema-defaults: "npm:0.1.1"
+    jsonschema: "npm:1.1.0"
+    juice: "npm:2.0.0"
+    mkdirp: "npm:0.5.1"
+    moment: "npm:2.13.0"
+    npm: "npm:3.9.2"
+    npmi: "npm:2.0.1"
+    nunjucks: "npm:2.5.2"
+    nunjucks-do: "npm:1.0.0"
+    object-path: "npm:^0.9.2"
+    omit-keys: "npm:^0.1.0"
+    open: "npm:0.0.5"
+    q: "npm:1.4.1"
+    read-installed: "npm:^4.0.3"
+    request: "npm:2.72.0"
+    resolve: "npm:1.1.7"
+    rmdir: "npm:1.2.0"
+    semver: "npm:5.1.0"
+    send: "npm:0.13.2"
+    spawn-cmd: "npm:0.0.2"
+    tiny-lr: "npm:0.2.1"
+    tmp: "npm:0.0.28"
+    urijs: "npm:1.18.0"
   bin:
     gitbook: ./bin/gitbook.js
   checksum: 5a233889a91d2665d128a7223a873422aa5c2f112a7aa10eb4a66651f062997d64b2489038592ab3da48760f6053b076afce4b0cc270bb779b8cf111c1a680d6
@@ -6310,8 +6260,8 @@ __metadata:
   version: 0.3.0
   resolution: "glob-base@npm:0.3.0"
   dependencies:
-    glob-parent: ^2.0.0
-    is-glob: ^2.0.0
+    glob-parent: "npm:^2.0.0"
+    is-glob: "npm:^2.0.0"
   checksum: 4ce785c1dac2ff1e4660c010fa43ed2f1b38993dfd004023a3e7080b20bc61f29fbfe5d265b7e64cc84096ecf44e8ca876c7c1aad8f1f995d4c0f33034f3ae8c
   languageName: node
   linkType: hard
@@ -6320,7 +6270,7 @@ __metadata:
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
-    is-glob: ^4.0.1
+    is-glob: "npm:^4.0.1"
   checksum: cab87638e2112bee3f839ef5f6e0765057163d39c66be8ec1602f3823da4692297ad4e972de876ea17c44d652978638d2fd583c6713d0eb6591706825020c9ee
   languageName: node
   linkType: hard
@@ -6329,7 +6279,7 @@ __metadata:
   version: 2.0.0
   resolution: "glob-parent@npm:2.0.0"
   dependencies:
-    is-glob: ^2.0.0
+    is-glob: "npm:^2.0.0"
   checksum: b9d59dc532d47aaaa4841046ff631b325a707f738445300b83b7a1ee603dd060c041a378e8a195c887d479bb703685cee4725c8f54b8dacef65355375f57d32a
   languageName: node
   linkType: hard
@@ -6345,10 +6295,10 @@ __metadata:
   version: 4.5.3
   resolution: "glob@npm:4.5.3"
   dependencies:
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^2.0.1
-    once: ^1.3.0
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^2.0.1"
+    once: "npm:^1.3.0"
   checksum: a72de9015a530d26a20de56a7a8f1779d281c1ae1a1aedada32be712b6555a92f07369972df2598e54402c32d81da50915e744b5ade6394a97844f9f0bf56ee3
   languageName: node
   linkType: hard
@@ -6357,26 +6307,26 @@ __metadata:
   version: 7.1.4
   resolution: "glob@npm:7.1.4"
   dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.0.4
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.0.4"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
   checksum: 7f6fcbf600eb2298cce34c65f6d8bbe6933ddd4f88aa5b38a9c6feec82b615bb33b63b120725303e89c4b50284413c21d2ff883414717a5c7d0c9f7cd7a0e5fe
   languageName: node
   linkType: hard
 
-"glob@npm:7.2.0, glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.0.5, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:7.2.0, glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.0.5, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.0.4
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.0.4"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
   checksum: 478b40e38be5a3d514e64950e1e07e0ac120585add6a37c98d0ed24d72d9127d734d2a125786073c8deb687096e84ae82b641c441a869ada3a9cc91b68978632
   languageName: node
   linkType: hard
@@ -6385,11 +6335,11 @@ __metadata:
   version: 6.0.4
   resolution: "glob@npm:6.0.4"
   dependencies:
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: 2 || 3
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:2 || 3"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
   checksum: 520146ebce0f4594b8357338f86281b38ee14214debce398a2902176a28f18e0f98911ea48516d85022de64fbbaa57f074aa13715d1daa5d70e21b82cea22183
   languageName: node
   linkType: hard
@@ -6398,26 +6348,26 @@ __metadata:
   version: 7.0.6
   resolution: "glob@npm:7.0.6"
   dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.0.2
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.0.2"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
   checksum: 3ce0f7a4716527b45b26444441f4d50c7b34516b110055ff51addca93ca4562ab0b0484cb1b2093613fc01e604edebc1f8ff297d92778b2db4b8940a8f490392
   languageName: node
   linkType: hard
 
-"glob@npm:~7.1.0, glob@npm:~7.1.1":
+"glob@npm:~7.1.0":
   version: 7.1.7
   resolution: "glob@npm:7.1.7"
   dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.0.4
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.0.4"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
   checksum: 173245e6f9ccf904309eb7ef4a44a11f3bf68e9e341dff5a28b5db0dd7123b7506daf41497f3437a0710f57198187b758c2351eeaabce4d16935e956920da6a4
   languageName: node
   linkType: hard
@@ -6426,7 +6376,7 @@ __metadata:
   version: 0.1.1
   resolution: "global-dirs@npm:0.1.1"
   dependencies:
-    ini: ^1.3.4
+    ini: "npm:^1.3.4"
   checksum: 3608072e58962396c124ad5a1cfb3f99ee76c998654a3432d82977b3c3eeb09dc8a5a2a9849b2b8113906c8d0aad89ce362c22e97cec5fe34405bbf4f3cdbe7a
   languageName: node
   linkType: hard
@@ -6442,7 +6392,7 @@ __metadata:
   version: 12.4.0
   resolution: "globals@npm:12.4.0"
   dependencies:
-    type-fest: ^0.8.1
+    type-fest: "npm:^0.8.1"
   checksum: f6731c915f5fde6ac3737016be748682fdf52a436e4f2702d14cec4f15f3aefcc306483bdae4c9195b04848416443f57e9de6771c74fd77becfbba2d2068bc73
   languageName: node
   linkType: hard
@@ -6458,14 +6408,14 @@ __metadata:
   version: 10.0.2
   resolution: "globby@npm:10.0.2"
   dependencies:
-    "@types/glob": ^7.1.1
-    array-union: ^2.1.0
-    dir-glob: ^3.0.1
-    fast-glob: ^3.0.3
-    glob: ^7.1.3
-    ignore: ^5.1.1
-    merge2: ^1.2.3
-    slash: ^3.0.0
+    "@types/glob": "npm:^7.1.1"
+    array-union: "npm:^2.1.0"
+    dir-glob: "npm:^3.0.1"
+    fast-glob: "npm:^3.0.3"
+    glob: "npm:^7.1.3"
+    ignore: "npm:^5.1.1"
+    merge2: "npm:^1.2.3"
+    slash: "npm:^3.0.0"
   checksum: 9c610ad47117b9dfbc5b0c6c2408c3b72f89c1b9f91ee14c4dc794794e35768ee0920e2a403b688cfa749f48617c6ba3f3a52df07677ed73d602d4349b68c810
   languageName: node
   linkType: hard
@@ -6474,23 +6424,12 @@ __metadata:
   version: 6.1.0
   resolution: "globby@npm:6.1.0"
   dependencies:
-    array-union: ^1.0.1
-    glob: ^7.0.3
-    object-assign: ^4.0.1
-    pify: ^2.0.0
-    pinkie-promise: ^2.0.0
+    array-union: "npm:^1.0.1"
+    glob: "npm:^7.0.3"
+    object-assign: "npm:^4.0.1"
+    pify: "npm:^2.0.0"
+    pinkie-promise: "npm:^2.0.0"
   checksum: 656ad1f0d02c6ef378c07589519ed3ec27fe988ea177195c05b8aff280320f3d67b91fa0baa6f7e49288f9bf1f92fc84f783a79ac3ed66278f3fa082e627ed84
-  languageName: node
-  linkType: hard
-
-"globule@npm:^1.0.0":
-  version: 1.3.3
-  resolution: "globule@npm:1.3.3"
-  dependencies:
-    glob: ~7.1.1
-    lodash: ~4.17.10
-    minimatch: ~3.0.2
-  checksum: e8b624b83bbf523b4bfbd7b65c7255b4f444630869687ba0f31fd60d063cfaa739d4f56e0a5d8b8b5c4e12c67546676eb6e6b32511b09731f4c671dcb86fb1d7
   languageName: node
   linkType: hard
 
@@ -6498,17 +6437,17 @@ __metadata:
   version: 9.6.0
   resolution: "got@npm:9.6.0"
   dependencies:
-    "@sindresorhus/is": ^0.14.0
-    "@szmarczak/http-timer": ^1.1.2
-    cacheable-request: ^6.0.0
-    decompress-response: ^3.3.0
-    duplexer3: ^0.1.4
-    get-stream: ^4.1.0
-    lowercase-keys: ^1.0.1
-    mimic-response: ^1.0.1
-    p-cancelable: ^1.0.0
-    to-readable-stream: ^1.0.0
-    url-parse-lax: ^3.0.0
+    "@sindresorhus/is": "npm:^0.14.0"
+    "@szmarczak/http-timer": "npm:^1.1.2"
+    cacheable-request: "npm:^6.0.0"
+    decompress-response: "npm:^3.3.0"
+    duplexer3: "npm:^0.1.4"
+    get-stream: "npm:^4.1.0"
+    lowercase-keys: "npm:^1.0.1"
+    mimic-response: "npm:^1.0.1"
+    p-cancelable: "npm:^1.0.0"
+    to-readable-stream: "npm:^1.0.0"
+    url-parse-lax: "npm:^3.0.0"
   checksum: 5cb3111e14b48bf4fb8b414627be481ebfb14151ec867e80a74b6d1472489965b9c4f4ac5cf4f3b1f9b90c60a2ce63584d9072b16efd9a3171553e00afc5abc8
   languageName: node
   linkType: hard
@@ -6545,10 +6484,10 @@ __metadata:
   version: 2.0.6
   resolution: "har-validator@npm:2.0.6"
   dependencies:
-    chalk: ^1.1.1
-    commander: ^2.9.0
-    is-my-json-valid: ^2.12.4
-    pinkie-promise: ^2.0.0
+    chalk: "npm:^1.1.1"
+    commander: "npm:^2.9.0"
+    is-my-json-valid: "npm:^2.12.4"
+    pinkie-promise: "npm:^2.0.0"
   bin:
     har-validator: bin/har-validator
   checksum: 79abc6ff14b83760fe7adcfee9c88be164293f0549b9718ad8afa0efc52e06068204cc863504d3d06b8fe233498927f13b079a13362ad8329c410cf29dcdff39
@@ -6559,8 +6498,8 @@ __metadata:
   version: 5.1.5
   resolution: "har-validator@npm:5.1.5"
   dependencies:
-    ajv: ^6.12.3
-    har-schema: ^2.0.0
+    ajv: "npm:^6.12.3"
+    har-schema: "npm:^2.0.0"
   checksum: f1d606eb1021839e3a905be5ef7cca81c2256a6be0748efb8fefc14312214f9e6c15d7f2eaf37514104071207d84f627b68bb9f6178703da4e06fbd1a0649a5e
   languageName: node
   linkType: hard
@@ -6569,7 +6508,7 @@ __metadata:
   version: 2.0.0
   resolution: "has-ansi@npm:2.0.0"
   dependencies:
-    ansi-regex: ^2.0.0
+    ansi-regex: "npm:^2.0.0"
   checksum: f54e4887b9f8f3c4bfefd649c48825b3c093987c92c27880ee9898539e6f01aed261e82e73153c3f920fde0db5bf6ebd58deb498ed1debabcb4bc40113ccdf05
   languageName: node
   linkType: hard
@@ -6613,7 +6552,7 @@ __metadata:
   version: 1.0.0
   resolution: "has-tostringtag@npm:1.0.0"
   dependencies:
-    has-symbols: ^1.0.2
+    has-symbols: "npm:^1.0.2"
   checksum: 1cdba76b7d13f65198a92b8ca1560ba40edfa09e85d182bf436d928f3588a9ebd260451d569f0ed1b849c4bf54f49c862aa0d0a77f9552b1855bb6deb526c011
   languageName: node
   linkType: hard
@@ -6629,9 +6568,9 @@ __metadata:
   version: 0.3.1
   resolution: "has-value@npm:0.3.1"
   dependencies:
-    get-value: ^2.0.3
-    has-values: ^0.1.4
-    isobject: ^2.0.0
+    get-value: "npm:^2.0.3"
+    has-values: "npm:^0.1.4"
+    isobject: "npm:^2.0.0"
   checksum: 7a7c2e9d07bc9742c81806150adb154d149bc6155267248c459cd1ce2a64b0759980d26213260e4b7599c8a3754551179f155ded88d0533a0d2bc7bc29028432
   languageName: node
   linkType: hard
@@ -6640,9 +6579,9 @@ __metadata:
   version: 1.0.0
   resolution: "has-value@npm:1.0.0"
   dependencies:
-    get-value: ^2.0.6
-    has-values: ^1.0.0
-    isobject: ^3.0.0
+    get-value: "npm:^2.0.6"
+    has-values: "npm:^1.0.0"
+    isobject: "npm:^3.0.0"
   checksum: 17cdccaf50f8aac80a109dba2e2ee5e800aec9a9d382ef9deab66c56b34269e4c9ac720276d5ffa722764304a1180ae436df077da0dd05548cfae0209708ba4d
   languageName: node
   linkType: hard
@@ -6658,8 +6597,8 @@ __metadata:
   version: 1.0.0
   resolution: "has-values@npm:1.0.0"
   dependencies:
-    is-number: ^3.0.0
-    kind-of: ^4.0.0
+    is-number: "npm:^3.0.0"
+    kind-of: "npm:^4.0.0"
   checksum: a6f2a1cc6b2e43eacc68e62e71ad6890def7f4b13d2ef06b4ad3ee156c23e470e6df144b9b467701908e17633411f1075fdff0cab45fb66c5e0584d89b25f35e
   languageName: node
   linkType: hard
@@ -6675,7 +6614,7 @@ __metadata:
   version: 1.0.3
   resolution: "has@npm:1.0.3"
   dependencies:
-    function-bind: ^1.1.1
+    function-bind: "npm:^1.1.1"
   checksum: e1da0d2bd109f116b632f27782cf23182b42f14972ca9540e4c5aa7e52647407a0a4a76937334fddcb56befe94a3494825ec22b19b51f5e5507c3153fd1a5e1b
   languageName: node
   linkType: hard
@@ -6684,7 +6623,7 @@ __metadata:
   version: 3.0.0
   resolution: "hasha@npm:3.0.0"
   dependencies:
-    is-stream: ^1.0.1
+    is-stream: "npm:^1.0.1"
   checksum: 6412d08e8bb165b0616a27dbe34476162af8469de3a0d75b02aa2f2f78634b92650fcc31c6dcf6d9b76df71323df8c37befb4c1e42a367f08fbd1f0c04ae5a26
   languageName: node
   linkType: hard
@@ -6693,10 +6632,10 @@ __metadata:
   version: 3.1.3
   resolution: "hawk@npm:3.1.3"
   dependencies:
-    boom: 2.x.x
-    cryptiles: 2.x.x
-    hoek: 2.x.x
-    sntp: 1.x.x
+    boom: "npm:2.x.x"
+    cryptiles: "npm:2.x.x"
+    hoek: "npm:2.x.x"
+    sntp: "npm:1.x.x"
   checksum: 42856c5afb6958d8396bb2ed7e1646117856741fa81edd0dc753d4840e200c0536ab291a28d72f85c778480afe3d695cf99111ca86b337e9a1dc487d7e58dd7a
   languageName: node
   linkType: hard
@@ -6735,7 +6674,7 @@ __metadata:
   version: 3.0.8
   resolution: "hosted-git-info@npm:3.0.8"
   dependencies:
-    lru-cache: ^6.0.0
+    lru-cache: "npm:^6.0.0"
   checksum: af1392086ab3ab5576aa81af07be2f93ee1588407af18fd9752eb67502558e6ea0ffdd4be35ac6c8bef12fb9017f6e7705757e21b10b5ce7798da9106c9c0d9d
   languageName: node
   linkType: hard
@@ -6765,12 +6704,12 @@ __metadata:
   version: 3.10.1
   resolution: "htmlparser2@npm:3.10.1"
   dependencies:
-    domelementtype: ^1.3.1
-    domhandler: ^2.3.0
-    domutils: ^1.5.1
-    entities: ^1.1.1
-    inherits: ^2.0.1
-    readable-stream: ^3.1.1
+    domelementtype: "npm:^1.3.1"
+    domhandler: "npm:^2.3.0"
+    domutils: "npm:^1.5.1"
+    entities: "npm:^1.1.1"
+    inherits: "npm:^2.0.1"
+    readable-stream: "npm:^3.1.1"
   checksum: b1424536ff062088501efa06a2afd478545d3134a5ad2e28bbe02dc2d092784982286b90f1c87fa3d86692958dbfb8936352dfd71d1cb2ff7cb61208c00fcdb1
   languageName: node
   linkType: hard
@@ -6779,11 +6718,11 @@ __metadata:
   version: 3.8.3
   resolution: "htmlparser2@npm:3.8.3"
   dependencies:
-    domelementtype: 1
-    domhandler: 2.3
-    domutils: 1.5
-    entities: 1.0
-    readable-stream: 1.1
+    domelementtype: "npm:1"
+    domhandler: "npm:2.3"
+    domutils: "npm:1.5"
+    entities: "npm:1.0"
+    readable-stream: "npm:1.1"
   checksum: 253a673976c1e2c2b8429e45830a5a89c3f23bb6dd34f5958aefbb104a8caf1268515b535277714deb034d894aa0bd315e901cbf2ec906e8ed0d1e49b2d73b3e
   languageName: node
   linkType: hard
@@ -6799,8 +6738,8 @@ __metadata:
   version: 1.3.1
   resolution: "http-errors@npm:1.3.1"
   dependencies:
-    inherits: ~2.0.1
-    statuses: 1
+    inherits: "npm:~2.0.1"
+    statuses: "npm:1"
   checksum: 57d226e31203fd41b84ddc5701c86035c4aca0997637805b5cc344458b02894576ccf97c26bb11e0b798b21912548ba57d455ff266a0dc776f6908237755f470
   languageName: node
   linkType: hard
@@ -6816,9 +6755,9 @@ __metadata:
   version: 4.0.1
   resolution: "http-proxy-agent@npm:4.0.1"
   dependencies:
-    "@tootallnate/once": 1
-    agent-base: 6
-    debug: 4
+    "@tootallnate/once": "npm:1"
+    agent-base: "npm:6"
+    debug: "npm:4"
   checksum: 4fa4774d65b5331814b74ac05cefea56854fc0d5989c80b13432c1b0d42a14c9f4342ca3ad9f0359a52e78da12b1744c9f8a28e50042136ea9171675d972a5fd
   languageName: node
   linkType: hard
@@ -6827,9 +6766,9 @@ __metadata:
   version: 1.1.1
   resolution: "http-signature@npm:1.1.1"
   dependencies:
-    assert-plus: ^0.2.0
-    jsprim: ^1.2.2
-    sshpk: ^1.7.0
+    assert-plus: "npm:^0.2.0"
+    jsprim: "npm:^1.2.2"
+    sshpk: "npm:^1.7.0"
   checksum: d58c5cd070ff2695d900de171eec412f903a948b520bb3d064fb66bc408707d3c409a3fc3fd97f0764612ca6a5b5cb342fc9a7a5a8daee6a622cc2cfc183c5f3
   languageName: node
   linkType: hard
@@ -6838,9 +6777,9 @@ __metadata:
   version: 1.2.0
   resolution: "http-signature@npm:1.2.0"
   dependencies:
-    assert-plus: ^1.0.0
-    jsprim: ^1.2.2
-    sshpk: ^1.7.0
+    assert-plus: "npm:^1.0.0"
+    jsprim: "npm:^1.2.2"
+    sshpk: "npm:^1.7.0"
   checksum: 582f7af7f354429e1fb19b3bbb9d35520843c69bb30a25b88ca3c5c2c10715f20ae7924e20cffbed220b1d3a726ef4fe8ccc48568d5744db87be9a79887d6733
   languageName: node
   linkType: hard
@@ -6849,8 +6788,8 @@ __metadata:
   version: 5.0.0
   resolution: "https-proxy-agent@npm:5.0.0"
   dependencies:
-    agent-base: 6
-    debug: 4
+    agent-base: "npm:6"
+    debug: "npm:4"
   checksum: 670c04f7f0effb5a449c094ea037cbcfb28a5ab93ed22e8c343095202cc7288027869a5a21caf4ee3b8ea06f9624ef1e1fc9044669c0fd92617654ff39f30806
   languageName: node
   linkType: hard
@@ -6859,7 +6798,7 @@ __metadata:
   version: 1.2.1
   resolution: "humanize-ms@npm:1.2.1"
   dependencies:
-    ms: ^2.0.0
+    ms: "npm:^2.0.0"
   checksum: f34a2c20161d02303c2807badec2f3b49cbfbbb409abd4f95a07377ae01cfe6b59e3d15ac609cffcd8f2521f0eb37b7e1091acf65da99aa2a4f1ad63c21e7e7a
   languageName: node
   linkType: hard
@@ -6868,8 +6807,8 @@ __metadata:
   version: 1.0.1
   resolution: "humanize-url@npm:1.0.1"
   dependencies:
-    normalize-url: ^1.0.0
-    strip-url-auth: ^1.0.0
+    normalize-url: "npm:^1.0.0"
+    strip-url-auth: "npm:^1.0.0"
   checksum: 2d8574ec4a0d30576237a3318d1639690bd077deacab5c0f7fb59dbdb0fa9ec7a7cfd05dfef191c9c00c7d8d5d08c271f5dec217c9aeddc4f1086bb75b108b17
   languageName: node
   linkType: hard
@@ -6878,7 +6817,7 @@ __metadata:
   version: 1.0.1
   resolution: "i18n-t@npm:1.0.1"
   dependencies:
-    lodash: ^4.13.1
+    lodash: "npm:^4.13.1"
   checksum: 55bc9370e058c8fd01d9ca91965f80d47f5b7858ad37ad44646861039bcd99b6f7bd13002319fd097303372ce68c7547a474888ac6b34fca12d6e713c6614b08
   languageName: node
   linkType: hard
@@ -6894,7 +6833,7 @@ __metadata:
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
   dependencies:
-    safer-buffer: ">= 2.1.2 < 3"
+    safer-buffer: "npm:>= 2.1.2 < 3"
   checksum: c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
   languageName: node
   linkType: hard
@@ -6903,7 +6842,7 @@ __metadata:
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
-    safer-buffer: ">= 2.1.2 < 3.0.0"
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
   languageName: node
   linkType: hard
@@ -6956,8 +6895,8 @@ __metadata:
   version: 2.0.0
   resolution: "import-fresh@npm:2.0.0"
   dependencies:
-    caller-path: ^2.0.0
-    resolve-from: ^3.0.0
+    caller-path: "npm:^2.0.0"
+    resolve-from: "npm:^3.0.0"
   checksum: 116c55ee5215a7839062285b60df85dbedde084c02111dc58c1b9d03ff7876627059f4beb16cdc090a3db21fea9022003402aa782139dc8d6302589038030504
   languageName: node
   linkType: hard
@@ -6966,8 +6905,8 @@ __metadata:
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
   dependencies:
-    parent-module: ^1.0.0
-    resolve-from: ^4.0.0
+    parent-module: "npm:^1.0.0"
+    resolve-from: "npm:^4.0.0"
   checksum: 7f882953aa6b740d1f0e384d0547158bc86efbf2eea0f1483b8900a6f65c5a5123c2cf09b0d542cc419d0b98a759ecaeb394237e97ea427f2da221dc3cd80cc3
   languageName: node
   linkType: hard
@@ -6983,27 +6922,6 @@ __metadata:
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
   checksum: 8b51313850dd33605c6c9d3fd9638b714f4c4c40250cff658209f30d40da60f78992fb2df5dabee4acf589a6a82bbc79ad5486550754bd9ec4e3fc0d4a57d6a6
-  languageName: node
-  linkType: hard
-
-"in-publish@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "in-publish@npm:2.0.1"
-  bin:
-    in-install: in-install.js
-    in-publish: in-publish.js
-    not-in-install: not-in-install.js
-    not-in-publish: not-in-publish.js
-  checksum: d83f7ac47f3f922134d26a586795d7bbd4a6d487601153ddf5b35980141f82a4563f7072fafc64785f6948244ab8681a10b85c0f6d18bbcb14333ff7c88f1ccc
-  languageName: node
-  linkType: hard
-
-"indent-string@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "indent-string@npm:2.1.0"
-  dependencies:
-    repeating: ^2.0.0
-  checksum: d38e04bbd9b0e1843164d06e9ac1e106ead5a6f7b5714c94ecebc2555b2d3af075b3ddc4d6f92ac87d5319c0935df60d571d3f45f17a6f0ec707be65f26ae924
   languageName: node
   linkType: hard
 
@@ -7032,8 +6950,8 @@ __metadata:
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
   dependencies:
-    once: ^1.3.0
-    wrappy: 1
+    once: "npm:^1.3.0"
+    wrappy: "npm:1"
   checksum: 7faca22584600a9dc5b9fca2cd5feb7135ac8c935449837b315676b4c90aa4f391ec4f42240178244b5a34e8bede1948627fda392ca3191522fc46b34e985ab2
   languageName: node
   linkType: hard
@@ -7056,14 +6974,14 @@ __metadata:
   version: 1.9.6
   resolution: "init-package-json@npm:1.9.6"
   dependencies:
-    glob: ^7.1.1
-    npm-package-arg: ^4.0.0 || ^5.0.0
-    promzard: ^0.3.0
-    read: ~1.0.1
-    read-package-json: 1 || 2
-    semver: 2.x || 3.x || 4 || 5
-    validate-npm-package-license: ^3.0.1
-    validate-npm-package-name: ^3.0.0
+    glob: "npm:^7.1.1"
+    npm-package-arg: "npm:^4.0.0 || ^5.0.0"
+    promzard: "npm:^0.3.0"
+    read: "npm:~1.0.1"
+    read-package-json: "npm:1 || 2"
+    semver: "npm:2.x || 3.x || 4 || 5"
+    validate-npm-package-license: "npm:^3.0.1"
+    validate-npm-package-name: "npm:^3.0.0"
   checksum: 46bcdb47854f9b286695f89c4aadfe9aa36c36adbb1eb852589f43e330193b0d19a00b03eaa135bfd73c0edbffc85be683e9b39bdc711dc92ae14e34ccbb15fe
   languageName: node
   linkType: hard
@@ -7072,20 +6990,20 @@ __metadata:
   version: 3.3.0
   resolution: "inquirer@npm:3.3.0"
   dependencies:
-    ansi-escapes: ^3.0.0
-    chalk: ^2.0.0
-    cli-cursor: ^2.1.0
-    cli-width: ^2.0.0
-    external-editor: ^2.0.4
-    figures: ^2.0.0
-    lodash: ^4.3.0
-    mute-stream: 0.0.7
-    run-async: ^2.2.0
-    rx-lite: ^4.0.8
-    rx-lite-aggregates: ^4.0.8
-    string-width: ^2.1.0
-    strip-ansi: ^4.0.0
-    through: ^2.3.6
+    ansi-escapes: "npm:^3.0.0"
+    chalk: "npm:^2.0.0"
+    cli-cursor: "npm:^2.1.0"
+    cli-width: "npm:^2.0.0"
+    external-editor: "npm:^2.0.4"
+    figures: "npm:^2.0.0"
+    lodash: "npm:^4.3.0"
+    mute-stream: "npm:0.0.7"
+    run-async: "npm:^2.2.0"
+    rx-lite: "npm:^4.0.8"
+    rx-lite-aggregates: "npm:^4.0.8"
+    string-width: "npm:^2.1.0"
+    strip-ansi: "npm:^4.0.0"
+    through: "npm:^2.3.6"
   checksum: d17475d6446e177227f5707cbd89ae6027cc316791d433c1b64f7be14d54456227186a0b058d580d7bbaf10e7098b0a1a986833cf71a956aa6d4f78878e78d3c
   languageName: node
   linkType: hard
@@ -7094,19 +7012,19 @@ __metadata:
   version: 7.3.3
   resolution: "inquirer@npm:7.3.3"
   dependencies:
-    ansi-escapes: ^4.2.1
-    chalk: ^4.1.0
-    cli-cursor: ^3.1.0
-    cli-width: ^3.0.0
-    external-editor: ^3.0.3
-    figures: ^3.0.0
-    lodash: ^4.17.19
-    mute-stream: 0.0.8
-    run-async: ^2.4.0
-    rxjs: ^6.6.0
-    string-width: ^4.1.0
-    strip-ansi: ^6.0.0
-    through: ^2.3.6
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.1.0"
+    cli-cursor: "npm:^3.1.0"
+    cli-width: "npm:^3.0.0"
+    external-editor: "npm:^3.0.3"
+    figures: "npm:^3.0.0"
+    lodash: "npm:^4.17.19"
+    mute-stream: "npm:0.0.8"
+    run-async: "npm:^2.4.0"
+    rxjs: "npm:^6.6.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    through: "npm:^2.3.6"
   checksum: 96e75974cfd863fe6653c075e41fa5f1a290896df141189816db945debabcd92d3277145f11aef8d2cfca5409ab003ccdd18a099744814057b52a2f27aeb8c94
   languageName: node
   linkType: hard
@@ -7115,9 +7033,9 @@ __metadata:
   version: 1.0.3
   resolution: "internal-slot@npm:1.0.3"
   dependencies:
-    get-intrinsic: ^1.1.0
-    has: ^1.0.3
-    side-channel: ^1.0.4
+    get-intrinsic: "npm:^1.1.0"
+    has: "npm:^1.0.3"
+    side-channel: "npm:^1.0.4"
   checksum: bb41342a474c1b607458b0c716c742d779a6ed9dfaf7986e5d20d1e7f55b7f3676e4d9f416bc253af4fd78d367e1f83e586f74840302bcf2e60c424f9284dde5
   languageName: node
   linkType: hard
@@ -7133,7 +7051,7 @@ __metadata:
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:
-    loose-envify: ^1.0.0
+    loose-envify: "npm:^1.0.0"
   checksum: 5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
   languageName: node
   linkType: hard
@@ -7163,7 +7081,7 @@ __metadata:
   version: 0.1.6
   resolution: "is-accessor-descriptor@npm:0.1.6"
   dependencies:
-    kind-of: ^3.0.2
+    kind-of: "npm:^3.0.2"
   checksum: f2c314b314ec6e8a6e559351bff3c7ee9aed7a5e9c6f61dd8cb9e1382c8bfe33dca3f0e0af13daf9ded9e6e66390ff23b4acfb615d7a249009a51506a7b0f151
   languageName: node
   linkType: hard
@@ -7172,7 +7090,7 @@ __metadata:
   version: 1.0.0
   resolution: "is-accessor-descriptor@npm:1.0.0"
   dependencies:
-    kind-of: ^6.0.0
+    kind-of: "npm:^6.0.0"
   checksum: d68edafd8ef133e9003837f3c80f4e5b82b12ab5456c772d1796857671ae83e3a426ed225a28a7e35bceabbce68c1f1ffdabf47e6d53f5a4d6c4558776ad3c20
   languageName: node
   linkType: hard
@@ -7181,8 +7099,8 @@ __metadata:
   version: 1.1.1
   resolution: "is-arguments@npm:1.1.1"
   dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
+    call-bind: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.0"
   checksum: 5ff1f341ee4475350adfc14b2328b38962564b7c2076be2f5bac7bd9b61779efba99b9f844a7b82ba7654adccf8e8eb19d1bb0cc6d1c1a085e498f6793d4328f
   languageName: node
   linkType: hard
@@ -7198,7 +7116,7 @@ __metadata:
   version: 1.0.4
   resolution: "is-bigint@npm:1.0.4"
   dependencies:
-    has-bigints: ^1.0.1
+    has-bigints: "npm:^1.0.1"
   checksum: eb9c88e418a0d195ca545aff2b715c9903d9b0a5033bc5922fec600eb0c3d7b1ee7f882dbf2e0d5a6e694e42391be3683e4368737bd3c4a77f8ac293e7773696
   languageName: node
   linkType: hard
@@ -7207,7 +7125,7 @@ __metadata:
   version: 1.0.1
   resolution: "is-binary-path@npm:1.0.1"
   dependencies:
-    binary-extensions: ^1.0.0
+    binary-extensions: "npm:^1.0.0"
   checksum: 16e456fa3782eaf3d8e28d382b750507e3d54ff6694df8a1b2c6498da321e2ead311de9c42e653d8fb3213de72bac204b5f97e4a110cda8a72f17b1c1b4eb643
   languageName: node
   linkType: hard
@@ -7216,7 +7134,7 @@ __metadata:
   version: 2.1.0
   resolution: "is-binary-path@npm:2.1.0"
   dependencies:
-    binary-extensions: ^2.0.0
+    binary-extensions: "npm:^2.0.0"
   checksum: a16eaee59ae2b315ba36fad5c5dcaf8e49c3e27318f8ab8fa3cdb8772bf559c8d1ba750a589c2ccb096113bb64497084361a25960899cb6172a6925ab6123d38
   languageName: node
   linkType: hard
@@ -7225,8 +7143,8 @@ __metadata:
   version: 1.1.2
   resolution: "is-boolean-object@npm:1.1.2"
   dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
+    call-bind: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.0"
   checksum: 6090587f8a8a8534c0f816da868bc94f32810f08807aa72fa7e79f7e11c466d281486ffe7a788178809c2aa71fe3e700b167fe80dd96dad68026bfff8ebf39f7
   languageName: node
   linkType: hard
@@ -7242,7 +7160,7 @@ __metadata:
   version: 1.0.0
   resolution: "is-builtin-module@npm:1.0.0"
   dependencies:
-    builtin-modules: ^1.0.0
+    builtin-modules: "npm:^1.0.0"
   checksum: 4292d9255c7d8b02fb83b19a4a2512f4be2aefb537c65499f00453ebaed6d6cf88334d458c7d7dea93065c5b1d4ab42eca10c7a29d6b81d54b748265f78ec357
   languageName: node
   linkType: hard
@@ -7258,7 +7176,7 @@ __metadata:
   version: 2.0.0
   resolution: "is-ci@npm:2.0.0"
   dependencies:
-    ci-info: ^2.0.0
+    ci-info: "npm:^2.0.0"
   bin:
     is-ci: bin.js
   checksum: 17de4e2cd8f993c56c86472dd53dd9e2c7f126d0ee55afe610557046cdd64de0e8feadbad476edc9eeff63b060523b8673d9094ed2ab294b59efb5a66dd05a9a
@@ -7269,7 +7187,7 @@ __metadata:
   version: 2.8.1
   resolution: "is-core-module@npm:2.8.1"
   dependencies:
-    has: ^1.0.3
+    has: "npm:^1.0.3"
   checksum: f1139970deb2ec159c54be154d35cd17d71b9b56c60221ff7c8c328ca7efe20b6d676cef43d08c21966e162bfd5068dcd0ce23e64c77b76a19824563ecd82e0e
   languageName: node
   linkType: hard
@@ -7278,7 +7196,7 @@ __metadata:
   version: 0.1.4
   resolution: "is-data-descriptor@npm:0.1.4"
   dependencies:
-    kind-of: ^3.0.2
+    kind-of: "npm:^3.0.2"
   checksum: 32fda7e966b2c1f093230d5ef2aad1bb86e43e7280da50961e38ec31dbd8a50570a2911fd45277d321074a0762adc98e8462bb62820462594128857225e90d21
   languageName: node
   linkType: hard
@@ -7287,7 +7205,7 @@ __metadata:
   version: 1.0.0
   resolution: "is-data-descriptor@npm:1.0.0"
   dependencies:
-    kind-of: ^6.0.0
+    kind-of: "npm:^6.0.0"
   checksum: bed31385d7d1a0dbb2ab3077faf2188acf42609192dca4e320ed7b3dc14a9d70c00658956cdaa2c0402be136c6b56e183973ad81b730fd90ab427fb6fd3608be
   languageName: node
   linkType: hard
@@ -7296,7 +7214,7 @@ __metadata:
   version: 1.0.5
   resolution: "is-date-object@npm:1.0.5"
   dependencies:
-    has-tostringtag: ^1.0.0
+    has-tostringtag: "npm:^1.0.0"
   checksum: eed21e5dcc619c48ccef804dfc83a739dbb2abee6ca202838ee1bd5f760fe8d8a93444f0d49012ad19bb7c006186e2884a1b92f6e1c056da7fd23d0a9ad5992e
   languageName: node
   linkType: hard
@@ -7305,9 +7223,9 @@ __metadata:
   version: 0.1.6
   resolution: "is-descriptor@npm:0.1.6"
   dependencies:
-    is-accessor-descriptor: ^0.1.6
-    is-data-descriptor: ^0.1.4
-    kind-of: ^5.0.0
+    is-accessor-descriptor: "npm:^0.1.6"
+    is-data-descriptor: "npm:^0.1.4"
+    kind-of: "npm:^5.0.0"
   checksum: 6b8f5617b764ef8c6be3d54830184357e6cdedd8e0eddf1b97d0658616ac170bfdbc7c1ad00e0aa9f5b767acdb9d6c63d4df936501784b34936bd0f9acf3b665
   languageName: node
   linkType: hard
@@ -7316,9 +7234,9 @@ __metadata:
   version: 1.0.2
   resolution: "is-descriptor@npm:1.0.2"
   dependencies:
-    is-accessor-descriptor: ^1.0.0
-    is-data-descriptor: ^1.0.0
-    kind-of: ^6.0.2
+    is-accessor-descriptor: "npm:^1.0.0"
+    is-data-descriptor: "npm:^1.0.0"
+    kind-of: "npm:^6.0.2"
   checksum: a05169c7a87feb88fc155e3ada469090cfabb5a548a3f794358b511cc47a0871b8b95e7345be4925a22ef3df585c3923b31943b3ad6255ce563a9d97f2e221e0
   languageName: node
   linkType: hard
@@ -7341,7 +7259,7 @@ __metadata:
   version: 0.1.3
   resolution: "is-equal-shallow@npm:0.1.3"
   dependencies:
-    is-primitive: ^2.0.0
+    is-primitive: "npm:^2.0.0"
   checksum: ae623698cdfeeec0688b2e6128d76cabe1cc5957d533bf7f7596caf3f2993d4c50a20c97420e60a0d58745fc4b2709dfb62e653e054cf948c5834615b715f05f
   languageName: node
   linkType: hard
@@ -7357,7 +7275,7 @@ __metadata:
   version: 1.0.1
   resolution: "is-extendable@npm:1.0.1"
   dependencies:
-    is-plain-object: ^2.0.4
+    is-plain-object: "npm:^2.0.4"
   checksum: 1d6678a5be1563db6ecb121331c819c38059703f0179f52aa80c242c223ee9c6b66470286636c0e63d7163e4d905c0a7d82a096e0b5eaeabb51b9f8d0af0d73f
   languageName: node
   linkType: hard
@@ -7387,7 +7305,7 @@ __metadata:
   version: 1.0.0
   resolution: "is-fullwidth-code-point@npm:1.0.0"
   dependencies:
-    number-is-nan: ^1.0.0
+    number-is-nan: "npm:^1.0.0"
   checksum: 12acfcf16142f2d431bf6af25d68569d3198e81b9799b4ae41058247aafcc666b0127d64384ea28e67a746372611fcbe9b802f69175287aba466da3eddd5ba0f
   languageName: node
   linkType: hard
@@ -7410,7 +7328,7 @@ __metadata:
   version: 1.0.10
   resolution: "is-generator-function@npm:1.0.10"
   dependencies:
-    has-tostringtag: ^1.0.0
+    has-tostringtag: "npm:^1.0.0"
   checksum: df03514df01a6098945b5a0cfa1abff715807c8e72f57c49a0686ad54b3b74d394e2d8714e6f709a71eb00c9630d48e73ca1796c1ccc84ac95092c1fecc0d98b
   languageName: node
   linkType: hard
@@ -7419,7 +7337,7 @@ __metadata:
   version: 2.0.1
   resolution: "is-glob@npm:2.0.1"
   dependencies:
-    is-extglob: ^1.0.0
+    is-extglob: "npm:^1.0.0"
   checksum: ef156806af0924983325c9218a8b8a838fa50e1a104ed2a11fe94829a5b27c1b05a4c8cf98d96cb3a7fea539c21f14ae2081e1a248f3d5a9eea62f2d4e9f8b0c
   languageName: node
   linkType: hard
@@ -7428,7 +7346,7 @@ __metadata:
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
-    is-extglob: ^2.1.1
+    is-extglob: "npm:^2.1.1"
   checksum: 17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
   languageName: node
   linkType: hard
@@ -7437,8 +7355,8 @@ __metadata:
   version: 0.1.0
   resolution: "is-installed-globally@npm:0.1.0"
   dependencies:
-    global-dirs: ^0.1.0
-    is-path-inside: ^1.0.0
+    global-dirs: "npm:^0.1.0"
+    is-path-inside: "npm:^1.0.0"
   checksum: e5664812205367240bf7229e56410a4d33a83843e32642938dc5d0ba6d53e5125b24ea9aefcf5d35bc3ab8a868469d631624ce59dead1d6ceadf88b19cca6ab7
   languageName: node
   linkType: hard
@@ -7447,8 +7365,8 @@ __metadata:
   version: 0.2.0
   resolution: "is-installed-globally@npm:0.2.0"
   dependencies:
-    global-dirs: ^0.1.1
-    is-path-inside: ^2.1.0
+    global-dirs: "npm:^0.1.1"
+    is-path-inside: "npm:^2.1.0"
   checksum: bfba0fdceac4c010ded3268fd2d8674790cf90c3305f5d02d9d49083f333011a824d0293020389d0cd06187e603eb1bbef034ef05048969cffd75339d44f6d0d
   languageName: node
   linkType: hard
@@ -7471,11 +7389,11 @@ __metadata:
   version: 2.20.6
   resolution: "is-my-json-valid@npm:2.20.6"
   dependencies:
-    generate-function: ^2.0.0
-    generate-object-property: ^1.1.0
-    is-my-ip-valid: ^1.0.0
-    jsonpointer: ^5.0.0
-    xtend: ^4.0.0
+    generate-function: "npm:^2.0.0"
+    generate-object-property: "npm:^1.1.0"
+    is-my-ip-valid: "npm:^1.0.0"
+    jsonpointer: "npm:^5.0.0"
+    xtend: "npm:^4.0.0"
   checksum: 1f74c24db02b3ee9dc7042f828b4fb204566350d72b01ca1efa8a61e8c41fab8ef664dfeb1158c11de29a3ca87ac2645b9829e50116205919a1da91b7039d041
   languageName: node
   linkType: hard
@@ -7484,8 +7402,8 @@ __metadata:
   version: 1.3.2
   resolution: "is-nan@npm:1.3.2"
   dependencies:
-    call-bind: ^1.0.0
-    define-properties: ^1.1.3
+    call-bind: "npm:^1.0.0"
+    define-properties: "npm:^1.1.3"
   checksum: 8bfb286f85763f9c2e28ea32e9127702fe980ffd15fa5d63ade3be7786559e6e21355d3625dd364c769c033c5aedf0a2ed3d4025d336abf1b9241e3d9eddc5b0
   languageName: node
   linkType: hard
@@ -7508,7 +7426,7 @@ __metadata:
   version: 1.0.6
   resolution: "is-number-object@npm:1.0.6"
   dependencies:
-    has-tostringtag: ^1.0.0
+    has-tostringtag: "npm:^1.0.0"
   checksum: f3220cd4882ed6c18f08d5122d320b353bc3ceeab5d93dbefded56da70fb544eaa3f27323902dd64d76a84260504c9bf7f4743f2d1817c716658b972573ef6ff
   languageName: node
   linkType: hard
@@ -7517,7 +7435,7 @@ __metadata:
   version: 2.1.0
   resolution: "is-number@npm:2.1.0"
   dependencies:
-    kind-of: ^3.0.2
+    kind-of: "npm:^3.0.2"
   checksum: f9d2079a0dbfbce6f9f3b6644f6eb60d0211ee56bb26db3963ef4d514e2444f87e3f56c8169896c90544c501ed5e510c5b83abae6748a57d15f6ac8d85efd602
   languageName: node
   linkType: hard
@@ -7526,7 +7444,7 @@ __metadata:
   version: 3.0.0
   resolution: "is-number@npm:3.0.0"
   dependencies:
-    kind-of: ^3.0.2
+    kind-of: "npm:^3.0.2"
   checksum: e639c54640b7f029623df24d3d103901e322c0c25ea5bde97cd723c2d0d4c05857a8364ab5c58d963089dbed6bf1d0ffe975cb6aef917e2ad0ccbca653d31b4f
   languageName: node
   linkType: hard
@@ -7556,7 +7474,7 @@ __metadata:
   version: 1.1.0
   resolution: "is-observable@npm:1.1.0"
   dependencies:
-    symbol-observable: ^1.1.0
+    symbol-observable: "npm:^1.1.0"
   checksum: cf3166b0822f70ad06e7851e09430166ce658349d54aaa64c93a03320420b9285735821b23164bdce741ff83a86730ac3e53035ce4e2511ed843dbff4105bfa2
   languageName: node
   linkType: hard
@@ -7572,7 +7490,7 @@ __metadata:
   version: 2.1.0
   resolution: "is-path-in-cwd@npm:2.1.0"
   dependencies:
-    is-path-inside: ^2.1.0
+    is-path-inside: "npm:^2.1.0"
   checksum: 674a4282fb3732cf4b4e9ea31e06380d8b074fb8106c4c1742a9f0f3d5650bf059b2c45e5c4cfa7abe847ca88474de63abec323a7fe1eb14f8ec4de2fa951d3a
   languageName: node
   linkType: hard
@@ -7581,7 +7499,7 @@ __metadata:
   version: 1.0.1
   resolution: "is-path-inside@npm:1.0.1"
   dependencies:
-    path-is-inside: ^1.0.1
+    path-is-inside: "npm:^1.0.1"
   checksum: 093ab1324e33a95c2d057e1450e1936ee7a3ed25b78c8dc42f576f3dc3489dd8788d431ea2969bb0e081f005de1571792ea99cf7b1b69ab2dd4ca477ae7a8e51
   languageName: node
   linkType: hard
@@ -7590,7 +7508,7 @@ __metadata:
   version: 2.1.0
   resolution: "is-path-inside@npm:2.1.0"
   dependencies:
-    path-is-inside: ^1.0.2
+    path-is-inside: "npm:^1.0.2"
   checksum: 50272b9aa301964c0bc4032d5c968e63c516d15bd7800cd06845df97bee637451fcd92a8001b37e309563eff2dffae5fa6d635a0c1d162dc257489c86b1fda51
   languageName: node
   linkType: hard
@@ -7620,7 +7538,7 @@ __metadata:
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
   dependencies:
-    isobject: ^3.0.1
+    isobject: "npm:^3.0.1"
   checksum: f050fdd5203d9c81e8c4df1b3ff461c4bc64e8b5ca383bcdde46131361d0a678e80bcf00b5257646f6c636197629644d53bd8e2375aea633de09a82d57e942f4
   languageName: node
   linkType: hard
@@ -7657,8 +7575,8 @@ __metadata:
   version: 1.1.4
   resolution: "is-regex@npm:1.1.4"
   dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
+    call-bind: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.0"
   checksum: bb72aae604a69eafd4a82a93002058c416ace8cde95873589a97fc5dac96a6c6c78a9977d487b7b95426a8f5073969124dd228f043f9f604f041f32fcc465fc1
   languageName: node
   linkType: hard
@@ -7674,7 +7592,7 @@ __metadata:
   version: 2.1.0
   resolution: "is-scoped@npm:2.1.0"
   dependencies:
-    scoped-regex: ^2.0.0
+    scoped-regex: "npm:^2.0.0"
   checksum: 2dca54be0bfe6d2c6c2af651bd476f549042b45dac1ccafdc630a241738de15ee0a12ce2e04fc8d4dd2ae639577b6d4182d3ac68e6ad75ed602a7f4edec996ef
   languageName: node
   linkType: hard
@@ -7704,7 +7622,7 @@ __metadata:
   version: 1.0.7
   resolution: "is-string@npm:1.0.7"
   dependencies:
-    has-tostringtag: ^1.0.0
+    has-tostringtag: "npm:^1.0.0"
   checksum: 905f805cbc6eedfa678aaa103ab7f626aac9ebbdc8737abb5243acaa61d9820f8edc5819106b8fcd1839e33db21de9f0116ae20de380c8382d16dc2a601921f6
   languageName: node
   linkType: hard
@@ -7713,7 +7631,7 @@ __metadata:
   version: 1.0.4
   resolution: "is-symbol@npm:1.0.4"
   dependencies:
-    has-symbols: ^1.0.2
+    has-symbols: "npm:^1.0.2"
   checksum: 9381dd015f7c8906154dbcbf93fad769de16b4b961edc94f88d26eb8c555935caa23af88bda0c93a18e65560f6d7cca0fd5a3f8a8e1df6f1abbb9bead4502ef7
   languageName: node
   linkType: hard
@@ -7722,11 +7640,11 @@ __metadata:
   version: 1.1.8
   resolution: "is-typed-array@npm:1.1.8"
   dependencies:
-    available-typed-arrays: ^1.0.5
-    call-bind: ^1.0.2
-    es-abstract: ^1.18.5
-    foreach: ^2.0.5
-    has-tostringtag: ^1.0.0
+    available-typed-arrays: "npm:^1.0.5"
+    call-bind: "npm:^1.0.2"
+    es-abstract: "npm:^1.18.5"
+    foreach: "npm:^2.0.5"
+    has-tostringtag: "npm:^1.0.0"
   checksum: 31e0561cfc03b3e167b61f011de4eff12cda6a7d8a5f3e92e67c9043776e27df32f2ba4e690246711465ed1bef1917e7bdb09f68cc68b24666d2a3e7c5437af9
   languageName: node
   linkType: hard
@@ -7749,7 +7667,7 @@ __metadata:
   version: 3.0.0
   resolution: "is-url-superb@npm:3.0.0"
   dependencies:
-    url-regex: ^5.0.0
+    url-regex: "npm:^5.0.0"
   checksum: d242520fc3d6b86d6e87283ba472c89d43dbcf0700da4631c328558e9524d25403b5da042a826efb468df16f61e361c4b405ddd2981cd28bf2c56a2c316ab898
   languageName: node
   linkType: hard
@@ -7765,7 +7683,7 @@ __metadata:
   version: 1.0.2
   resolution: "is-weakref@npm:1.0.2"
   dependencies:
-    call-bind: ^1.0.2
+    call-bind: "npm:^1.0.2"
   checksum: 1545c5d172cb690c392f2136c23eec07d8d78a7f57d0e41f10078aa4f5daf5d7f57b6513a67514ab4f073275ad00c9822fc8935e00229d0a2089e1c02685d4b1
   languageName: node
   linkType: hard
@@ -7837,7 +7755,7 @@ __metadata:
   version: 2.1.0
   resolution: "isobject@npm:2.1.0"
   dependencies:
-    isarray: 1.0.0
+    isarray: "npm:1.0.0"
   checksum: c4cafec73b3b2ee11be75dff8dafd283b5728235ac099b07d7873d5182553a707768e208327bbc12931b9422d8822280bf88d894a0024ff5857b3efefb480e7b
   languageName: node
   linkType: hard
@@ -7881,7 +7799,7 @@ __metadata:
   version: 2.0.7
   resolution: "istanbul-lib-hook@npm:2.0.7"
   dependencies:
-    append-transform: ^1.0.0
+    append-transform: "npm:^1.0.0"
   checksum: acbc2c2b16c3c96075ea84f03e80f54877cdc113763273e51d06b562e8c2d29530461373ca359ec9126408536366ae0ee0464d3111b206c5e2ca930c54b2e364
   languageName: node
   linkType: hard
@@ -7890,13 +7808,13 @@ __metadata:
   version: 1.10.2
   resolution: "istanbul-lib-instrument@npm:1.10.2"
   dependencies:
-    babel-generator: ^6.18.0
-    babel-template: ^6.16.0
-    babel-traverse: ^6.18.0
-    babel-types: ^6.18.0
-    babylon: ^6.18.0
-    istanbul-lib-coverage: ^1.2.1
-    semver: ^5.3.0
+    babel-generator: "npm:^6.18.0"
+    babel-template: "npm:^6.16.0"
+    babel-traverse: "npm:^6.18.0"
+    babel-types: "npm:^6.18.0"
+    babylon: "npm:^6.18.0"
+    istanbul-lib-coverage: "npm:^1.2.1"
+    semver: "npm:^5.3.0"
   checksum: 1f861fb757a1e26ca8a80542fdc1b7f2d35a131a0116d20a1a785837472c474cfa6ac4058ae5389a0e358563da0e2c8ef5f958336ea9d29ee39a4d0da143b9d7
   languageName: node
   linkType: hard
@@ -7905,13 +7823,13 @@ __metadata:
   version: 3.3.0
   resolution: "istanbul-lib-instrument@npm:3.3.0"
   dependencies:
-    "@babel/generator": ^7.4.0
-    "@babel/parser": ^7.4.3
-    "@babel/template": ^7.4.0
-    "@babel/traverse": ^7.4.3
-    "@babel/types": ^7.4.0
-    istanbul-lib-coverage: ^2.0.5
-    semver: ^6.0.0
+    "@babel/generator": "npm:^7.4.0"
+    "@babel/parser": "npm:^7.4.3"
+    "@babel/template": "npm:^7.4.0"
+    "@babel/traverse": "npm:^7.4.3"
+    "@babel/types": "npm:^7.4.0"
+    istanbul-lib-coverage: "npm:^2.0.5"
+    semver: "npm:^6.0.0"
   checksum: 988eb9d58ae0ae69686369f6809a610f6f8db5c5f73931a496b02b941da56cfc176f84af0dd8db819ad2e6aca6dc2f38c91a288f1c6a3f79cfb10320180e998d
   languageName: node
   linkType: hard
@@ -7920,9 +7838,9 @@ __metadata:
   version: 2.0.8
   resolution: "istanbul-lib-report@npm:2.0.8"
   dependencies:
-    istanbul-lib-coverage: ^2.0.5
-    make-dir: ^2.1.0
-    supports-color: ^6.1.0
+    istanbul-lib-coverage: "npm:^2.0.5"
+    make-dir: "npm:^2.1.0"
+    supports-color: "npm:^6.1.0"
   checksum: 6c3907620a4ff9ec03ce58b325df0be551daf911c54f1e2d732ef310e9bc7b39ac57214736322e24241422ad8e8ab2780fea41a3f0a5238cbdcf7d3db8d6f956
   languageName: node
   linkType: hard
@@ -7931,11 +7849,11 @@ __metadata:
   version: 3.0.6
   resolution: "istanbul-lib-source-maps@npm:3.0.6"
   dependencies:
-    debug: ^4.1.1
-    istanbul-lib-coverage: ^2.0.5
-    make-dir: ^2.1.0
-    rimraf: ^2.6.3
-    source-map: ^0.6.1
+    debug: "npm:^4.1.1"
+    istanbul-lib-coverage: "npm:^2.0.5"
+    make-dir: "npm:^2.1.0"
+    rimraf: "npm:^2.6.3"
+    source-map: "npm:^0.6.1"
   checksum: 0d2c0e6b301fd964d74137000b7f949d18856ad6e40e065a9f28eec041b33b901e3ff6f4f61505230558b26a1be0be044ae2e2bd6c692a9a7985e762fb300722
   languageName: node
   linkType: hard
@@ -7944,7 +7862,7 @@ __metadata:
   version: 2.2.7
   resolution: "istanbul-reports@npm:2.2.7"
   dependencies:
-    html-escaper: ^2.0.0
+    html-escaper: "npm:^2.0.0"
   checksum: cf6fd9992a65dc9167f8fbe336cd2b9aa108ecc8b97653ea87c9eb3db283e9c40f9333e588629c771bfebff124e6f922dddeef9b6fcbe13385c536f860e86ae4
   languageName: node
   linkType: hard
@@ -7953,17 +7871,10 @@ __metadata:
   version: 26.6.2
   resolution: "jest-worker@npm:26.6.2"
   dependencies:
-    "@types/node": "*"
-    merge-stream: ^2.0.0
-    supports-color: ^7.0.0
+    "@types/node": "npm:*"
+    merge-stream: "npm:^2.0.0"
+    supports-color: "npm:^7.0.0"
   checksum: 07e4dba650381604cda253ab6d5837fe0279c8d68c25884995b45bfe149a7a1e1b5a97f304b4518f257dac2a9ddc1808d57d650649c3ab855e9e60cf824d2970
-  languageName: node
-  linkType: hard
-
-"js-base64@npm:^2.1.8":
-  version: 2.6.4
-  resolution: "js-base64@npm:2.6.4"
-  checksum: 95d93c4eca0bbe0f2d5ffe8682d9acd23051e5c0ad71873ff5a48dd46a5f19025de9f7b36e63fa3f02f342ae4a8ca4c56e7b590d7300ebb6639ce09675e0fd02
   languageName: node
   linkType: hard
 
@@ -7985,7 +7896,7 @@ __metadata:
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
   dependencies:
-    argparse: ^2.0.1
+    argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
@@ -8003,21 +7914,21 @@ __metadata:
   version: 7.2.2
   resolution: "jsdom@npm:7.2.2"
   dependencies:
-    abab: ^1.0.0
-    acorn: ^2.4.0
-    acorn-globals: ^1.0.4
-    cssom: ">= 0.3.0 < 0.4.0"
-    cssstyle: ">= 0.2.29 < 0.3.0"
-    escodegen: ^1.6.1
-    nwmatcher: ">= 1.3.7 < 2.0.0"
-    parse5: ^1.5.1
-    request: ^2.55.0
-    sax: ^1.1.4
-    symbol-tree: ">= 3.1.0 < 4.0.0"
-    tough-cookie: ^2.2.0
-    webidl-conversions: ^2.0.0
-    whatwg-url-compat: ~0.6.5
-    xml-name-validator: ">= 2.0.1 < 3.0.0"
+    abab: "npm:^1.0.0"
+    acorn: "npm:^2.4.0"
+    acorn-globals: "npm:^1.0.4"
+    cssom: "npm:>= 0.3.0 < 0.4.0"
+    cssstyle: "npm:>= 0.2.29 < 0.3.0"
+    escodegen: "npm:^1.6.1"
+    nwmatcher: "npm:>= 1.3.7 < 2.0.0"
+    parse5: "npm:^1.5.1"
+    request: "npm:^2.55.0"
+    sax: "npm:^1.1.4"
+    symbol-tree: "npm:>= 3.1.0 < 4.0.0"
+    tough-cookie: "npm:^2.2.0"
+    webidl-conversions: "npm:^2.0.0"
+    whatwg-url-compat: "npm:~0.6.5"
+    xml-name-validator: "npm:>= 2.0.1 < 3.0.0"
   checksum: c74dd24bb8a02f1ef7806dbe4377dcb196ec3155e6829080703e9a4f998831239ab148958aa66245250a65a6815f14160e3a90cd303f1eb39ee9fa9549402d5f
   languageName: node
   linkType: hard
@@ -8109,7 +8020,7 @@ __metadata:
   version: 1.0.1
   resolution: "json5@npm:1.0.1"
   dependencies:
-    minimist: ^1.2.0
+    minimist: "npm:^1.2.0"
   bin:
     json5: lib/cli.js
   checksum: 7f75dd797151680a4e14c4224c1343b32a43272aa6e6333ddec2b0822df4ea116971689b251879a1248592da24f7929902c13f83d7390c3f3d44f18e8e9719f5
@@ -8120,7 +8031,7 @@ __metadata:
   version: 2.2.0
   resolution: "json5@npm:2.2.0"
   dependencies:
-    minimist: ^1.2.5
+    minimist: "npm:^1.2.5"
   bin:
     json5: lib/cli.js
   checksum: fbe021f69fa100f0a863e5ab9105ead3971ad5141e7c0dc5134c6148545dae98a69602fb8f9f4dd65af0db7ca00887bf5b35af60be34c10f58fb5fc1f2366a4e
@@ -8131,7 +8042,7 @@ __metadata:
   version: 4.0.0
   resolution: "jsonfile@npm:4.0.0"
   dependencies:
-    graceful-fs: ^4.1.6
+    graceful-fs: "npm:^4.1.6"
   dependenciesMeta:
     graceful-fs:
       optional: true
@@ -8157,10 +8068,10 @@ __metadata:
   version: 1.4.2
   resolution: "jsprim@npm:1.4.2"
   dependencies:
-    assert-plus: 1.0.0
-    extsprintf: 1.3.0
-    json-schema: 0.4.0
-    verror: 1.10.0
+    assert-plus: "npm:1.0.0"
+    extsprintf: "npm:1.3.0"
+    json-schema: "npm:0.4.0"
+    verror: "npm:1.10.0"
   checksum: 5e4bca99e90727c2040eb4c2190d0ef1fe51798ed5714e87b841d304526190d960f9772acc7108fa1416b61e1122bcd60e4460c91793dce0835df5852aab55af
   languageName: node
   linkType: hard
@@ -8169,14 +8080,14 @@ __metadata:
   version: 2.0.0
   resolution: "juice@npm:2.0.0"
   dependencies:
-    batch: 0.5.3
-    cheerio: 0.20.0
-    commander: 2.9.0
-    cross-spawn-async: ^2.1.8
-    cssom: 0.3.1
-    deep-extend: ^0.4.0
-    slick: 1.12.2
-    web-resource-inliner: 2.0.0
+    batch: "npm:0.5.3"
+    cheerio: "npm:0.20.0"
+    commander: "npm:2.9.0"
+    cross-spawn-async: "npm:^2.1.8"
+    cssom: "npm:0.3.1"
+    deep-extend: "npm:^0.4.0"
+    slick: "npm:1.12.2"
+    web-resource-inliner: "npm:2.0.0"
   bin:
     juice: bin/juice
   checksum: 94679b6fbf2f3be693c71d324c4d1d289f0ce56d35fad05e015986e9c08ac9b2e2854a7d83af94bf60eead57ff2e911d258409c895f0b22ef1b16c4b750e1311
@@ -8194,7 +8105,7 @@ __metadata:
   version: 3.1.0
   resolution: "keyv@npm:3.1.0"
   dependencies:
-    json-buffer: 3.0.0
+    json-buffer: "npm:3.0.0"
   checksum: 6ad784361b4c0213333a8c5bc0bcc59cf46cb7cbbe21fb2f1539ffcc8fe18b8f1562ff913b40552278fdea5f152a15996dfa61ce24ce1a22222560c650be4a1b
   languageName: node
   linkType: hard
@@ -8203,7 +8114,7 @@ __metadata:
   version: 3.2.2
   resolution: "kind-of@npm:3.2.2"
   dependencies:
-    is-buffer: ^1.1.5
+    is-buffer: "npm:^1.1.5"
   checksum: 7e34bc29d4b02c997f92f080de34ebb92033a96736bbb0bb2410e033a7e5ae6571f1fa37b2d7710018f95361473b816c604234197f4f203f9cf149d8ef1574d9
   languageName: node
   linkType: hard
@@ -8212,7 +8123,7 @@ __metadata:
   version: 4.0.0
   resolution: "kind-of@npm:4.0.0"
   dependencies:
-    is-buffer: ^1.1.5
+    is-buffer: "npm:^1.1.5"
   checksum: d6c44c75ee36898142dfc7106afbd50593216c37f96acb81a7ab33ca1a6938ce97d5692b8fc8fccd035f83811a9d97749d68771116441a48eedd0b68e2973165
   languageName: node
   linkType: hard
@@ -8258,7 +8169,7 @@ __metadata:
   version: 5.1.0
   resolution: "latest-version@npm:5.1.0"
   dependencies:
-    package-json: ^6.3.0
+    package-json: "npm:^6.3.0"
   checksum: 6219631d8651467c54c58ef1b5d5c5c53e146f5ae2b0ecbb78b202da3eaad55b05b043db2d2d6f1d4230ee071b2ae8c2f85089e01377e4338bad97fa76a963b7
   languageName: node
   linkType: hard
@@ -8274,7 +8185,7 @@ __metadata:
   version: 1.0.0
   resolution: "lcid@npm:1.0.0"
   dependencies:
-    invert-kv: ^1.0.0
+    invert-kv: "npm:^1.0.0"
   checksum: 87fb32196c3c80458778f34f71c042e114f3134a3c86c0d60ee9c94f0750e467d7ca0c005a5224ffd9d49a6e449b5e5c31e1544f1827765a0ba8747298f5980e
   languageName: node
   linkType: hard
@@ -8283,8 +8194,8 @@ __metadata:
   version: 0.3.0
   resolution: "levn@npm:0.3.0"
   dependencies:
-    prelude-ls: ~1.1.2
-    type-check: ~0.3.2
+    prelude-ls: "npm:~1.1.2"
+    type-check: "npm:~0.3.2"
   checksum: e440df9de4233da0b389cd55bd61f0f6aaff766400bebbccd1231b81801f6dbc1d816c676ebe8d70566394b749fa624b1ed1c68070e9c94999f0bdecc64cb676
   languageName: node
   linkType: hard
@@ -8300,9 +8211,9 @@ __metadata:
   version: 0.1.3
   resolution: "listr-input@npm:0.1.3"
   dependencies:
-    inquirer: ^3.3.0
-    rxjs: ^5.5.2
-    through: ^2.3.8
+    inquirer: "npm:^3.3.0"
+    rxjs: "npm:^5.5.2"
+    through: "npm:^2.3.8"
   checksum: 36787c3c7dc0c921f8271397f79da445e3fa7d7fafcd048aef0c4f6dd7462f902969566a2fe7ade46a67c5b22a181bb9372e7fedd1a6522cc47b09eb5fe08164
   languageName: node
   linkType: hard
@@ -8318,14 +8229,14 @@ __metadata:
   version: 0.5.0
   resolution: "listr-update-renderer@npm:0.5.0"
   dependencies:
-    chalk: ^1.1.3
-    cli-truncate: ^0.2.1
-    elegant-spinner: ^1.0.1
-    figures: ^1.7.0
-    indent-string: ^3.0.0
-    log-symbols: ^1.0.2
-    log-update: ^2.3.0
-    strip-ansi: ^3.0.1
+    chalk: "npm:^1.1.3"
+    cli-truncate: "npm:^0.2.1"
+    elegant-spinner: "npm:^1.0.1"
+    figures: "npm:^1.7.0"
+    indent-string: "npm:^3.0.0"
+    log-symbols: "npm:^1.0.2"
+    log-update: "npm:^2.3.0"
+    strip-ansi: "npm:^3.0.1"
   peerDependencies:
     listr: ^0.14.2
   checksum: 8ade44bf3dc6146c8e0178000619439e8889792c4689b66be6ce82bd459f5fe462ecb34b05147fb206a8ad60e6d4e6f34c9f48038e18366f867fd972688b8edc
@@ -8336,10 +8247,10 @@ __metadata:
   version: 0.5.0
   resolution: "listr-verbose-renderer@npm:0.5.0"
   dependencies:
-    chalk: ^2.4.1
-    cli-cursor: ^2.1.0
-    date-fns: ^1.27.2
-    figures: ^2.0.0
+    chalk: "npm:^2.4.1"
+    cli-cursor: "npm:^2.1.0"
+    date-fns: "npm:^1.27.2"
+    figures: "npm:^2.0.0"
   checksum: 041cd1e82da7054f27ae0a914e98b40d15faf9f950ef850578fc6241d3fff3c2d7158a4f6226006e566b4c47bf445be2d254dd1ce5c16569a3a5dcd575bec656
   languageName: node
   linkType: hard
@@ -8348,15 +8259,15 @@ __metadata:
   version: 0.14.3
   resolution: "listr@npm:0.14.3"
   dependencies:
-    "@samverschueren/stream-to-observable": ^0.3.0
-    is-observable: ^1.1.0
-    is-promise: ^2.1.0
-    is-stream: ^1.1.0
-    listr-silent-renderer: ^1.1.1
-    listr-update-renderer: ^0.5.0
-    listr-verbose-renderer: ^0.5.0
-    p-map: ^2.0.0
-    rxjs: ^6.3.3
+    "@samverschueren/stream-to-observable": "npm:^0.3.0"
+    is-observable: "npm:^1.1.0"
+    is-promise: "npm:^2.1.0"
+    is-stream: "npm:^1.1.0"
+    listr-silent-renderer: "npm:^1.1.1"
+    listr-update-renderer: "npm:^0.5.0"
+    listr-verbose-renderer: "npm:^0.5.0"
+    p-map: "npm:^2.0.0"
+    rxjs: "npm:^6.3.3"
   checksum: 753d518218c423f46bee8eeacccecadfd2e414ba9c0f602e7f85fe3f6fa18404dfab0812433aeda4683ee2548358488f597ac1a3d321196baec5d3149b200b10
   languageName: node
   linkType: hard
@@ -8372,11 +8283,11 @@ __metadata:
   version: 1.1.0
   resolution: "load-json-file@npm:1.1.0"
   dependencies:
-    graceful-fs: ^4.1.2
-    parse-json: ^2.2.0
-    pify: ^2.0.0
-    pinkie-promise: ^2.0.0
-    strip-bom: ^2.0.0
+    graceful-fs: "npm:^4.1.2"
+    parse-json: "npm:^2.2.0"
+    pify: "npm:^2.0.0"
+    pinkie-promise: "npm:^2.0.0"
+    strip-bom: "npm:^2.0.0"
   checksum: 2a5344c2d88643735a938fdca8582c0504e1c290577faa74f56b9cc187fa443832709a15f36e5771f779ec0878215a03abc8faf97ec57bb86092ceb7e0caef22
   languageName: node
   linkType: hard
@@ -8385,10 +8296,10 @@ __metadata:
   version: 4.0.0
   resolution: "load-json-file@npm:4.0.0"
   dependencies:
-    graceful-fs: ^4.1.2
-    parse-json: ^4.0.0
-    pify: ^3.0.0
-    strip-bom: ^3.0.0
+    graceful-fs: "npm:^4.1.2"
+    parse-json: "npm:^4.0.0"
+    pify: "npm:^3.0.0"
+    strip-bom: "npm:^3.0.0"
   checksum: 6b48f6a0256bdfcc8970be2c57f68f10acb2ee7e63709b386b2febb6ad3c86198f840889cdbe71d28f741cbaa2f23a7771206b138cd1bdd159564511ca37c1d5
   languageName: node
   linkType: hard
@@ -8404,9 +8315,9 @@ __metadata:
   version: 1.4.0
   resolution: "loader-utils@npm:1.4.0"
   dependencies:
-    big.js: ^5.2.2
-    emojis-list: ^3.0.0
-    json5: ^1.0.1
+    big.js: "npm:^5.2.2"
+    emojis-list: "npm:^3.0.0"
+    json5: "npm:^1.0.1"
   checksum: b3f383612c23c0adf535d61709fb3eaf864afa54dae45608e3831156b89b4b05a0a4ddc6db7d742071babe872750ba3f4f9ce89326d94f6e096dbed978fa424e
   languageName: node
   linkType: hard
@@ -8415,9 +8326,9 @@ __metadata:
   version: 2.0.2
   resolution: "loader-utils@npm:2.0.2"
   dependencies:
-    big.js: ^5.2.2
-    emojis-list: ^3.0.0
-    json5: ^2.1.2
+    big.js: "npm:^5.2.2"
+    emojis-list: "npm:^3.0.0"
+    json5: "npm:^2.1.2"
   checksum: 332ae8db3d4d3fac7e5bbed82da9230857d3f85b3ccf6d3f2e286fa2431887aa9e46965928b2c77a93f5f721cec037539c0cfc718164f0287c5c90f5dce07ad9
   languageName: node
   linkType: hard
@@ -8426,8 +8337,8 @@ __metadata:
   version: 2.0.0
   resolution: "locate-path@npm:2.0.0"
   dependencies:
-    p-locate: ^2.0.0
-    path-exists: ^3.0.0
+    p-locate: "npm:^2.0.0"
+    path-exists: "npm:^3.0.0"
   checksum: 24efa0e589be6aa3c469b502f795126b26ab97afa378846cb508174211515633b770aa0ba610cab113caedab8d2a4902b061a08aaed5297c12ab6f5be4df0133
   languageName: node
   linkType: hard
@@ -8436,8 +8347,8 @@ __metadata:
   version: 3.0.0
   resolution: "locate-path@npm:3.0.0"
   dependencies:
-    p-locate: ^3.0.0
-    path-exists: ^3.0.0
+    p-locate: "npm:^3.0.0"
+    path-exists: "npm:^3.0.0"
   checksum: 3db394b7829a7fe2f4fbdd25d3c4689b85f003c318c5da4052c7e56eed697da8f1bce5294f685c69ff76e32cba7a33629d94396976f6d05fb7f4c755c5e2ae8b
   languageName: node
   linkType: hard
@@ -8446,7 +8357,7 @@ __metadata:
   version: 5.0.0
   resolution: "locate-path@npm:5.0.0"
   dependencies:
-    p-locate: ^4.1.0
+    p-locate: "npm:^4.1.0"
   checksum: 33a1c5247e87e022f9713e6213a744557a3e9ec32c5d0b5efb10aa3a38177615bf90221a5592674857039c1a0fd2063b82f285702d37b792d973e9e72ace6c59
   languageName: node
   linkType: hard
@@ -8455,7 +8366,7 @@ __metadata:
   version: 6.0.0
   resolution: "locate-path@npm:6.0.0"
   dependencies:
-    p-locate: ^5.0.0
+    p-locate: "npm:^5.0.0"
   checksum: d3972ab70dfe58ce620e64265f90162d247e87159b6126b01314dd67be43d50e96a50b517bce2d9452a79409c7614054c277b5232377de50416564a77ac7aad3
   languageName: node
   linkType: hard
@@ -8464,7 +8375,7 @@ __metadata:
   version: 1.0.4
   resolution: "lockfile@npm:1.0.4"
   dependencies:
-    signal-exit: ^3.0.2
+    signal-exit: "npm:^3.0.2"
   checksum: 80b7777ceb43105d9e588733c3efc2514653a5e3a0dae3e61347a1f5381da34dcaa2caaa60c39ed5d4ad31c1735a4831e5639a0ba1c508bfea8dbc9c89777b37
   languageName: node
   linkType: hard
@@ -8480,7 +8391,7 @@ __metadata:
   version: 4.5.0
   resolution: "lodash._basedifference@npm:4.5.0"
   dependencies:
-    lodash._root: ~3.0.0
+    lodash._root: "npm:~3.0.0"
   checksum: 67753e1286368c06ee1e0d170f6f4d9f50eaa62085160b14a1ba7b191d4ce239c82709f0075dc5633629c4994c034a2065be4a4d1b74d9bbf3648a18723125d9
   languageName: node
   linkType: hard
@@ -8503,8 +8414,8 @@ __metadata:
   version: 4.6.0
   resolution: "lodash._baseuniq@npm:4.6.0"
   dependencies:
-    lodash._createset: ~4.0.0
-    lodash._root: ~3.0.0
+    lodash._createset: "npm:~4.0.0"
+    lodash._root: "npm:~3.0.0"
   checksum: 07e2ac63efde634685ed12b16664ee04931b258cd2511b703fddd9ddfc624a85542e3f03a6c2fdac369c00559296198daa8efffaf90d71c7a35f5c89f94ebb14
   languageName: node
   linkType: hard
@@ -8527,7 +8438,7 @@ __metadata:
   version: 3.1.2
   resolution: "lodash._createcache@npm:3.1.2"
   dependencies:
-    lodash._getnative: ^3.0.0
+    lodash._getnative: "npm:^3.0.0"
   checksum: 3dc696d4e0532a5243596efc37e8a088833219058f5292c62df7444cf71e5a98243c60d0e4f87129192a76ef5f41777529c0106f7ac13b7c7ecc3f8920f6914a
   languageName: node
   linkType: hard
@@ -8557,7 +8468,7 @@ __metadata:
   version: 4.3.2
   resolution: "lodash.clonedeep@npm:4.3.2"
   dependencies:
-    lodash._baseclone: ~4.5.0
+    lodash._baseclone: "npm:~4.5.0"
   checksum: 070183db46c4db94231f5be2cad3b5848c0570ce39ff15820f6b0a318af45632471aff8fc4eff5a50cdeb3eaf6a1755d2edf1f5cb3495e8c0ddd38c5897a2b44
   languageName: node
   linkType: hard
@@ -8643,9 +8554,9 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.union@npm:4.4.0"
   dependencies:
-    lodash._baseflatten: ~4.2.0
-    lodash._baseuniq: ~4.6.0
-    lodash.rest: ^4.0.0
+    lodash._baseflatten: "npm:~4.2.0"
+    lodash._baseuniq: "npm:~4.6.0"
+    lodash.rest: "npm:^4.0.0"
   checksum: cf66a6a5238d9cfd4e2cc4a57d7972e9aba21b32362db78086f2aa70914b5bad989219999a60399d570221ad42191fa19b2ea9261e4c9ccd08049d5ac045a9b5
   languageName: node
   linkType: hard
@@ -8661,7 +8572,7 @@ __metadata:
   version: 4.3.0
   resolution: "lodash.uniq@npm:4.3.0"
   dependencies:
-    lodash._baseuniq: ~4.6.0
+    lodash._baseuniq: "npm:~4.6.0"
   checksum: 747a48548894862e7733f7d2f601672f57b49f68f14649acfcc2b7e2d26798cbf53b653bf5d770e68f649ca6d59518090ee4f5b512a2f50c3a295d1933109571
   languageName: node
   linkType: hard
@@ -8677,8 +8588,8 @@ __metadata:
   version: 4.2.0
   resolution: "lodash.without@npm:4.2.0"
   dependencies:
-    lodash._basedifference: ~4.5.0
-    lodash.rest: ^4.0.0
+    lodash._basedifference: "npm:~4.5.0"
+    lodash.rest: "npm:^4.0.0"
   checksum: 99eb81ae0ec293bfa1d29643255ea4b861121d0dfcc990756a3789638ced78a250a0a3b7b79d9d852b153472e937fb97d313cf859b1ddfe5a357fbbaaf5a018a
   languageName: node
   linkType: hard
@@ -8704,7 +8615,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.0.0, lodash@npm:^4.1.0, lodash@npm:^4.13.1, lodash@npm:^4.17.10, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.4, lodash@npm:^4.3.0, lodash@npm:~4.17.10":
+"lodash@npm:^4.1.0, lodash@npm:^4.13.1, lodash@npm:^4.17.10, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.4, lodash@npm:^4.3.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -8715,8 +8626,8 @@ __metadata:
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
   dependencies:
-    chalk: ^4.1.0
-    is-unicode-supported: ^0.1.0
+    chalk: "npm:^4.1.0"
+    is-unicode-supported: "npm:^0.1.0"
   checksum: 67f445a9ffa76db1989d0fa98586e5bc2fd5247260dafb8ad93d9f0ccd5896d53fb830b0e54dade5ad838b9de2006c826831a3c528913093af20dff8bd24aca6
   languageName: node
   linkType: hard
@@ -8725,7 +8636,7 @@ __metadata:
   version: 1.0.2
   resolution: "log-symbols@npm:1.0.2"
   dependencies:
-    chalk: ^1.0.0
+    chalk: "npm:^1.0.0"
   checksum: c64e1fe41d0d043840f8b592d043b8607a836b846506f525a53d99d578561f02f97b2cba1d2b3c30bae5311d64b308d5a392a9930d252b906a9042fc2877da7a
   languageName: node
   linkType: hard
@@ -8734,7 +8645,7 @@ __metadata:
   version: 3.0.0
   resolution: "log-symbols@npm:3.0.0"
   dependencies:
-    chalk: ^2.4.2
+    chalk: "npm:^2.4.2"
   checksum: d11582a1b499b76aa1415988234ad54d9fb3f888f4cb4186cbc20ee4d314ac4b5f3d9fe9edd828748d2c0d372df2ea9f5dfd89100510988a8ce5ddf483ae015e
   languageName: node
   linkType: hard
@@ -8743,9 +8654,9 @@ __metadata:
   version: 2.3.0
   resolution: "log-update@npm:2.3.0"
   dependencies:
-    ansi-escapes: ^3.0.0
-    cli-cursor: ^2.0.0
-    wrap-ansi: ^3.0.1
+    ansi-escapes: "npm:^3.0.0"
+    cli-cursor: "npm:^2.0.0"
+    wrap-ansi: "npm:^3.0.1"
   checksum: 9bf21b138801ab4770a2bfa735161cf005b869360eaf5003a84ba64ddc5f5c3ce7217f4f1fa79d9c1f510d792213b2c9800327228e94df05859d19b716215d90
   languageName: node
   linkType: hard
@@ -8761,7 +8672,7 @@ __metadata:
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
-    js-tokens: ^3.0.0 || ^4.0.0
+    js-tokens: "npm:^3.0.0 || ^4.0.0"
   bin:
     loose-envify: cli.js
   checksum: 655d110220983c1a4b9c0c679a2e8016d4b67f6e9c7b5435ff5979ecdb20d0813f4dec0a08674fcbdd4846a3f07edbb50a36811fd37930b94aaa0d9daceb017e
@@ -8772,8 +8683,8 @@ __metadata:
   version: 1.6.0
   resolution: "loud-rejection@npm:1.6.0"
   dependencies:
-    currently-unhandled: ^0.4.1
-    signal-exit: ^3.0.0
+    currently-unhandled: "npm:^0.4.1"
+    signal-exit: "npm:^3.0.0"
   checksum: aa060b3fe55ad96b97890f1b0a24bf81a2d612e397d6cc0374ce1cf7e021cd0247f0ddb68134499882d0843c2776371d5221b80b0b3beeca5133a6e7f27a3845
   languageName: node
   linkType: hard
@@ -8803,8 +8714,8 @@ __metadata:
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
   dependencies:
-    pseudomap: ^1.0.2
-    yallist: ^2.1.2
+    pseudomap: "npm:^1.0.2"
+    yallist: "npm:^2.1.2"
   checksum: 1ca5306814e5add9ec63556d6fd9b24a4ecdeaef8e9cea52cbf30301e6b88c8d8ddc7cab45b59b56eb763e6c45af911585dc89925a074ab65e1502e3fe8103cf
   languageName: node
   linkType: hard
@@ -8813,7 +8724,7 @@ __metadata:
   version: 6.0.0
   resolution: "lru-cache@npm:6.0.0"
   dependencies:
-    yallist: ^4.0.0
+    yallist: "npm:^4.0.0"
   checksum: cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
   languageName: node
   linkType: hard
@@ -8822,7 +8733,7 @@ __metadata:
   version: 0.1.0
   resolution: "lru-queue@npm:0.1.0"
   dependencies:
-    es5-ext: ~0.10.2
+    es5-ext: "npm:~0.10.2"
   checksum: 83517032b46843601c4528be65e8aaf85f5a7860a9cfa3e4f2b5591da436e7cd748d95b450c91434c4ffb75d3ae4c069ddbdd9f71ada56a99a00c03088c51b4d
   languageName: node
   linkType: hard
@@ -8838,7 +8749,7 @@ __metadata:
   version: 1.3.0
   resolution: "make-dir@npm:1.3.0"
   dependencies:
-    pify: ^3.0.0
+    pify: "npm:^3.0.0"
   checksum: 5eb94f47d7ef41d89d1b8eef6539b8950d5bd99eeba093a942bfd327faa37d2d62227526b88b73633243a2ec7972d21eb0f4e5d62ae4e02a79e389f4a7bb3022
   languageName: node
   linkType: hard
@@ -8847,8 +8758,8 @@ __metadata:
   version: 2.1.0
   resolution: "make-dir@npm:2.1.0"
   dependencies:
-    pify: ^4.0.1
-    semver: ^5.6.0
+    pify: "npm:^4.0.1"
+    semver: "npm:^5.6.0"
   checksum: ada869944d866229819735bee5548944caef560d7a8536ecbc6536edca28c72add47cc4f6fc39c54fb25d06b58da1f8994cf7d9df7dadea047064749efc085d8
   languageName: node
   linkType: hard
@@ -8857,7 +8768,7 @@ __metadata:
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
   dependencies:
-    semver: ^6.0.0
+    semver: "npm:^6.0.0"
   checksum: 56aaafefc49c2dfef02c5c95f9b196c4eb6988040cf2c712185c7fe5c99b4091591a7fc4d4eafaaefa70ff763a26f6ab8c3ff60b9e75ea19876f49b18667ecaa
   languageName: node
   linkType: hard
@@ -8873,22 +8784,22 @@ __metadata:
   version: 9.1.0
   resolution: "make-fetch-happen@npm:9.1.0"
   dependencies:
-    agentkeepalive: ^4.1.3
-    cacache: ^15.2.0
-    http-cache-semantics: ^4.1.0
-    http-proxy-agent: ^4.0.1
-    https-proxy-agent: ^5.0.0
-    is-lambda: ^1.0.1
-    lru-cache: ^6.0.0
-    minipass: ^3.1.3
-    minipass-collect: ^1.0.2
-    minipass-fetch: ^1.3.2
-    minipass-flush: ^1.0.5
-    minipass-pipeline: ^1.2.4
-    negotiator: ^0.6.2
-    promise-retry: ^2.0.1
-    socks-proxy-agent: ^6.0.0
-    ssri: ^8.0.0
+    agentkeepalive: "npm:^4.1.3"
+    cacache: "npm:^15.2.0"
+    http-cache-semantics: "npm:^4.1.0"
+    http-proxy-agent: "npm:^4.0.1"
+    https-proxy-agent: "npm:^5.0.0"
+    is-lambda: "npm:^1.0.1"
+    lru-cache: "npm:^6.0.0"
+    minipass: "npm:^3.1.3"
+    minipass-collect: "npm:^1.0.2"
+    minipass-fetch: "npm:^1.3.2"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    negotiator: "npm:^0.6.2"
+    promise-retry: "npm:^2.0.1"
+    socks-proxy-agent: "npm:^6.0.0"
+    ssri: "npm:^8.0.0"
   checksum: 2c737faf6a7f67077679da548b5bfeeef890595bf8c4323a1f76eae355d27ebb33dcf9cf1a673f944cf2f2a7cbf4e2b09f0a0a62931737728f210d902c6be966
   languageName: node
   linkType: hard
@@ -8897,7 +8808,7 @@ __metadata:
   version: 0.1.3
   resolution: "map-age-cleaner@npm:0.1.3"
   dependencies:
-    p-defer: ^1.0.0
+    p-defer: "npm:^1.0.0"
   checksum: 7495236c7b0950956c144fd8b4bc6399d4e78072a8840a4232fe1c4faccbb5eb5d842e5c0a56a60afc36d723f315c1c672325ca03c1b328650f7fcc478f385fd
   languageName: node
   linkType: hard
@@ -8909,7 +8820,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"map-obj@npm:^1.0.0, map-obj@npm:^1.0.1":
+"map-obj@npm:^1.0.0":
   version: 1.0.1
   resolution: "map-obj@npm:1.0.1"
   checksum: ccca88395e7d38671ed9f5652ecf471ecd546924be2fb900836b9da35e068a96687d96a5f93dcdfa94d9a27d649d2f10a84595590f89a347fb4dda47629dcc52
@@ -8927,7 +8838,7 @@ __metadata:
   version: 1.0.0
   resolution: "map-visit@npm:1.0.0"
   dependencies:
-    object-visit: ^1.0.0
+    object-visit: "npm:^1.0.0"
   checksum: fb3475e5311939a6147e339999113db607adc11c7c3cd3103e5e9dbf502898416ecba6b1c7c649c6d4d12941de00cee58b939756bdf20a9efe7d4fa5a5738b73
   languageName: node
   linkType: hard
@@ -8950,9 +8861,9 @@ __metadata:
   version: 4.3.0
   resolution: "mem@npm:4.3.0"
   dependencies:
-    map-age-cleaner: ^0.1.1
-    mimic-fn: ^2.0.0
-    p-is-promise: ^2.0.0
+    map-age-cleaner: "npm:^0.1.1"
+    mimic-fn: "npm:^2.0.0"
+    p-is-promise: "npm:^2.0.0"
   checksum: fc74e16d877322aafe869fe92a5c3109b1683195f4ef507920322a2fc8cd9998f3299f716c9853e10304c06a528fd9b763de24bdd7ce0b448155f05c9fad8612
   languageName: node
   linkType: hard
@@ -8961,13 +8872,13 @@ __metadata:
   version: 0.3.10
   resolution: "memoizee@npm:0.3.10"
   dependencies:
-    d: ~0.1.1
-    es5-ext: ~0.10.11
-    es6-weak-map: ~0.1.4
-    event-emitter: ~0.3.4
-    lru-queue: 0.1
-    next-tick: ~0.2.2
-    timers-ext: 0.1
+    d: "npm:~0.1.1"
+    es5-ext: "npm:~0.10.11"
+    es6-weak-map: "npm:~0.1.4"
+    event-emitter: "npm:~0.3.4"
+    lru-queue: "npm:0.1"
+    next-tick: "npm:~0.2.2"
+    timers-ext: "npm:0.1"
   checksum: 8873e9eddd79ba1ffeb5f7bd2e37c46a4e6e0a724b753c368f6d68fc9237270cf4eb0a09ce016d5368f782d4822ad9e05612f948e9b5aa6732d4766f48e53d01
   languageName: node
   linkType: hard
@@ -8976,27 +8887,9 @@ __metadata:
   version: 0.4.1
   resolution: "memory-fs@npm:0.4.1"
   dependencies:
-    errno: ^0.1.3
-    readable-stream: ^2.0.1
+    errno: "npm:^0.1.3"
+    readable-stream: "npm:^2.0.1"
   checksum: f114c44ad8285103cb0e71420cf5bb628d3eb6cbd918197f5951590ff56ba2072f4a97924949c170320cdf180d2da4e8d16a0edd92ba0ca2d2de51dc932841e2
-  languageName: node
-  linkType: hard
-
-"meow@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "meow@npm:3.7.0"
-  dependencies:
-    camelcase-keys: ^2.0.0
-    decamelize: ^1.1.2
-    loud-rejection: ^1.0.0
-    map-obj: ^1.0.1
-    minimist: ^1.1.3
-    normalize-package-data: ^2.3.4
-    object-assign: ^4.0.1
-    read-pkg-up: ^1.0.1
-    redent: ^1.0.0
-    trim-newlines: ^1.0.0
-  checksum: e5ba4632b6558006b5f4df64b5a35e777d75629ab08d84f7bbc967e7603a396e16baa8f67aae26c7833a6a117e4857afef393e0b9aee21f52320e54812d9ae09
   languageName: node
   linkType: hard
 
@@ -9004,15 +8897,15 @@ __metadata:
   version: 5.0.0
   resolution: "meow@npm:5.0.0"
   dependencies:
-    camelcase-keys: ^4.0.0
-    decamelize-keys: ^1.0.0
-    loud-rejection: ^1.0.0
-    minimist-options: ^3.0.1
-    normalize-package-data: ^2.3.4
-    read-pkg-up: ^3.0.0
-    redent: ^2.0.0
-    trim-newlines: ^2.0.0
-    yargs-parser: ^10.0.0
+    camelcase-keys: "npm:^4.0.0"
+    decamelize-keys: "npm:^1.0.0"
+    loud-rejection: "npm:^1.0.0"
+    minimist-options: "npm:^3.0.1"
+    normalize-package-data: "npm:^2.3.4"
+    read-pkg-up: "npm:^3.0.0"
+    redent: "npm:^2.0.0"
+    trim-newlines: "npm:^2.0.0"
+    yargs-parser: "npm:^10.0.0"
   checksum: c9d62cc714e9b46c58f1f8b2ab35d0cab535f0ce08ecdc9c02f4e42b30d4b13bd67d0e0ea12c59ad7c94bdd9116a8ea5caf62fa1d22b991bcdbf7f3a40b0f60a
   languageName: node
   linkType: hard
@@ -9021,7 +8914,7 @@ __metadata:
   version: 1.1.0
   resolution: "merge-source-map@npm:1.1.0"
   dependencies:
-    source-map: ^0.6.1
+    source-map: "npm:^0.6.1"
   checksum: ac0e0192c9c7e30056c5baa939434c0d1015faa5c7ce7936ad77600f1752c03099134cb33c50f1bb32ec25350e191ca2392c6b76b1eaca89c7c989e42403655f
   languageName: node
   linkType: hard
@@ -9044,19 +8937,19 @@ __metadata:
   version: 2.3.11
   resolution: "micromatch@npm:2.3.11"
   dependencies:
-    arr-diff: ^2.0.0
-    array-unique: ^0.2.1
-    braces: ^1.8.2
-    expand-brackets: ^0.1.4
-    extglob: ^0.3.1
-    filename-regex: ^2.0.0
-    is-extglob: ^1.0.0
-    is-glob: ^2.0.1
-    kind-of: ^3.0.2
-    normalize-path: ^2.0.1
-    object.omit: ^2.0.0
-    parse-glob: ^3.0.4
-    regex-cache: ^0.4.2
+    arr-diff: "npm:^2.0.0"
+    array-unique: "npm:^0.2.1"
+    braces: "npm:^1.8.2"
+    expand-brackets: "npm:^0.1.4"
+    extglob: "npm:^0.3.1"
+    filename-regex: "npm:^2.0.0"
+    is-extglob: "npm:^1.0.0"
+    is-glob: "npm:^2.0.1"
+    kind-of: "npm:^3.0.2"
+    normalize-path: "npm:^2.0.1"
+    object.omit: "npm:^2.0.0"
+    parse-glob: "npm:^3.0.4"
+    regex-cache: "npm:^0.4.2"
   checksum: 56864f45f5a76523a3b3fe7c07c1a19cb9e6a2078b1e5dd036bacdd6e65f5d8adc00679ebb785ab88d577fce80197f2d8fd6f5565188643f87d8a47f64f6127a
   languageName: node
   linkType: hard
@@ -9065,19 +8958,19 @@ __metadata:
   version: 3.1.10
   resolution: "micromatch@npm:3.1.10"
   dependencies:
-    arr-diff: ^4.0.0
-    array-unique: ^0.3.2
-    braces: ^2.3.1
-    define-property: ^2.0.2
-    extend-shallow: ^3.0.2
-    extglob: ^2.0.4
-    fragment-cache: ^0.2.1
-    kind-of: ^6.0.2
-    nanomatch: ^1.2.9
-    object.pick: ^1.3.0
-    regex-not: ^1.0.0
-    snapdragon: ^0.8.1
-    to-regex: ^3.0.2
+    arr-diff: "npm:^4.0.0"
+    array-unique: "npm:^0.3.2"
+    braces: "npm:^2.3.1"
+    define-property: "npm:^2.0.2"
+    extend-shallow: "npm:^3.0.2"
+    extglob: "npm:^2.0.4"
+    fragment-cache: "npm:^0.2.1"
+    kind-of: "npm:^6.0.2"
+    nanomatch: "npm:^1.2.9"
+    object.pick: "npm:^1.3.0"
+    regex-not: "npm:^1.0.0"
+    snapdragon: "npm:^0.8.1"
+    to-regex: "npm:^3.0.2"
   checksum: 531a32e7ac92bef60657820202be71b63d0f945c08a69cc4c239c0b19372b751483d464a850a2e3a5ff6cc9060641e43d44c303af104c1a27493d137d8af017f
   languageName: node
   linkType: hard
@@ -9086,8 +8979,8 @@ __metadata:
   version: 4.0.4
   resolution: "micromatch@npm:4.0.4"
   dependencies:
-    braces: ^3.0.1
-    picomatch: ^2.2.3
+    braces: "npm:^3.0.1"
+    picomatch: "npm:^2.2.3"
   checksum: 87bc95e3e52ebe413dbadd43c96e797c736bf238f154e3b546859493e83781b6f7fa4dfa54e423034fb9aeea65259ee6480551581271c348d8e19214910a5a64
   languageName: node
   linkType: hard
@@ -9103,7 +8996,7 @@ __metadata:
   version: 2.1.34
   resolution: "mime-types@npm:2.1.34"
   dependencies:
-    mime-db: 1.51.0
+    mime-db: "npm:1.51.0"
   checksum: 7cb55d499f67fbaa9b4e5da552c54ae5c9ac1d57df93f89e2af185d2f3e7a3e6f2030b5b248fec2130f659ebcd9a40e51f63f91006b3ea876b3cadf4755ea410
   languageName: node
   linkType: hard
@@ -9151,17 +9044,17 @@ __metadata:
   version: 1.0.0
   resolution: "minimatch@npm:1.0.0"
   dependencies:
-    lru-cache: 2
-    sigmund: ~1.0.0
+    lru-cache: "npm:2"
+    sigmund: "npm:~1.0.0"
   checksum: 7c762d8a914935faceada2e5c73feaf830a72f1884848a21b3d70141bb234ac7fb2940d8bce7e70020b1ea87646f3f19fdfdf13748aac792a07be9044fd35d11
   languageName: node
   linkType: hard
 
-"minimatch@npm:2 || 3, minimatch@npm:3.0.4, minimatch@npm:^3.0.0, minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:~3.0.2":
+"minimatch@npm:2 || 3, minimatch@npm:3.0.4, minimatch@npm:^3.0.0, minimatch@npm:^3.0.2, minimatch@npm:^3.0.4":
   version: 3.0.4
   resolution: "minimatch@npm:3.0.4"
   dependencies:
-    brace-expansion: ^1.1.7
+    brace-expansion: "npm:^1.1.7"
   checksum: d0a2bcd93ebec08a9eef3ca83ba33c9fb6feb93932e0b4dc6aa46c5f37a9404bea7ad9ff7cafe23ce6634f1fe3b206f5315ecbb05812da6e692c21d8ecfd3dae
   languageName: node
   linkType: hard
@@ -9170,7 +9063,7 @@ __metadata:
   version: 2.0.10
   resolution: "minimatch@npm:2.0.10"
   dependencies:
-    brace-expansion: ^1.0.0
+    brace-expansion: "npm:^1.0.0"
   checksum: 82380832ff91278fb961a8e51cc5f53728e76fef8d2842f2593a3d32daebb62b36a3003b453e50cd51d7eafe9e155398d4feaa0162ef945d2c81d2d801b589e4
   languageName: node
   linkType: hard
@@ -9179,8 +9072,8 @@ __metadata:
   version: 3.0.2
   resolution: "minimist-options@npm:3.0.2"
   dependencies:
-    arrify: ^1.0.1
-    is-plain-obj: ^1.1.0
+    arrify: "npm:^1.0.1"
+    is-plain-obj: "npm:^1.1.0"
   checksum: 8277dc07e623a3d422735b67bef4f5da7733370896226efbff1aa2f34a54426989bdadd29d8205f7fd45225565c56ca8f38f7360626410b1e7aed8fee299b683
   languageName: node
   linkType: hard
@@ -9192,7 +9085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.3, minimist@npm:^1.2.0, minimist@npm:^1.2.5":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.5":
   version: 1.2.5
   resolution: "minimist@npm:1.2.5"
   checksum: c143b0c199af4df7a55c7a37b6465cdd438acdc6a3a345ba0fe9d94dfcc2042263f650879bc73be607c843deeaeaadf39c864e55bc6d80b36a025eca1a062ee7
@@ -9210,7 +9103,7 @@ __metadata:
   version: 1.0.2
   resolution: "minipass-collect@npm:1.0.2"
   dependencies:
-    minipass: ^3.0.0
+    minipass: "npm:^3.0.0"
   checksum: 8f82bd1f3095b24f53a991b04b67f4c710c894e518b813f0864a31de5570441a509be1ca17e0bb92b047591a8fdbeb886f502764fefb00d2f144f4011791e898
   languageName: node
   linkType: hard
@@ -9219,10 +9112,10 @@ __metadata:
   version: 1.4.1
   resolution: "minipass-fetch@npm:1.4.1"
   dependencies:
-    encoding: ^0.1.12
-    minipass: ^3.1.0
-    minipass-sized: ^1.0.3
-    minizlib: ^2.0.0
+    encoding: "npm:^0.1.12"
+    minipass: "npm:^3.1.0"
+    minipass-sized: "npm:^1.0.3"
+    minizlib: "npm:^2.0.0"
   dependenciesMeta:
     encoding:
       optional: true
@@ -9234,7 +9127,7 @@ __metadata:
   version: 1.0.5
   resolution: "minipass-flush@npm:1.0.5"
   dependencies:
-    minipass: ^3.0.0
+    minipass: "npm:^3.0.0"
   checksum: 2a51b63feb799d2bb34669205eee7c0eaf9dce01883261a5b77410c9408aa447e478efd191b4de6fc1101e796ff5892f8443ef20d9544385819093dbb32d36bd
   languageName: node
   linkType: hard
@@ -9243,7 +9136,7 @@ __metadata:
   version: 1.2.4
   resolution: "minipass-pipeline@npm:1.2.4"
   dependencies:
-    minipass: ^3.0.0
+    minipass: "npm:^3.0.0"
   checksum: cbda57cea20b140b797505dc2cac71581a70b3247b84480c1fed5ca5ba46c25ecc25f68bfc9e6dcb1a6e9017dab5c7ada5eab73ad4f0a49d84e35093e0c643f2
   languageName: node
   linkType: hard
@@ -9252,7 +9145,7 @@ __metadata:
   version: 1.0.3
   resolution: "minipass-sized@npm:1.0.3"
   dependencies:
-    minipass: ^3.0.0
+    minipass: "npm:^3.0.0"
   checksum: 298f124753efdc745cfe0f2bdfdd81ba25b9f4e753ca4a2066eb17c821f25d48acea607dfc997633ee5bf7b6dfffb4eee4f2051eb168663f0b99fad2fa4829cb
   languageName: node
   linkType: hard
@@ -9261,7 +9154,7 @@ __metadata:
   version: 3.1.6
   resolution: "minipass@npm:3.1.6"
   dependencies:
-    yallist: ^4.0.0
+    yallist: "npm:^4.0.0"
   checksum: 65c3007875602b0ed0e1ab11a284b8aea80cd7c3757a8db75ca3850bd1cd728bec1c87bb03fe35355aecd61e08de4875d7a81c654372ec0b50c29e13f2c3b924
   languageName: node
   linkType: hard
@@ -9270,8 +9163,8 @@ __metadata:
   version: 2.1.2
   resolution: "minizlib@npm:2.1.2"
   dependencies:
-    minipass: ^3.0.0
-    yallist: ^4.0.0
+    minipass: "npm:^3.0.0"
+    yallist: "npm:^4.0.0"
   checksum: 64fae024e1a7d0346a1102bb670085b17b7f95bf6cfdf5b128772ec8faf9ea211464ea4add406a3a6384a7d87a0cd1a96263692134323477b4fb43659a6cab78
   languageName: node
   linkType: hard
@@ -9280,8 +9173,8 @@ __metadata:
   version: 1.3.2
   resolution: "mixin-deep@npm:1.3.2"
   dependencies:
-    for-in: ^1.0.2
-    is-extendable: ^1.0.1
+    for-in: "npm:^1.0.2"
+    is-extendable: "npm:^1.0.1"
   checksum: cb39ffb73c377222391af788b4c83d1a6cecb2d9fceb7015384f8deb46e151a9b030c21ef59a79cb524d4557e3f74c7248ab948a62a6e7e296b42644863d183b
   languageName: node
   linkType: hard
@@ -9290,7 +9183,7 @@ __metadata:
   version: 0.5.1
   resolution: "mkdirp@npm:0.5.1"
   dependencies:
-    minimist: 0.0.8
+    minimist: "npm:0.0.8"
   bin:
     mkdirp: bin/cmd.js
   checksum: e5ff572d761240a06dbfc69e1ea303d5482815a1f66033b999bd9d78583fcdc9ef63e99e61d396bbd57eca45b388af80a7f7f35f63510619c991c9d44c75341c
@@ -9301,7 +9194,7 @@ __metadata:
   version: 0.5.5
   resolution: "mkdirp@npm:0.5.5"
   dependencies:
-    minimist: ^1.2.5
+    minimist: "npm:^1.2.5"
   bin:
     mkdirp: bin/cmd.js
   checksum: 4469faeeba703bc46b7cdbe3097d6373747a581eb8b556ce41c8fd25a826eb3254466c6522ba823c2edb0b6f0da7beb91cf71f040bc4e361534a3e67f0994bd0
@@ -9321,30 +9214,30 @@ __metadata:
   version: 9.2.0
   resolution: "mocha@npm:9.2.0"
   dependencies:
-    "@ungap/promise-all-settled": 1.1.2
-    ansi-colors: 4.1.1
-    browser-stdout: 1.3.1
-    chokidar: 3.5.3
-    debug: 4.3.3
-    diff: 5.0.0
-    escape-string-regexp: 4.0.0
-    find-up: 5.0.0
-    glob: 7.2.0
-    growl: 1.10.5
-    he: 1.2.0
-    js-yaml: 4.1.0
-    log-symbols: 4.1.0
-    minimatch: 3.0.4
-    ms: 2.1.3
-    nanoid: 3.2.0
-    serialize-javascript: 6.0.0
-    strip-json-comments: 3.1.1
-    supports-color: 8.1.1
-    which: 2.0.2
-    workerpool: 6.2.0
-    yargs: 16.2.0
-    yargs-parser: 20.2.4
-    yargs-unparser: 2.0.0
+    "@ungap/promise-all-settled": "npm:1.1.2"
+    ansi-colors: "npm:4.1.1"
+    browser-stdout: "npm:1.3.1"
+    chokidar: "npm:3.5.3"
+    debug: "npm:4.3.3"
+    diff: "npm:5.0.0"
+    escape-string-regexp: "npm:4.0.0"
+    find-up: "npm:5.0.0"
+    glob: "npm:7.2.0"
+    growl: "npm:1.10.5"
+    he: "npm:1.2.0"
+    js-yaml: "npm:4.1.0"
+    log-symbols: "npm:4.1.0"
+    minimatch: "npm:3.0.4"
+    ms: "npm:2.1.3"
+    nanoid: "npm:3.2.0"
+    serialize-javascript: "npm:6.0.0"
+    strip-json-comments: "npm:3.1.1"
+    supports-color: "npm:8.1.1"
+    which: "npm:2.0.2"
+    workerpool: "npm:6.2.0"
+    yargs: "npm:16.2.0"
+    yargs-parser: "npm:20.2.4"
+    yargs-unparser: "npm:2.0.0"
   bin:
     _mocha: bin/_mocha
     mocha: bin/mocha
@@ -9356,84 +9249,83 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "mochapack@workspace:."
   dependencies:
-    "@babel/cli": ^7.0.0
-    "@babel/core": ^7.0.0
-    "@babel/plugin-proposal-class-properties": ^7.0.0
-    "@babel/plugin-proposal-decorators": ^7.0.0
-    "@babel/plugin-proposal-object-rest-spread": ^7.0.0
-    "@babel/plugin-transform-runtime": ^7.0.0
-    "@babel/preset-env": ^7.0.0
-    "@babel/preset-typescript": ^7.7.4
-    "@babel/register": ^7.0.0
-    "@babel/runtime": ^7.7.6
-    "@babel/runtime-corejs2": ^7.0.0
-    "@types/chai": ^4.2.7
-    "@types/lodash": ^4.14.149
-    "@types/mocha": ^9.1.0
-    "@types/node": ^12.12.17
-    "@types/sinon": ^9.0.0
-    "@types/sinon-chai": ^3.2.4
-    "@types/yargs": ^15.0.4
-    "@typescript-eslint/eslint-plugin": ^2.11.0
-    "@typescript-eslint/parser": ^2.11.0
-    anymatch: 3.1.1
-    assert: ^2.0.0
-    babel-eslint: ^9.0.0
-    babel-loader: ^8.0.0
-    babel-plugin-istanbul: 4.1.6
-    babel-plugin-lodash: ^3.2.10
-    bash-color: 0.0.4
-    bdd-lazy-var: ^2.5.0
-    chai: ^4.1.0
-    chalk: ^2.4.2
-    chokidar: ^3.5.2
-    coffee-script: ^1.11.1
-    commander: 2.11.0
-    cross-env: 6.0.3
-    css-loader: ^5.0.1
-    del: 5.1.0
-    del-cli: 3.0.0
-    eslint: ^6.7.2
-    eslint-config-airbnb-base: ^14.2.1
-    eslint-config-prettier: ^6.7.0
-    eslint-plugin-import: ^2.24.2
-    fs-extra: 5.0.0
-    gh-pages: 1.2.0
-    gitbook: 3.2.2
-    gitbook-plugin-anchors: ^0.7.1
-    gitbook-plugin-edit-link: ^2.0.2
-    gitbook-plugin-github: ^2.0.0
-    gitbook-plugin-prism: ^2.0.0
-    glob: 7.1.4
-    glob-parent: 5.1.2
-    globby: ^10.0.1
-    interpret: ^1.2.0
-    is-glob: ^4.0.1
-    loader-utils: ^1.2.3
-    lodash: ^4.17.15
-    memory-fs: ^0.4.1
-    minimatch: ^3.0.4
-    mocha: 9.2.0
-    node-sass: ^4.11.0
-    nodent-runtime: ^3.2.1
-    normalize-path: ^3.0.0
-    np: 5.1.0
-    nyc: 14.1.1
-    optimist: 0.6.1
-    prettier: ^1.19.1
-    progress: ^2.0.3
-    sass-loader: ^10.1.0
-    sinon: ^9.0.2
-    sinon-chai: ^3.5.0
-    source-map-support: ^0.5.13
-    strip-ansi: ^5.2.0
-    tiny-worker: 2.3.0
-    toposort: ^2.0.2
-    ts-mocha: ^7.0.0
-    typescript: ^3.8.3
-    webpack: 5.0.0
-    worker-loader: ^3.0.5
-    yargs: 14.0.0
+    "@babel/cli": "npm:^7.0.0"
+    "@babel/core": "npm:^7.0.0"
+    "@babel/plugin-proposal-class-properties": "npm:^7.0.0"
+    "@babel/plugin-proposal-decorators": "npm:^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread": "npm:^7.0.0"
+    "@babel/plugin-transform-runtime": "npm:^7.0.0"
+    "@babel/preset-env": "npm:^7.0.0"
+    "@babel/preset-typescript": "npm:^7.7.4"
+    "@babel/register": "npm:^7.0.0"
+    "@babel/runtime": "npm:^7.7.6"
+    "@babel/runtime-corejs2": "npm:^7.0.0"
+    "@types/chai": "npm:^4.2.7"
+    "@types/lodash": "npm:^4.14.149"
+    "@types/mocha": "npm:^9.1.0"
+    "@types/node": "npm:^12.12.17"
+    "@types/sinon": "npm:^9.0.0"
+    "@types/sinon-chai": "npm:^3.2.4"
+    "@types/yargs": "npm:^15.0.4"
+    "@typescript-eslint/eslint-plugin": "npm:^2.11.0"
+    "@typescript-eslint/parser": "npm:^2.11.0"
+    anymatch: "npm:3.1.1"
+    assert: "npm:^2.0.0"
+    babel-eslint: "npm:^9.0.0"
+    babel-loader: "npm:^8.0.0"
+    babel-plugin-istanbul: "npm:4.1.6"
+    babel-plugin-lodash: "npm:^3.2.10"
+    bash-color: "npm:0.0.4"
+    bdd-lazy-var: "npm:^2.5.0"
+    chai: "npm:^4.1.0"
+    chalk: "npm:^2.4.2"
+    chokidar: "npm:^3.5.2"
+    coffee-script: "npm:^1.11.1"
+    commander: "npm:2.11.0"
+    cross-env: "npm:6.0.3"
+    css-loader: "npm:^5.0.1"
+    del: "npm:5.1.0"
+    del-cli: "npm:3.0.0"
+    eslint: "npm:^6.7.2"
+    eslint-config-airbnb-base: "npm:^14.2.1"
+    eslint-config-prettier: "npm:^6.7.0"
+    eslint-plugin-import: "npm:^2.24.2"
+    fs-extra: "npm:5.0.0"
+    gh-pages: "npm:1.2.0"
+    gitbook: "npm:3.2.2"
+    gitbook-plugin-anchors: "npm:^0.7.1"
+    gitbook-plugin-edit-link: "npm:^2.0.2"
+    gitbook-plugin-github: "npm:^2.0.0"
+    gitbook-plugin-prism: "npm:^2.0.0"
+    glob: "npm:7.1.4"
+    glob-parent: "npm:5.1.2"
+    globby: "npm:^10.0.1"
+    interpret: "npm:^1.2.0"
+    is-glob: "npm:^4.0.1"
+    loader-utils: "npm:^1.2.3"
+    lodash: "npm:^4.17.15"
+    memory-fs: "npm:^0.4.1"
+    minimatch: "npm:^3.0.4"
+    mocha: "npm:9.2.0"
+    nodent-runtime: "npm:^3.2.1"
+    normalize-path: "npm:^3.0.0"
+    np: "npm:5.1.0"
+    nyc: "npm:14.1.1"
+    optimist: "npm:0.6.1"
+    prettier: "npm:^1.19.1"
+    progress: "npm:^2.0.3"
+    sass-loader: "npm:^10.1.0"
+    sinon: "npm:^9.0.2"
+    sinon-chai: "npm:^3.5.0"
+    source-map-support: "npm:^0.5.13"
+    strip-ansi: "npm:^5.2.0"
+    tiny-worker: "npm:2.3.0"
+    toposort: "npm:^2.0.2"
+    ts-mocha: "npm:^7.0.0"
+    typescript: "npm:^3.8.3"
+    webpack: "npm:5.0.0"
+    worker-loader: "npm:^3.0.5"
+    yargs: "npm:14.0.0"
   peerDependencies:
     mocha: ">=6"
     webpack: ^4.0.0 || ^5.0.0
@@ -9491,11 +9383,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.12.1, nan@npm:^2.13.2":
+"nan@npm:^2.12.1":
   version: 2.15.0
   resolution: "nan@npm:2.15.0"
   dependencies:
-    node-gyp: latest
+    node-gyp: "npm:latest"
   checksum: 797924e8dd64c32d571f322f998d5aa5a732012a23315976456017ea37515b21a808020995d7f48b716476b7e9a6a1ba9cce43bee30399016b9ac7257454ea04
   languageName: node
   linkType: hard
@@ -9513,17 +9405,17 @@ __metadata:
   version: 1.2.13
   resolution: "nanomatch@npm:1.2.13"
   dependencies:
-    arr-diff: ^4.0.0
-    array-unique: ^0.3.2
-    define-property: ^2.0.2
-    extend-shallow: ^3.0.2
-    fragment-cache: ^0.2.1
-    is-windows: ^1.0.2
-    kind-of: ^6.0.2
-    object.pick: ^1.3.0
-    regex-not: ^1.0.0
-    snapdragon: ^0.8.1
-    to-regex: ^3.0.1
+    arr-diff: "npm:^4.0.0"
+    array-unique: "npm:^0.3.2"
+    define-property: "npm:^2.0.2"
+    extend-shallow: "npm:^3.0.2"
+    fragment-cache: "npm:^0.2.1"
+    is-windows: "npm:^1.0.2"
+    kind-of: "npm:^6.0.2"
+    object.pick: "npm:^1.3.0"
+    regex-not: "npm:^1.0.0"
+    snapdragon: "npm:^0.8.1"
+    to-regex: "npm:^3.0.1"
   checksum: 0f5cefa755ca2e20c86332821995effb24acb79551ddaf51c1b9112628cad234a0d8fd9ac6aa56ad1f8bfad6ff6ae86e851acb960943249d9fa44b091479953a
   languageName: node
   linkType: hard
@@ -9588,34 +9480,12 @@ __metadata:
   version: 4.1.0
   resolution: "nise@npm:4.1.0"
   dependencies:
-    "@sinonjs/commons": ^1.7.0
-    "@sinonjs/fake-timers": ^6.0.0
-    "@sinonjs/text-encoding": ^0.7.1
-    just-extend: ^4.0.2
-    path-to-regexp: ^1.7.0
+    "@sinonjs/commons": "npm:^1.7.0"
+    "@sinonjs/fake-timers": "npm:^6.0.0"
+    "@sinonjs/text-encoding": "npm:^0.7.1"
+    just-extend: "npm:^4.0.2"
+    path-to-regexp: "npm:^1.7.0"
   checksum: 63ddcb88bb979f7fccbb8094af9ffc8e12753665eae34367fc31bbbbf5f2c7694146a1379e89043a3ac8d30be77653ce1abbaa5f7aaeaab95d9578b714817e00
-  languageName: node
-  linkType: hard
-
-"node-gyp@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "node-gyp@npm:3.8.0"
-  dependencies:
-    fstream: ^1.0.0
-    glob: ^7.0.3
-    graceful-fs: ^4.1.2
-    mkdirp: ^0.5.0
-    nopt: 2 || 3
-    npmlog: 0 || 1 || 2 || 3 || 4
-    osenv: 0
-    request: ^2.87.0
-    rimraf: 2
-    semver: ~5.3.0
-    tar: ^2.0.0
-    which: 1
-  bin:
-    node-gyp: ./bin/node-gyp.js
-  checksum: 4774276e94c88db739b966092ddbcb8f850ba5efada8752d21ba6e6d1f65e348f3f040f6089fcd7b3062790e2dce0876a486eb9ce785e460e9f5bcc6a2249bb4
   languageName: node
   linkType: hard
 
@@ -9623,16 +9493,16 @@ __metadata:
   version: 8.4.1
   resolution: "node-gyp@npm:8.4.1"
   dependencies:
-    env-paths: ^2.2.0
-    glob: ^7.1.4
-    graceful-fs: ^4.2.6
-    make-fetch-happen: ^9.1.0
-    nopt: ^5.0.0
-    npmlog: ^6.0.0
-    rimraf: ^3.0.2
-    semver: ^7.3.5
-    tar: ^6.1.2
-    which: ^2.0.2
+    env-paths: "npm:^2.2.0"
+    glob: "npm:^7.1.4"
+    graceful-fs: "npm:^4.2.6"
+    make-fetch-happen: "npm:^9.1.0"
+    nopt: "npm:^5.0.0"
+    npmlog: "npm:^6.0.0"
+    rimraf: "npm:^3.0.2"
+    semver: "npm:^7.3.5"
+    tar: "npm:^6.1.2"
+    which: "npm:^2.0.2"
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 80ef333b3a882eb6a2695a8e08f31d618f4533eff192864e4a3a16b67ff0abc9d8c1d5fac0395550ec699326b9248c5e2b3be178492f7f4d1ccf97d2cf948021
@@ -9643,20 +9513,20 @@ __metadata:
   version: 3.3.1
   resolution: "node-gyp@npm:3.3.1"
   dependencies:
-    fstream: ^1.0.0
-    glob: 3 || 4
-    graceful-fs: ^4.1.2
-    minimatch: 1
-    mkdirp: ^0.5.0
-    nopt: 2 || 3
-    npmlog: 0 || 1 || 2
-    osenv: 0
-    path-array: ^1.0.0
-    request: 2
-    rimraf: 2
-    semver: 2.x || 3.x || 4 || 5
-    tar: ^2.0.0
-    which: 1
+    fstream: "npm:^1.0.0"
+    glob: "npm:3 || 4"
+    graceful-fs: "npm:^4.1.2"
+    minimatch: "npm:1"
+    mkdirp: "npm:^0.5.0"
+    nopt: "npm:2 || 3"
+    npmlog: "npm:0 || 1 || 2"
+    osenv: "npm:0"
+    path-array: "npm:^1.0.0"
+    request: "npm:2"
+    rimraf: "npm:2"
+    semver: "npm:2.x || 3.x || 4 || 5"
+    tar: "npm:^2.0.0"
+    which: "npm:1"
   bin:
     node-gyp: ./bin/node-gyp.js
   checksum: 1a2ced5354148e8a092d65a12e9f8222f56fca5a3d1c78768cc330c12c35723880c1d0156b17575505ef18c1cdf15baf729ff840059ce87a8eafcf694479fad9
@@ -9667,20 +9537,20 @@ __metadata:
   version: 3.4.0
   resolution: "node-gyp@npm:3.4.0"
   dependencies:
-    fstream: ^1.0.0
-    glob: ^7.0.3
-    graceful-fs: ^4.1.2
-    minimatch: ^3.0.2
-    mkdirp: ^0.5.0
-    nopt: 2 || 3
-    npmlog: 0 || 1 || 2 || 3
-    osenv: 0
-    path-array: ^1.0.0
-    request: 2
-    rimraf: 2
-    semver: 2.x || 3.x || 4 || 5
-    tar: ^2.0.0
-    which: 1
+    fstream: "npm:^1.0.0"
+    glob: "npm:^7.0.3"
+    graceful-fs: "npm:^4.1.2"
+    minimatch: "npm:^3.0.2"
+    mkdirp: "npm:^0.5.0"
+    nopt: "npm:2 || 3"
+    npmlog: "npm:0 || 1 || 2 || 3"
+    osenv: "npm:0"
+    path-array: "npm:^1.0.0"
+    request: "npm:2"
+    rimraf: "npm:2"
+    semver: "npm:2.x || 3.x || 4 || 5"
+    tar: "npm:^2.0.0"
+    which: "npm:1"
   bin:
     node-gyp: ./bin/node-gyp.js
   checksum: 6c4fa7d8e6b6d78fe5805588a4dcfb46682d511758adbef11b7de5795644292e249f888514d7e571212f0038e9665cc60159a55ce01965a8f31e749188388261
@@ -9691,33 +9561,6 @@ __metadata:
   version: 2.0.1
   resolution: "node-releases@npm:2.0.1"
   checksum: cb6c373458422e584b46ce18d7b5c95590fe1f31a9ec4833d3f557aff8c99a64be331cbb94ddee473f40ff17d52a907939c3f234a537da35967c58585c9ee09e
-  languageName: node
-  linkType: hard
-
-"node-sass@npm:^4.11.0":
-  version: 4.14.1
-  resolution: "node-sass@npm:4.14.1"
-  dependencies:
-    async-foreach: ^0.1.3
-    chalk: ^1.1.1
-    cross-spawn: ^3.0.0
-    gaze: ^1.0.0
-    get-stdin: ^4.0.1
-    glob: ^7.0.3
-    in-publish: ^2.0.0
-    lodash: ^4.17.15
-    meow: ^3.7.0
-    mkdirp: ^0.5.1
-    nan: ^2.13.2
-    node-gyp: ^3.8.0
-    npmlog: ^4.0.0
-    request: ^2.88.0
-    sass-graph: 2.2.5
-    stdout-stream: ^1.4.0
-    true-case-path: ^1.0.2
-  bin:
-    node-sass: bin/node-sass
-  checksum: dce6c80114fe8b06cd7aaa52a6a15869216d2d64e794b7ac077ad3eb705e6009fdbe5c0125800dab778bd05f12759f18a41be24e84779b82b501a17c2630dc18
   languageName: node
   linkType: hard
 
@@ -9734,8 +9577,8 @@ __metadata:
   version: 1.0.8
   resolution: "node.extend@npm:1.0.8"
   dependencies:
-    is: ~0.2.6
-    object-keys: ~0.4.0
+    is: "npm:~0.2.6"
+    object-keys: "npm:~0.4.0"
   checksum: f21d9bac67ecbb647fb6fd1214d42cb8d4fe6768e2bb847a76cfe3c662eaaac93badfaa267243cdca22a93a47f78337cab30d9befa52b72686360c7c606cab42
   languageName: node
   linkType: hard
@@ -9744,7 +9587,7 @@ __metadata:
   version: 1.2.3
   resolution: "node.flow@npm:1.2.3"
   dependencies:
-    node.extend: 1.0.8
+    node.extend: "npm:1.0.8"
   checksum: 6b430abd302fc32f95367e320669e31b1b78624d829a2a7d3f68feeb802b142da603801881cbb79b0866448c5f5c31652276cc4f1c3cef4b85ce35b8116f817f
   languageName: node
   linkType: hard
@@ -9760,7 +9603,7 @@ __metadata:
   version: 3.0.6
   resolution: "nopt@npm:3.0.6"
   dependencies:
-    abbrev: 1
+    abbrev: "npm:1"
   bin:
     nopt: ./bin/nopt.js
   checksum: f4414223c392dd215910942268d9bdc101ab876400f2c0626b88b718254f5c730dbab5eda58519dc4ea05b681ed8f09c147570ed273ade7fc07757e2e4f12c3d
@@ -9771,7 +9614,7 @@ __metadata:
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
   dependencies:
-    abbrev: 1
+    abbrev: "npm:1"
   bin:
     nopt: bin/nopt.js
   checksum: fc5c4f07155cb455bf5fc3dd149fac421c1a40fd83c6bfe83aa82b52f02c17c5e88301321318adaa27611c8a6811423d51d29deaceab5fa158b585a61a551061
@@ -9789,10 +9632,10 @@ __metadata:
   version: 2.5.0
   resolution: "normalize-package-data@npm:2.5.0"
   dependencies:
-    hosted-git-info: ^2.1.4
-    resolve: ^1.10.0
-    semver: 2 || 3 || 4 || 5
-    validate-npm-package-license: ^3.0.1
+    hosted-git-info: "npm:^2.1.4"
+    resolve: "npm:^1.10.0"
+    semver: "npm:2 || 3 || 4 || 5"
+    validate-npm-package-license: "npm:^3.0.1"
   checksum: 357cb1646deb42f8eb4c7d42c4edf0eec312f3628c2ef98501963cc4bbe7277021b2b1d977f982b2edce78f5a1014613ce9cf38085c3df2d76730481357ca504
   languageName: node
   linkType: hard
@@ -9801,10 +9644,10 @@ __metadata:
   version: 2.3.8
   resolution: "normalize-package-data@npm:2.3.8"
   dependencies:
-    hosted-git-info: ^2.1.4
-    is-builtin-module: ^1.0.0
-    semver: 2 || 3 || 4 || 5
-    validate-npm-package-license: ^3.0.1
+    hosted-git-info: "npm:^2.1.4"
+    is-builtin-module: "npm:^1.0.0"
+    semver: "npm:2 || 3 || 4 || 5"
+    validate-npm-package-license: "npm:^3.0.1"
   checksum: aca3c1a21c03da9e42f3bb13a58a8795b5af94d315fd484479a3679fd3a8b6ce9b9c4db1649cdf706c24cbd23b80a04f7066eba685919573325d9b652bb9759f
   languageName: node
   linkType: hard
@@ -9813,7 +9656,7 @@ __metadata:
   version: 2.1.1
   resolution: "normalize-path@npm:2.1.1"
   dependencies:
-    remove-trailing-separator: ^1.0.1
+    remove-trailing-separator: "npm:^1.0.1"
   checksum: db814326ff88057437233361b4c7e9cac7b54815b051b57f2d341ce89b1d8ec8cbd43e7fa95d7652b3b69ea8fcc294b89b8530d556a84d1bdace94229e1e9a8b
   languageName: node
   linkType: hard
@@ -9829,10 +9672,10 @@ __metadata:
   version: 1.9.1
   resolution: "normalize-url@npm:1.9.1"
   dependencies:
-    object-assign: ^4.0.1
-    prepend-http: ^1.0.0
-    query-string: ^4.1.0
-    sort-keys: ^1.0.0
+    object-assign: "npm:^4.0.1"
+    prepend-http: "npm:^1.0.0"
+    query-string: "npm:^4.1.0"
+    sort-keys: "npm:^1.0.0"
   checksum: 5ecd525f743c3fb5370d2bab8e78446f3e3bd7c0c97a5fd3f0bc0c5f396fbd117d13c9118766128d25ed575755cb539dc33a38419f18ca9d8577c8d1cd7a8daf
   languageName: node
   linkType: hard
@@ -9848,39 +9691,39 @@ __metadata:
   version: 5.1.0
   resolution: "np@npm:5.1.0"
   dependencies:
-    "@samverschueren/stream-to-observable": ^0.3.0
-    any-observable: ^0.4.0
-    async-exit-hook: ^2.0.1
-    chalk: ^2.3.0
-    cosmiconfig: ^5.2.1
-    del: ^4.1.0
-    escape-string-regexp: ^2.0.0
-    execa: ^2.0.1
-    github-url-from-git: ^1.5.0
-    has-yarn: ^2.1.0
-    hosted-git-info: ^3.0.0
-    inquirer: ^7.0.0
-    is-installed-globally: ^0.2.0
-    is-scoped: ^2.1.0
-    issue-regex: ^2.0.0
-    listr: ^0.14.3
-    listr-input: ^0.1.3
-    log-symbols: ^3.0.0
-    meow: ^5.0.0
-    npm-name: ^5.4.0
-    onetime: ^5.1.0
-    open: ^6.1.0
-    ow: ^0.13.2
-    p-memoize: ^3.1.0
-    p-timeout: ^3.1.0
-    pkg-dir: ^4.1.0
-    read-pkg-up: ^6.0.0
-    rxjs: ^6.3.3
-    semver: ^6.1.2
-    split: ^1.0.0
-    symbol-observable: ^1.2.0
-    terminal-link: ^2.0.0
-    update-notifier: ^3.0.0
+    "@samverschueren/stream-to-observable": "npm:^0.3.0"
+    any-observable: "npm:^0.4.0"
+    async-exit-hook: "npm:^2.0.1"
+    chalk: "npm:^2.3.0"
+    cosmiconfig: "npm:^5.2.1"
+    del: "npm:^4.1.0"
+    escape-string-regexp: "npm:^2.0.0"
+    execa: "npm:^2.0.1"
+    github-url-from-git: "npm:^1.5.0"
+    has-yarn: "npm:^2.1.0"
+    hosted-git-info: "npm:^3.0.0"
+    inquirer: "npm:^7.0.0"
+    is-installed-globally: "npm:^0.2.0"
+    is-scoped: "npm:^2.1.0"
+    issue-regex: "npm:^2.0.0"
+    listr: "npm:^0.14.3"
+    listr-input: "npm:^0.1.3"
+    log-symbols: "npm:^3.0.0"
+    meow: "npm:^5.0.0"
+    npm-name: "npm:^5.4.0"
+    onetime: "npm:^5.1.0"
+    open: "npm:^6.1.0"
+    ow: "npm:^0.13.2"
+    p-memoize: "npm:^3.1.0"
+    p-timeout: "npm:^3.1.0"
+    pkg-dir: "npm:^4.1.0"
+    read-pkg-up: "npm:^6.0.0"
+    rxjs: "npm:^6.3.3"
+    semver: "npm:^6.1.2"
+    split: "npm:^1.0.0"
+    symbol-observable: "npm:^1.2.0"
+    terminal-link: "npm:^2.0.0"
+    update-notifier: "npm:^3.0.0"
   bin:
     np: source/cli.js
   checksum: a9537960164246111cd52c0838be1c9a61889024a44700d3527068bd2f4348f2cf3e94266ca58ca3f677196cc1937f894fbc9353f04adf58d666ad65eee5a05c
@@ -9898,7 +9741,7 @@ __metadata:
   version: 3.0.2
   resolution: "npm-install-checks@npm:3.0.2"
   dependencies:
-    semver: ^2.3.0 || 3.x || 4 || 5
+    semver: "npm:^2.3.0 || 3.x || 4 || 5"
   checksum: 823c7ce77fce10bf43d0af6473dc4116aee60700203047f9959bceadd69274fe8ebbe9c6e635e558dcec6a169fdb7881cc854e87dcfc1a9c2c162efa1e7ec056
   languageName: node
   linkType: hard
@@ -9907,13 +9750,13 @@ __metadata:
   version: 5.5.0
   resolution: "npm-name@npm:5.5.0"
   dependencies:
-    got: ^9.6.0
-    is-scoped: ^2.1.0
-    is-url-superb: ^3.0.0
-    lodash.zip: ^4.2.0
-    registry-auth-token: ^4.0.0
-    registry-url: ^5.1.0
-    validate-npm-package-name: ^3.0.0
+    got: "npm:^9.6.0"
+    is-scoped: "npm:^2.1.0"
+    is-url-superb: "npm:^3.0.0"
+    lodash.zip: "npm:^4.2.0"
+    registry-auth-token: "npm:^4.0.0"
+    registry-url: "npm:^5.1.0"
+    validate-npm-package-name: "npm:^3.0.0"
   checksum: 11b85216ee874d22f4f6820a3de0014e2c17722402362f04e46a28a6971ecf44e5bc7e72db9d5727e58b074eaaa9695651a3fd54fec32c3e44bc1107d480cb9b
   languageName: node
   linkType: hard
@@ -9929,8 +9772,8 @@ __metadata:
   version: 4.2.1
   resolution: "npm-package-arg@npm:4.2.1"
   dependencies:
-    hosted-git-info: ^2.1.5
-    semver: ^5.1.0
+    hosted-git-info: "npm:^2.1.5"
+    semver: "npm:^5.1.0"
   checksum: 7d40b51ab4da8c4f8ec71e01036ce8e67712b40dce2672fd9927fb53361eb2f7f597359583150d9c5431a94ca8ed97d4b3e905e3a609f9a21f4252960030395d
   languageName: node
   linkType: hard
@@ -9939,10 +9782,10 @@ __metadata:
   version: 5.1.2
   resolution: "npm-package-arg@npm:5.1.2"
   dependencies:
-    hosted-git-info: ^2.4.2
-    osenv: ^0.1.4
-    semver: ^5.1.0
-    validate-npm-package-name: ^3.0.0
+    hosted-git-info: "npm:^2.4.2"
+    osenv: "npm:^0.1.4"
+    semver: "npm:^5.1.0"
+    validate-npm-package-name: "npm:^3.0.0"
   checksum: 4a9deff79cc2ccd844ae3d645a1f192506d12984f4c24010eae78774c5fca5ca2ad4594a41c3a55f3759258bd8e750418b88a5e5fcc6dc20af213b34cd057a0e
   languageName: node
   linkType: hard
@@ -9951,8 +9794,8 @@ __metadata:
   version: 4.1.1
   resolution: "npm-package-arg@npm:4.1.1"
   dependencies:
-    hosted-git-info: ^2.1.4
-    semver: 4 || 5
+    hosted-git-info: "npm:^2.1.4"
+    semver: "npm:4 || 5"
   checksum: 33a158ae82b5ffbb5ec18af412a434d2c9380581daac4eca865cb76151b3cafa5d914e8154765d590154b7a89254eae978437594e93f4d76c46b7121e69600b0
   languageName: node
   linkType: hard
@@ -9961,19 +9804,19 @@ __metadata:
   version: 7.1.2
   resolution: "npm-registry-client@npm:7.1.2"
   dependencies:
-    chownr: ^1.0.1
-    concat-stream: ^1.4.6
-    graceful-fs: ^4.1.2
-    mkdirp: ^0.5.0
-    normalize-package-data: ~1.0.1 || ^2.0.0
-    npm-package-arg: ^3.0.0 || ^4.0.0
-    npmlog: ~2.0.0 || ~3.1.0
-    once: ^1.3.0
-    request: ^2.47.0
-    retry: ^0.8.0
-    rimraf: 2
-    semver: 2 >=2.2.1 || 3.x || 4 || 5
-    slide: ^1.1.3
+    chownr: "npm:^1.0.1"
+    concat-stream: "npm:^1.4.6"
+    graceful-fs: "npm:^4.1.2"
+    mkdirp: "npm:^0.5.0"
+    normalize-package-data: "npm:~1.0.1 || ^2.0.0"
+    npm-package-arg: "npm:^3.0.0 || ^4.0.0"
+    npmlog: "npm:~2.0.0 || ~3.1.0"
+    once: "npm:^1.3.0"
+    request: "npm:^2.47.0"
+    retry: "npm:^0.8.0"
+    rimraf: "npm:2"
+    semver: "npm:2 >=2.2.1 || 3.x || 4 || 5"
+    slide: "npm:^1.1.3"
   dependenciesMeta:
     npmlog:
       optional: true
@@ -9985,16 +9828,16 @@ __metadata:
   version: 7.2.1
   resolution: "npm-registry-client@npm:7.2.1"
   dependencies:
-    concat-stream: ^1.5.2
-    graceful-fs: ^4.1.6
-    normalize-package-data: ~1.0.1 || ^2.0.0
-    npm-package-arg: ^3.0.0 || ^4.0.0
-    npmlog: ~2.0.0 || ~3.1.0
-    once: ^1.3.3
-    request: ^2.74.0
-    retry: ^0.10.0
-    semver: 2 >=2.2.1 || 3.x || 4 || 5
-    slide: ^1.1.3
+    concat-stream: "npm:^1.5.2"
+    graceful-fs: "npm:^4.1.6"
+    normalize-package-data: "npm:~1.0.1 || ^2.0.0"
+    npm-package-arg: "npm:^3.0.0 || ^4.0.0"
+    npmlog: "npm:~2.0.0 || ~3.1.0"
+    once: "npm:^1.3.3"
+    request: "npm:^2.74.0"
+    retry: "npm:^0.10.0"
+    semver: "npm:2 >=2.2.1 || 3.x || 4 || 5"
+    slide: "npm:^1.1.3"
   dependenciesMeta:
     npmlog:
       optional: true
@@ -10006,7 +9849,7 @@ __metadata:
   version: 2.0.2
   resolution: "npm-run-path@npm:2.0.2"
   dependencies:
-    path-key: ^2.0.0
+    path-key: "npm:^2.0.0"
   checksum: 95549a477886f48346568c97b08c4fda9cdbf7ce8a4fbc2213f36896d0d19249e32d68d7451bdcbca8041b5fba04a6b2c4a618beaf19849505c05b700740f1de
   languageName: node
   linkType: hard
@@ -10015,7 +9858,7 @@ __metadata:
   version: 3.1.0
   resolution: "npm-run-path@npm:3.1.0"
   dependencies:
-    path-key: ^3.0.0
+    path-key: "npm:^3.0.0"
   checksum: 8399f01239e9a5bf5a10bddbc71ecac97e0b7890e5b78abe9731fc759db48865b0686cc86ec079cd254a98ba119a3fa08f1b23f9de1a5428c19007bbc7b5a728
   languageName: node
   linkType: hard
@@ -10031,89 +9874,89 @@ __metadata:
   version: 3.9.2
   resolution: "npm@npm:3.9.2"
   dependencies:
-    abbrev: ~1.0.7
-    ansi-regex: "*"
-    ansicolors: ~0.3.2
-    ansistyles: ~0.1.3
-    aproba: ~1.0.1
-    archy: ~1.0.0
-    chownr: ~1.0.1
-    cmd-shim: ~2.0.2
-    columnify: ~1.5.4
-    config-chain: ~1.1.10
-    debuglog: "*"
-    dezalgo: ~1.0.3
-    editor: ~1.0.0
-    fs-vacuum: ~1.2.9
-    fs-write-stream-atomic: ~1.0.8
-    fstream: ~1.0.8
-    fstream-npm: ~1.0.7
-    glob: ~7.0.3
-    graceful-fs: ~4.1.4
-    has-unicode: ~2.0.0
-    hosted-git-info: ~2.1.4
-    iferr: ~0.1.5
-    imurmurhash: "*"
-    inflight: ~1.0.4
-    inherits: ~2.0.1
-    ini: ~1.3.4
-    init-package-json: ~1.9.3
-    lockfile: ~1.0.1
-    lodash._baseindexof: "*"
-    lodash._baseuniq: ~4.6.0
-    lodash._bindcallback: "*"
-    lodash._cacheindexof: "*"
-    lodash._createcache: "*"
-    lodash._getnative: "*"
-    lodash.clonedeep: ~4.3.2
-    lodash.isarray: ~4.0.0
-    lodash.keys: ~4.0.7
-    lodash.restparam: "*"
-    lodash.union: ~4.4.0
-    lodash.uniq: ~4.3.0
-    lodash.without: ~4.2.0
-    mkdirp: ~0.5.1
-    node-gyp: ~3.3.1
-    nopt: ~3.0.6
-    normalize-git-url: ~3.0.2
-    normalize-package-data: ~2.3.5
-    npm-cache-filename: ~1.0.2
-    npm-install-checks: ~3.0.0
-    npm-package-arg: ~4.1.1
-    npm-registry-client: ~7.1.0
-    npm-user-validate: ~0.1.2
-    npmlog: ~2.0.3
-    once: ~1.3.3
-    opener: ~1.4.1
-    osenv: ~0.1.3
-    path-is-inside: ~1.0.1
-    read: ~1.0.7
-    read-cmd-shim: ~1.0.1
-    read-installed: ~4.0.3
-    read-package-json: ~2.0.4
-    read-package-tree: ~5.1.2
-    readable-stream: ~2.1.2
-    readdir-scoped-modules: "*"
-    realize-package-specifier: ~3.0.3
-    request: ~2.72.0
-    retry: ~0.9.0
-    rimraf: ~2.5.2
-    semver: ~5.1.0
-    sha: ~2.0.1
-    slide: ~1.1.6
-    sorted-object: ~2.0.0
-    strip-ansi: ~3.0.1
-    tar: ~2.2.1
-    text-table: ~0.2.0
-    uid-number: 0.0.6
-    umask: ~1.1.0
-    unique-filename: ~1.1.0
-    unpipe: ~1.0.0
-    validate-npm-package-license: "*"
-    validate-npm-package-name: ~2.2.2
-    which: ~1.2.8
-    wrappy: ~1.0.1
-    write-file-atomic: ~1.1.4
+    abbrev: "npm:~1.0.7"
+    ansi-regex: "npm:*"
+    ansicolors: "npm:~0.3.2"
+    ansistyles: "npm:~0.1.3"
+    aproba: "npm:~1.0.1"
+    archy: "npm:~1.0.0"
+    chownr: "npm:~1.0.1"
+    cmd-shim: "npm:~2.0.2"
+    columnify: "npm:~1.5.4"
+    config-chain: "npm:~1.1.10"
+    debuglog: "npm:*"
+    dezalgo: "npm:~1.0.3"
+    editor: "npm:~1.0.0"
+    fs-vacuum: "npm:~1.2.9"
+    fs-write-stream-atomic: "npm:~1.0.8"
+    fstream: "npm:~1.0.8"
+    fstream-npm: "npm:~1.0.7"
+    glob: "npm:~7.0.3"
+    graceful-fs: "npm:~4.1.4"
+    has-unicode: "npm:~2.0.0"
+    hosted-git-info: "npm:~2.1.4"
+    iferr: "npm:~0.1.5"
+    imurmurhash: "npm:*"
+    inflight: "npm:~1.0.4"
+    inherits: "npm:~2.0.1"
+    ini: "npm:~1.3.4"
+    init-package-json: "npm:~1.9.3"
+    lockfile: "npm:~1.0.1"
+    lodash._baseindexof: "npm:*"
+    lodash._baseuniq: "npm:~4.6.0"
+    lodash._bindcallback: "npm:*"
+    lodash._cacheindexof: "npm:*"
+    lodash._createcache: "npm:*"
+    lodash._getnative: "npm:*"
+    lodash.clonedeep: "npm:~4.3.2"
+    lodash.isarray: "npm:~4.0.0"
+    lodash.keys: "npm:~4.0.7"
+    lodash.restparam: "npm:*"
+    lodash.union: "npm:~4.4.0"
+    lodash.uniq: "npm:~4.3.0"
+    lodash.without: "npm:~4.2.0"
+    mkdirp: "npm:~0.5.1"
+    node-gyp: "npm:~3.3.1"
+    nopt: "npm:~3.0.6"
+    normalize-git-url: "npm:~3.0.2"
+    normalize-package-data: "npm:~2.3.5"
+    npm-cache-filename: "npm:~1.0.2"
+    npm-install-checks: "npm:~3.0.0"
+    npm-package-arg: "npm:~4.1.1"
+    npm-registry-client: "npm:~7.1.0"
+    npm-user-validate: "npm:~0.1.2"
+    npmlog: "npm:~2.0.3"
+    once: "npm:~1.3.3"
+    opener: "npm:~1.4.1"
+    osenv: "npm:~0.1.3"
+    path-is-inside: "npm:~1.0.1"
+    read: "npm:~1.0.7"
+    read-cmd-shim: "npm:~1.0.1"
+    read-installed: "npm:~4.0.3"
+    read-package-json: "npm:~2.0.4"
+    read-package-tree: "npm:~5.1.2"
+    readable-stream: "npm:~2.1.2"
+    readdir-scoped-modules: "npm:*"
+    realize-package-specifier: "npm:~3.0.3"
+    request: "npm:~2.72.0"
+    retry: "npm:~0.9.0"
+    rimraf: "npm:~2.5.2"
+    semver: "npm:~5.1.0"
+    sha: "npm:~2.0.1"
+    slide: "npm:~1.1.6"
+    sorted-object: "npm:~2.0.0"
+    strip-ansi: "npm:~3.0.1"
+    tar: "npm:~2.2.1"
+    text-table: "npm:~0.2.0"
+    uid-number: "npm:0.0.6"
+    umask: "npm:~1.1.0"
+    unique-filename: "npm:~1.1.0"
+    unpipe: "npm:~1.0.0"
+    validate-npm-package-license: "npm:*"
+    validate-npm-package-name: "npm:~2.2.2"
+    which: "npm:~1.2.8"
+    wrappy: "npm:~1.0.1"
+    write-file-atomic: "npm:~1.1.4"
   bin:
     npm: ./bin/npm-cli.js
   checksum: 187fe45df6484973e4e49fe46a328f0084e445edaed3ce5b7a4ced08c38c9eab68cf5918ddf4bbb6558f19427e0b78929162dad1b98eb424f809dc815dedd98c
@@ -10124,88 +9967,88 @@ __metadata:
   version: 3.10.10
   resolution: "npm@npm:3.10.10"
   dependencies:
-    abbrev: ~1.0.9
-    ansi-regex: "*"
-    ansicolors: ~0.3.2
-    ansistyles: ~0.1.3
-    aproba: ~1.0.4
-    archy: ~1.0.0
-    asap: ~2.0.5
-    chownr: ~1.0.1
-    cmd-shim: ~2.0.2
-    columnify: ~1.5.4
-    config-chain: ~1.1.11
-    debuglog: "*"
-    dezalgo: ~1.0.3
-    editor: ~1.0.0
-    fs-vacuum: ~1.2.9
-    fs-write-stream-atomic: ~1.0.8
-    fstream: ~1.0.10
-    fstream-npm: ~1.2.0
-    glob: ~7.1.0
-    graceful-fs: ~4.1.9
-    has-unicode: ~2.0.1
-    hosted-git-info: ~2.1.5
-    iferr: ~0.1.5
-    imurmurhash: "*"
-    inflight: ~1.0.5
-    inherits: ~2.0.3
-    ini: ~1.3.4
-    init-package-json: ~1.9.4
-    lockfile: ~1.0.2
-    lodash._baseindexof: "*"
-    lodash._baseuniq: ~4.6.0
-    lodash._bindcallback: "*"
-    lodash._cacheindexof: "*"
-    lodash._createcache: "*"
-    lodash._getnative: "*"
-    lodash.clonedeep: ~4.5.0
-    lodash.restparam: "*"
-    lodash.union: ~4.6.0
-    lodash.uniq: ~4.5.0
-    lodash.without: ~4.4.0
-    mkdirp: ~0.5.1
-    node-gyp: ~3.4.0
-    nopt: ~3.0.6
-    normalize-git-url: ~3.0.2
-    normalize-package-data: ~2.3.5
-    npm-cache-filename: ~1.0.2
-    npm-install-checks: ~3.0.0
-    npm-package-arg: ~4.2.0
-    npm-registry-client: ~7.2.1
-    npm-user-validate: ~0.1.5
-    npmlog: ~4.0.0
-    once: ~1.4.0
-    opener: ~1.4.2
-    osenv: ~0.1.3
-    path-is-inside: ~1.0.2
-    read: ~1.0.7
-    read-cmd-shim: ~1.0.1
-    read-installed: ~4.0.3
-    read-package-json: ~2.0.4
-    read-package-tree: ~5.1.5
-    readable-stream: ~2.1.5
-    readdir-scoped-modules: "*"
-    realize-package-specifier: ~3.0.3
-    request: ~2.75.0
-    retry: ~0.10.0
-    rimraf: ~2.5.4
-    semver: ~5.3.0
-    sha: ~2.0.1
-    slide: ~1.1.6
-    sorted-object: ~2.0.1
-    strip-ansi: ~3.0.1
-    tar: ~2.2.1
-    text-table: ~0.2.0
-    uid-number: 0.0.6
-    umask: ~1.1.0
-    unique-filename: ~1.1.0
-    unpipe: ~1.0.0
-    validate-npm-package-license: "*"
-    validate-npm-package-name: ~2.2.2
-    which: ~1.2.11
-    wrappy: ~1.0.2
-    write-file-atomic: ~1.2.0
+    abbrev: "npm:~1.0.9"
+    ansi-regex: "npm:*"
+    ansicolors: "npm:~0.3.2"
+    ansistyles: "npm:~0.1.3"
+    aproba: "npm:~1.0.4"
+    archy: "npm:~1.0.0"
+    asap: "npm:~2.0.5"
+    chownr: "npm:~1.0.1"
+    cmd-shim: "npm:~2.0.2"
+    columnify: "npm:~1.5.4"
+    config-chain: "npm:~1.1.11"
+    debuglog: "npm:*"
+    dezalgo: "npm:~1.0.3"
+    editor: "npm:~1.0.0"
+    fs-vacuum: "npm:~1.2.9"
+    fs-write-stream-atomic: "npm:~1.0.8"
+    fstream: "npm:~1.0.10"
+    fstream-npm: "npm:~1.2.0"
+    glob: "npm:~7.1.0"
+    graceful-fs: "npm:~4.1.9"
+    has-unicode: "npm:~2.0.1"
+    hosted-git-info: "npm:~2.1.5"
+    iferr: "npm:~0.1.5"
+    imurmurhash: "npm:*"
+    inflight: "npm:~1.0.5"
+    inherits: "npm:~2.0.3"
+    ini: "npm:~1.3.4"
+    init-package-json: "npm:~1.9.4"
+    lockfile: "npm:~1.0.2"
+    lodash._baseindexof: "npm:*"
+    lodash._baseuniq: "npm:~4.6.0"
+    lodash._bindcallback: "npm:*"
+    lodash._cacheindexof: "npm:*"
+    lodash._createcache: "npm:*"
+    lodash._getnative: "npm:*"
+    lodash.clonedeep: "npm:~4.5.0"
+    lodash.restparam: "npm:*"
+    lodash.union: "npm:~4.6.0"
+    lodash.uniq: "npm:~4.5.0"
+    lodash.without: "npm:~4.4.0"
+    mkdirp: "npm:~0.5.1"
+    node-gyp: "npm:~3.4.0"
+    nopt: "npm:~3.0.6"
+    normalize-git-url: "npm:~3.0.2"
+    normalize-package-data: "npm:~2.3.5"
+    npm-cache-filename: "npm:~1.0.2"
+    npm-install-checks: "npm:~3.0.0"
+    npm-package-arg: "npm:~4.2.0"
+    npm-registry-client: "npm:~7.2.1"
+    npm-user-validate: "npm:~0.1.5"
+    npmlog: "npm:~4.0.0"
+    once: "npm:~1.4.0"
+    opener: "npm:~1.4.2"
+    osenv: "npm:~0.1.3"
+    path-is-inside: "npm:~1.0.2"
+    read: "npm:~1.0.7"
+    read-cmd-shim: "npm:~1.0.1"
+    read-installed: "npm:~4.0.3"
+    read-package-json: "npm:~2.0.4"
+    read-package-tree: "npm:~5.1.5"
+    readable-stream: "npm:~2.1.5"
+    readdir-scoped-modules: "npm:*"
+    realize-package-specifier: "npm:~3.0.3"
+    request: "npm:~2.75.0"
+    retry: "npm:~0.10.0"
+    rimraf: "npm:~2.5.4"
+    semver: "npm:~5.3.0"
+    sha: "npm:~2.0.1"
+    slide: "npm:~1.1.6"
+    sorted-object: "npm:~2.0.1"
+    strip-ansi: "npm:~3.0.1"
+    tar: "npm:~2.2.1"
+    text-table: "npm:~0.2.0"
+    uid-number: "npm:0.0.6"
+    umask: "npm:~1.1.0"
+    unique-filename: "npm:~1.1.0"
+    unpipe: "npm:~1.0.0"
+    validate-npm-package-license: "npm:*"
+    validate-npm-package-name: "npm:~2.2.2"
+    which: "npm:~1.2.11"
+    wrappy: "npm:~1.0.2"
+    write-file-atomic: "npm:~1.2.0"
   bin:
     npm: ./bin/npm-cli.js
   checksum: 75f3fea79bdd6b3f037db64768e0a7c7db1f2dedeb6ca2a17896be92d1a89223491f07075e84bb1543b948197b9b2a4f79ec5398fa813704037635da07f76a51
@@ -10216,21 +10059,9 @@ __metadata:
   version: 2.0.1
   resolution: "npmi@npm:2.0.1"
   dependencies:
-    npm: ^3
-    semver: ^4.1.0
+    npm: "npm:^3"
+    semver: "npm:^4.1.0"
   checksum: c6ee67f9073a8e3d95678aa96c73326335f67019b15ce188299ef2a0e95e6eef5bfcb7fc445577bf6f2059576ee0d1d2e8527dc67bd4ef8c4b5819f8dbd32f44
-  languageName: node
-  linkType: hard
-
-"npmlog@npm:0 || 1 || 2 || 3 || 4, npmlog@npm:^4.0.0":
-  version: 4.1.2
-  resolution: "npmlog@npm:4.1.2"
-  dependencies:
-    are-we-there-yet: ~1.1.2
-    console-control-strings: ~1.1.0
-    gauge: ~2.7.3
-    set-blocking: ~2.0.0
-  checksum: d6a26cb362277c65e24a70ebdaff31f81184ceb5415fd748abaaf26417bf0794a17ba849116e4f454a0370b9067ae320834cc78d74527dbeadf6e9d19a959046
   languageName: node
   linkType: hard
 
@@ -10238,10 +10069,10 @@ __metadata:
   version: 3.1.2
   resolution: "npmlog@npm:3.1.2"
   dependencies:
-    are-we-there-yet: ~1.1.2
-    console-control-strings: ~1.1.0
-    gauge: ~2.6.0
-    set-blocking: ~2.0.0
+    are-we-there-yet: "npm:~1.1.2"
+    console-control-strings: "npm:~1.1.0"
+    gauge: "npm:~2.6.0"
+    set-blocking: "npm:~2.0.0"
   checksum: e09b91e99fe6a73bdb583ca94cc42cd98b66460fba453210b227077f31cee4c460cfbc1205f7f89713c1ccc0daf11ce06042172585115a6388888a318dc66cee
   languageName: node
   linkType: hard
@@ -10250,9 +10081,9 @@ __metadata:
   version: 2.0.4
   resolution: "npmlog@npm:2.0.4"
   dependencies:
-    ansi: ~0.3.1
-    are-we-there-yet: ~1.1.2
-    gauge: ~1.2.5
+    ansi: "npm:~0.3.1"
+    are-we-there-yet: "npm:~1.1.2"
+    gauge: "npm:~1.2.5"
   checksum: de1e99ee06e0616d4ef54d6598657413a2037a55b0260c7c3a87192970f65dad2a54fd897d9475c6c7fc8f01883b22b96a630261cedca87ba92b547da428d330
   languageName: node
   linkType: hard
@@ -10261,10 +10092,10 @@ __metadata:
   version: 6.0.0
   resolution: "npmlog@npm:6.0.0"
   dependencies:
-    are-we-there-yet: ^2.0.0
-    console-control-strings: ^1.1.0
-    gauge: ^4.0.0
-    set-blocking: ^2.0.0
+    are-we-there-yet: "npm:^2.0.0"
+    console-control-strings: "npm:^1.1.0"
+    gauge: "npm:^4.0.0"
+    set-blocking: "npm:^2.0.0"
   checksum: e31920162392a4e55172dcac183446501fbb4d3466fd9c84cf72f6facd4dbeaea0a582d28e9f89d9294d1cdb6be1e595cf4ab6dc53f8c0986a327d666f9d6c3a
   languageName: node
   linkType: hard
@@ -10273,10 +10104,10 @@ __metadata:
   version: 4.0.2
   resolution: "npmlog@npm:4.0.2"
   dependencies:
-    are-we-there-yet: ~1.1.2
-    console-control-strings: ~1.1.0
-    gauge: ~2.7.1
-    set-blocking: ~2.0.0
+    are-we-there-yet: "npm:~1.1.2"
+    console-control-strings: "npm:~1.1.0"
+    gauge: "npm:~2.7.1"
+    set-blocking: "npm:~2.0.0"
   checksum: 186159bab08f9cb021a48ab9312dc268622fe584f8b56ac49d40749e315f7aed0149314551a40df85737b66a4bd7a54ce6cddb5caf2feae830b56718dad72e6a
   languageName: node
   linkType: hard
@@ -10285,7 +10116,7 @@ __metadata:
   version: 1.0.2
   resolution: "nth-check@npm:1.0.2"
   dependencies:
-    boolbase: ~1.0.0
+    boolbase: "npm:~1.0.0"
   checksum: 1a67ce53a99e276eea672f892d712b29f3e6802bbbef7285ffab72ecea4f972e8244defac1ebded0daffabf459def31355bb9c64e5657ac2ab032c13f185d0fd
   languageName: node
   linkType: hard
@@ -10308,9 +10139,9 @@ __metadata:
   version: 2.5.2
   resolution: "nunjucks@npm:2.5.2"
   dependencies:
-    asap: ^2.0.3
-    chokidar: ^1.6.0
-    yargs: ^3.32.0
+    asap: "npm:^2.0.3"
+    chokidar: "npm:^1.6.0"
+    yargs: "npm:^3.32.0"
   bin:
     nunjucks-precompile: ./bin/precompile
   checksum: 6a1775f1f7beb424a47bb4409bf7ae406dbb0f89a9569e52660572ed996f5ce493811bb238b0935451fe531f6c72a10133a99ef66aea0b7cb5317b6ff73b051c
@@ -10328,31 +10159,31 @@ __metadata:
   version: 14.1.1
   resolution: "nyc@npm:14.1.1"
   dependencies:
-    archy: ^1.0.0
-    caching-transform: ^3.0.2
-    convert-source-map: ^1.6.0
-    cp-file: ^6.2.0
-    find-cache-dir: ^2.1.0
-    find-up: ^3.0.0
-    foreground-child: ^1.5.6
-    glob: ^7.1.3
-    istanbul-lib-coverage: ^2.0.5
-    istanbul-lib-hook: ^2.0.7
-    istanbul-lib-instrument: ^3.3.0
-    istanbul-lib-report: ^2.0.8
-    istanbul-lib-source-maps: ^3.0.6
-    istanbul-reports: ^2.2.4
-    js-yaml: ^3.13.1
-    make-dir: ^2.1.0
-    merge-source-map: ^1.1.0
-    resolve-from: ^4.0.0
-    rimraf: ^2.6.3
-    signal-exit: ^3.0.2
-    spawn-wrap: ^1.4.2
-    test-exclude: ^5.2.3
-    uuid: ^3.3.2
-    yargs: ^13.2.2
-    yargs-parser: ^13.0.0
+    archy: "npm:^1.0.0"
+    caching-transform: "npm:^3.0.2"
+    convert-source-map: "npm:^1.6.0"
+    cp-file: "npm:^6.2.0"
+    find-cache-dir: "npm:^2.1.0"
+    find-up: "npm:^3.0.0"
+    foreground-child: "npm:^1.5.6"
+    glob: "npm:^7.1.3"
+    istanbul-lib-coverage: "npm:^2.0.5"
+    istanbul-lib-hook: "npm:^2.0.7"
+    istanbul-lib-instrument: "npm:^3.3.0"
+    istanbul-lib-report: "npm:^2.0.8"
+    istanbul-lib-source-maps: "npm:^3.0.6"
+    istanbul-reports: "npm:^2.2.4"
+    js-yaml: "npm:^3.13.1"
+    make-dir: "npm:^2.1.0"
+    merge-source-map: "npm:^1.1.0"
+    resolve-from: "npm:^4.0.0"
+    rimraf: "npm:^2.6.3"
+    signal-exit: "npm:^3.0.2"
+    spawn-wrap: "npm:^1.4.2"
+    test-exclude: "npm:^5.2.3"
+    uuid: "npm:^3.3.2"
+    yargs: "npm:^13.2.2"
+    yargs-parser: "npm:^13.0.0"
   bin:
     nyc: ./bin/nyc.js
   checksum: 4eaf0231aa5ca15d3db2e79a468d2a2abd644b5e4a48dbcff46e84262e4461accddfb6f79d36ebf53edc462b877c5a987e94d774a3ab15f321e36b3e336b408a
@@ -10384,9 +10215,9 @@ __metadata:
   version: 0.1.0
   resolution: "object-copy@npm:0.1.0"
   dependencies:
-    copy-descriptor: ^0.1.0
-    define-property: ^0.2.5
-    kind-of: ^3.0.3
+    copy-descriptor: "npm:^0.1.0"
+    define-property: "npm:^0.2.5"
+    kind-of: "npm:^3.0.3"
   checksum: 79314b05e9d626159a04f1d913f4c4aba9eae8848511cf5f4c8e3b04bb3cc313b65f60357f86462c959a14c2d58380fedf89b6b32ecec237c452a5ef3900a293
   languageName: node
   linkType: hard
@@ -10402,8 +10233,8 @@ __metadata:
   version: 1.1.5
   resolution: "object-is@npm:1.1.5"
   dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
   checksum: 8c263fb03fc28f1ffb54b44b9147235c5e233dc1ca23768e7d2569740b5d860154d7cc29a30220fe28ed6d8008e2422aefdebfe987c103e1c5d190cf02d9d886
   languageName: node
   linkType: hard
@@ -10433,7 +10264,7 @@ __metadata:
   version: 1.0.1
   resolution: "object-visit@npm:1.0.1"
   dependencies:
-    isobject: ^3.0.0
+    isobject: "npm:^3.0.0"
   checksum: 086b475bda24abd2318d2b187c3e928959b89f5cb5883d6fe5a42d03719b61fc18e765f658de9ac8730e67ba9ff26d61e73d991215948ff9ecefe771e0071029
   languageName: node
   linkType: hard
@@ -10442,10 +10273,10 @@ __metadata:
   version: 4.1.2
   resolution: "object.assign@npm:4.1.2"
   dependencies:
-    call-bind: ^1.0.0
-    define-properties: ^1.1.3
-    has-symbols: ^1.0.1
-    object-keys: ^1.1.1
+    call-bind: "npm:^1.0.0"
+    define-properties: "npm:^1.1.3"
+    has-symbols: "npm:^1.0.1"
+    object-keys: "npm:^1.1.1"
   checksum: ee0e796fad8952f05644d11632f046dc4b424f9a41d3816e11a612163b12a873c800456be9acdaec6221b72590ab5267e5fe4bf4cf1c67f88b05f82f133ac829
   languageName: node
   linkType: hard
@@ -10454,9 +10285,9 @@ __metadata:
   version: 1.1.5
   resolution: "object.entries@npm:1.1.5"
   dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.1
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.1"
   checksum: 308c07970818b0fb2b0ed92120b8fad76fb69a63c853592eac48c8437bb2385bc43f00b80d263aa2920b352c66c944018df7221099fc8e2d3bfb778566ca4ebb
   languageName: node
   linkType: hard
@@ -10465,8 +10296,8 @@ __metadata:
   version: 2.0.1
   resolution: "object.omit@npm:2.0.1"
   dependencies:
-    for-own: ^0.1.4
-    is-extendable: ^0.1.1
+    for-own: "npm:^0.1.4"
+    is-extendable: "npm:^0.1.1"
   checksum: 219549087650a1dce1990bbb9c207aa9e0c5302372cbcb363b4a7a36a7b1655a80287d290bebcaff5ae4b5ab7e5859a57f49e3f766cade65bc149fe15c0ba38d
   languageName: node
   linkType: hard
@@ -10475,7 +10306,7 @@ __metadata:
   version: 1.3.0
   resolution: "object.pick@npm:1.3.0"
   dependencies:
-    isobject: ^3.0.1
+    isobject: "npm:^3.0.1"
   checksum: cd316ec986e49895a28f2df9182de9cdeee57cd2a952c122aacc86344c28624fe002d9affc4f48b5014ec7c033da9942b08821ddb44db8c5bac5b3ec54bdc31e
   languageName: node
   linkType: hard
@@ -10484,9 +10315,9 @@ __metadata:
   version: 1.1.5
   resolution: "object.values@npm:1.1.5"
   dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.1
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.1"
   checksum: 9c6afa9a25ce36c27c8baef2321eaa719fc2b042ef17aa462b1fa1502ed7ce7acf18b269be2e7b0d91f228839f10a28fa30ebc8cb7e47dbf6a2e4e67cad466c1
   languageName: node
   linkType: hard
@@ -10495,8 +10326,8 @@ __metadata:
   version: 0.1.0
   resolution: "omit-keys@npm:0.1.0"
   dependencies:
-    array-difference: 0.0.1
-    isobject: ^0.2.0
+    array-difference: "npm:0.0.1"
+    isobject: "npm:^0.2.0"
   checksum: 448a23227a7ab094e9294926e6580751b72e842fc4fd6712c6526bc1e2eb80e511cc5644a52f7dc6957a4ab8d72523a419e174e2446aa8f4274f3053fceee425
   languageName: node
   linkType: hard
@@ -10505,7 +10336,7 @@ __metadata:
   version: 2.3.0
   resolution: "on-finished@npm:2.3.0"
   dependencies:
-    ee-first: 1.1.1
+    ee-first: "npm:1.1.1"
   checksum: c904f9e518b11941eb60279a3cbfaf1289bd0001f600a950255b1dede9fe3df8cd74f38483550b3bb9485165166acb5db500c3b4c4337aec2815c88c96fcc2ea
   languageName: node
   linkType: hard
@@ -10514,7 +10345,7 @@ __metadata:
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
-    wrappy: 1
+    wrappy: "npm:1"
   checksum: 5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
   languageName: node
   linkType: hard
@@ -10523,7 +10354,7 @@ __metadata:
   version: 1.3.3
   resolution: "once@npm:1.3.3"
   dependencies:
-    wrappy: 1
+    wrappy: "npm:1"
   checksum: bb9c0fa8f6420b89fea4e0fc80aac175f025358cd1374a8e7afb92672f58473684f45a784e18f147d07cf87e629cc277f63f35c48fdfdced662edd18779c5876
   languageName: node
   linkType: hard
@@ -10532,7 +10363,7 @@ __metadata:
   version: 2.0.1
   resolution: "onetime@npm:2.0.1"
   dependencies:
-    mimic-fn: ^1.0.0
+    mimic-fn: "npm:^1.0.0"
   checksum: b4e44a8c34e70e02251bfb578a6e26d6de6eedbed106cd78211d2fd64d28b6281d54924696554e4e966559644243753ac5df73c87f283b0927533d3315696215
   languageName: node
   linkType: hard
@@ -10541,7 +10372,7 @@ __metadata:
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
   dependencies:
-    mimic-fn: ^2.1.0
+    mimic-fn: "npm:^2.1.0"
   checksum: ffcef6fbb2692c3c40749f31ea2e22677a876daea92959b8a80b521d95cca7a668c884d8b2045d1d8ee7d56796aa405c405462af112a1477594cc63531baeb8f
   languageName: node
   linkType: hard
@@ -10564,7 +10395,7 @@ __metadata:
   version: 6.4.0
   resolution: "open@npm:6.4.0"
   dependencies:
-    is-wsl: ^1.1.0
+    is-wsl: "npm:^1.1.0"
   checksum: 447115632b4f3939fa0d973c33e17f28538fd268fd8257fc49763f7de6e76d29d65585b15998bbd2137337cfb70a92084a0e1b183a466e53a4829f704f295823
   languageName: node
   linkType: hard
@@ -10582,8 +10413,8 @@ __metadata:
   version: 0.6.1
   resolution: "optimist@npm:0.6.1"
   dependencies:
-    minimist: ~0.0.1
-    wordwrap: ~0.0.2
+    minimist: "npm:~0.0.1"
+    wordwrap: "npm:~0.0.2"
   checksum: 8cb417328121e732dbfb4d94d53bb39b1406446b55323ed4ce787decc52394927e051ba879eb3ffa3171fe22a35ce13b460114b60effcead77443ee87c2f9b0f
   languageName: node
   linkType: hard
@@ -10592,12 +10423,12 @@ __metadata:
   version: 0.8.3
   resolution: "optionator@npm:0.8.3"
   dependencies:
-    deep-is: ~0.1.3
-    fast-levenshtein: ~2.0.6
-    levn: ~0.3.0
-    prelude-ls: ~1.1.2
-    type-check: ~0.3.2
-    word-wrap: ~1.2.3
+    deep-is: "npm:~0.1.3"
+    fast-levenshtein: "npm:~2.0.6"
+    levn: "npm:~0.3.0"
+    prelude-ls: "npm:~1.1.2"
+    type-check: "npm:~0.3.2"
+    word-wrap: "npm:~1.2.3"
   checksum: ad7000ea661792b3ec5f8f86aac28895850988926f483b5f308f59f4607dfbe24c05df2d049532ee227c040081f39401a268cf7bbf3301512f74c4d760dc6dd8
   languageName: node
   linkType: hard
@@ -10613,7 +10444,7 @@ __metadata:
   version: 1.4.0
   resolution: "os-locale@npm:1.4.0"
   dependencies:
-    lcid: ^1.0.0
+    lcid: "npm:^1.0.0"
   checksum: 302173159d562000ddf982ed75c493a0d861e91372c9e1b13aab21590ff2e1ba264a41995b29be8dc5278a6127ffcd2ad5591779e8164a570fc5fa6c0787b057
   languageName: node
   linkType: hard
@@ -10629,8 +10460,8 @@ __metadata:
   version: 0.1.5
   resolution: "osenv@npm:0.1.5"
   dependencies:
-    os-homedir: ^1.0.0
-    os-tmpdir: ^1.0.0
+    os-homedir: "npm:^1.0.0"
+    os-tmpdir: "npm:^1.0.0"
   checksum: b33ed4b77e662f3ee2a04bf4b56cad2107ab069dee982feb9e39ad44feb9aa0cf1016b9ac6e05d0d84c91fa496798fe48dd05a33175d624e51668068b9805302
   languageName: node
   linkType: hard
@@ -10639,7 +10470,7 @@ __metadata:
   version: 0.13.2
   resolution: "ow@npm:0.13.2"
   dependencies:
-    type-fest: ^0.5.1
+    type-fest: "npm:^0.5.1"
   checksum: 18ad7e0bbeb984d8bd5033ce1cfb73084fe33d96c8825b8d62e7e901512914977bc1785c1996f37a02fabc639e7f67eabc69b78a6a09ae15a9070f0368cd7fe7
   languageName: node
   linkType: hard
@@ -10683,7 +10514,7 @@ __metadata:
   version: 1.3.0
   resolution: "p-limit@npm:1.3.0"
   dependencies:
-    p-try: ^1.0.0
+    p-try: "npm:^1.0.0"
   checksum: 5c1b1d53d180b2c7501efb04b7c817448e10efe1ba46f4783f8951994d5027e4cd88f36ad79af50546682594c4ebd11702ac4b9364c47f8074890e2acad0edee
   languageName: node
   linkType: hard
@@ -10692,7 +10523,7 @@ __metadata:
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
   dependencies:
-    p-try: ^2.0.0
+    p-try: "npm:^2.0.0"
   checksum: 8da01ac53efe6a627080fafc127c873da40c18d87b3f5d5492d465bb85ec7207e153948df6b9cbaeb130be70152f874229b8242ee2be84c0794082510af97f12
   languageName: node
   linkType: hard
@@ -10701,7 +10532,7 @@ __metadata:
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
   dependencies:
-    yocto-queue: ^0.1.0
+    yocto-queue: "npm:^0.1.0"
   checksum: 9db675949dbdc9c3763c89e748d0ef8bdad0afbb24d49ceaf4c46c02c77d30db4e0652ed36d0a0a7a95154335fab810d95c86153105bb73b3a90448e2bb14e1a
   languageName: node
   linkType: hard
@@ -10710,7 +10541,7 @@ __metadata:
   version: 2.0.0
   resolution: "p-locate@npm:2.0.0"
   dependencies:
-    p-limit: ^1.1.0
+    p-limit: "npm:^1.1.0"
   checksum: 82da4be88fb02fd29175e66021610c881938d3cc97c813c71c1a605fac05617d57fd5d3b337494a6106c0edb2a37c860241430851411f1b265108cead34aee67
   languageName: node
   linkType: hard
@@ -10719,7 +10550,7 @@ __metadata:
   version: 3.0.0
   resolution: "p-locate@npm:3.0.0"
   dependencies:
-    p-limit: ^2.0.0
+    p-limit: "npm:^2.0.0"
   checksum: 7b7f06f718f19e989ce6280ed4396fb3c34dabdee0df948376483032f9d5ec22fdf7077ec942143a75827bb85b11da72016497fc10dac1106c837ed593969ee8
   languageName: node
   linkType: hard
@@ -10728,7 +10559,7 @@ __metadata:
   version: 4.1.0
   resolution: "p-locate@npm:4.1.0"
   dependencies:
-    p-limit: ^2.2.0
+    p-limit: "npm:^2.2.0"
   checksum: 1b476ad69ad7f6059744f343b26d51ce091508935c1dbb80c4e0a2f397ffce0ca3a1f9f5cd3c7ce19d7929a09719d5c65fe70d8ee289c3f267cd36f2881813e9
   languageName: node
   linkType: hard
@@ -10737,7 +10568,7 @@ __metadata:
   version: 5.0.0
   resolution: "p-locate@npm:5.0.0"
   dependencies:
-    p-limit: ^3.0.2
+    p-limit: "npm:^3.0.2"
   checksum: 2290d627ab7903b8b70d11d384fee714b797f6040d9278932754a6860845c4d3190603a0772a663c8cb5a7b21d1b16acb3a6487ebcafa9773094edc3dfe6009a
   languageName: node
   linkType: hard
@@ -10753,7 +10584,7 @@ __metadata:
   version: 3.0.0
   resolution: "p-map@npm:3.0.0"
   dependencies:
-    aggregate-error: ^3.0.0
+    aggregate-error: "npm:^3.0.0"
   checksum: 297930737e52412ad9f5787c52774ad6496fad9a8be5f047e75fd0a3dc61930d8f7a9b2bbe1c4d1404e54324228a4f69721da2538208dadaa4ef4c81773c9f20
   languageName: node
   linkType: hard
@@ -10762,7 +10593,7 @@ __metadata:
   version: 4.0.0
   resolution: "p-map@npm:4.0.0"
   dependencies:
-    aggregate-error: ^3.0.0
+    aggregate-error: "npm:^3.0.0"
   checksum: 592c05bd6262c466ce269ff172bb8de7c6975afca9b50c975135b974e9bdaafbfe80e61aaaf5be6d1200ba08b30ead04b88cfa7e25ff1e3b93ab28c9f62a2c75
   languageName: node
   linkType: hard
@@ -10771,8 +10602,8 @@ __metadata:
   version: 3.1.0
   resolution: "p-memoize@npm:3.1.0"
   dependencies:
-    mem: ^4.3.0
-    mimic-fn: ^2.1.0
+    mem: "npm:^4.3.0"
+    mimic-fn: "npm:^2.1.0"
   checksum: 432de06fc7814f72fe8eb4889fd7fc48c59746e1577982a00b86a4de1fbc988cdfc858713b980a34f8525f3cac92d8543a1de1d910fb0095545e0ee405b962c0
   languageName: node
   linkType: hard
@@ -10781,7 +10612,7 @@ __metadata:
   version: 3.2.0
   resolution: "p-timeout@npm:3.2.0"
   dependencies:
-    p-finally: ^1.0.0
+    p-finally: "npm:^1.0.0"
   checksum: 524b393711a6ba8e1d48137c5924749f29c93d70b671e6db761afa784726572ca06149c715632da8f70c090073afb2af1c05730303f915604fd38ee207b70a61
   languageName: node
   linkType: hard
@@ -10804,10 +10635,10 @@ __metadata:
   version: 3.0.0
   resolution: "package-hash@npm:3.0.0"
   dependencies:
-    graceful-fs: ^4.1.15
-    hasha: ^3.0.0
-    lodash.flattendeep: ^4.4.0
-    release-zalgo: ^1.0.0
+    graceful-fs: "npm:^4.1.15"
+    hasha: "npm:^3.0.0"
+    lodash.flattendeep: "npm:^4.4.0"
+    release-zalgo: "npm:^1.0.0"
   checksum: 120855e7780d0402592c078a3f4e839f0eecb94200d25c0effe359b6c7d933747e2a65d613c02c9803a6b34338b5c0bdb89633fe138636883081b03efbaa4943
   languageName: node
   linkType: hard
@@ -10816,10 +10647,10 @@ __metadata:
   version: 6.5.0
   resolution: "package-json@npm:6.5.0"
   dependencies:
-    got: ^9.6.0
-    registry-auth-token: ^4.0.0
-    registry-url: ^5.0.0
-    semver: ^6.2.0
+    got: "npm:^9.6.0"
+    registry-auth-token: "npm:^4.0.0"
+    registry-url: "npm:^5.0.0"
+    semver: "npm:^6.2.0"
   checksum: 60c29fe357af43f96c92c334aa0160cebde44e8e65c1e5f9b065efb3f501af812f268ec967a07757b56447834ef7f71458ebbab94425a9f09c271f348f9b764f
   languageName: node
   linkType: hard
@@ -10828,7 +10659,7 @@ __metadata:
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
   dependencies:
-    callsites: ^3.0.0
+    callsites: "npm:^3.0.0"
   checksum: c63d6e80000d4babd11978e0d3fee386ca7752a02b035fd2435960ffaa7219dc42146f07069fb65e6e8bf1caef89daf9af7535a39bddf354d78bf50d8294f556
   languageName: node
   linkType: hard
@@ -10837,10 +10668,10 @@ __metadata:
   version: 3.0.4
   resolution: "parse-glob@npm:3.0.4"
   dependencies:
-    glob-base: ^0.3.0
-    is-dotfile: ^1.0.0
-    is-extglob: ^1.0.0
-    is-glob: ^2.0.0
+    glob-base: "npm:^0.3.0"
+    is-dotfile: "npm:^1.0.0"
+    is-extglob: "npm:^1.0.0"
+    is-glob: "npm:^2.0.0"
   checksum: 4faf2e81ca85bc545777a1210ab770e0305c9e095680c219e5635e1a439d763feaf761e055b136425c3d6dcd3ec9431b77fd20f7411525b21031620125dc1dbc
   languageName: node
   linkType: hard
@@ -10849,7 +10680,7 @@ __metadata:
   version: 2.2.0
   resolution: "parse-json@npm:2.2.0"
   dependencies:
-    error-ex: ^1.2.0
+    error-ex: "npm:^1.2.0"
   checksum: 7a90132aa76016f518a3d5d746a21b3f1ad0f97a68436ed71b6f995b67c7151141f5464eea0c16c59aec9b7756519a0e3007a8f98cf3714632d509ec07736df6
   languageName: node
   linkType: hard
@@ -10858,8 +10689,8 @@ __metadata:
   version: 4.0.0
   resolution: "parse-json@npm:4.0.0"
   dependencies:
-    error-ex: ^1.3.1
-    json-parse-better-errors: ^1.0.1
+    error-ex: "npm:^1.3.1"
+    json-parse-better-errors: "npm:^1.0.1"
   checksum: 8d80790b772ccb1bcea4e09e2697555e519d83d04a77c2b4237389b813f82898943a93ffff7d0d2406203bdd0c30dcf95b1661e3a53f83d0e417f053957bef32
   languageName: node
   linkType: hard
@@ -10868,10 +10699,10 @@ __metadata:
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
   dependencies:
-    "@babel/code-frame": ^7.0.0
-    error-ex: ^1.3.1
-    json-parse-even-better-errors: ^2.3.0
-    lines-and-columns: ^1.1.6
+    "@babel/code-frame": "npm:^7.0.0"
+    error-ex: "npm:^1.3.1"
+    json-parse-even-better-errors: "npm:^2.3.0"
+    lines-and-columns: "npm:^1.1.6"
   checksum: 77947f2253005be7a12d858aedbafa09c9ae39eb4863adf330f7b416ca4f4a08132e453e08de2db46459256fb66afaac5ee758b44fe6541b7cdaf9d252e59585
   languageName: node
   linkType: hard
@@ -10901,7 +10732,7 @@ __metadata:
   version: 1.0.1
   resolution: "path-array@npm:1.0.1"
   dependencies:
-    array-index: ^1.0.0
+    array-index: "npm:^1.0.0"
   checksum: fbd6f5ee6adbe14526de37f6e0b7ec82c99032173feb88bf1bc780eb78159faf3aba3f8cfb79792b372cee43aebf3ccf72aa6f57449fd1f6d19ebe5455ac4363
   languageName: node
   linkType: hard
@@ -10910,7 +10741,7 @@ __metadata:
   version: 2.1.0
   resolution: "path-exists@npm:2.1.0"
   dependencies:
-    pinkie-promise: ^2.0.0
+    pinkie-promise: "npm:^2.0.0"
   checksum: 87352f1601c085d5a6eb202f60e5c016c1b790bd0bc09398af446ed3f5c4510b4531ff99cf8acac2d91868886e792927b4292f768b35a83dce12588fb7cbb46e
   languageName: node
   linkType: hard
@@ -10968,7 +10799,7 @@ __metadata:
   version: 1.8.0
   resolution: "path-to-regexp@npm:1.8.0"
   dependencies:
-    isarray: 0.0.1
+    isarray: "npm:0.0.1"
   checksum: 7b25d6f27a8de03f49406d16195450f5ced694398adea1510b0f949d9660600d1769c5c6c83668583b7e6b503f3caf1ede8ffc08135dbe3e982f034f356fbb5c
   languageName: node
   linkType: hard
@@ -10977,9 +10808,9 @@ __metadata:
   version: 1.1.0
   resolution: "path-type@npm:1.1.0"
   dependencies:
-    graceful-fs: ^4.1.2
-    pify: ^2.0.0
-    pinkie-promise: ^2.0.0
+    graceful-fs: "npm:^4.1.2"
+    pify: "npm:^2.0.0"
+    pinkie-promise: "npm:^2.0.0"
   checksum: 2b8c348cb52bbc0c0568afa10a0a5d8f6233adfe5ae75feb56064f6aed6324ab74185c61c2545f4e52ca08acdc76005f615da4e127ed6eecb866002cf491f350
   languageName: node
   linkType: hard
@@ -10988,7 +10819,7 @@ __metadata:
   version: 3.0.0
   resolution: "path-type@npm:3.0.0"
   dependencies:
-    pify: ^3.0.0
+    pify: "npm:^3.0.0"
   checksum: 1332c632f1cac15790ebab8dd729b67ba04fc96f81647496feb1c2975d862d046f41e4b975dbd893048999b2cc90721f72924ad820acc58c78507ba7141a8e56
   languageName: node
   linkType: hard
@@ -11053,7 +10884,7 @@ __metadata:
   version: 2.0.1
   resolution: "pinkie-promise@npm:2.0.1"
   dependencies:
-    pinkie: ^2.0.0
+    pinkie: "npm:^2.0.0"
   checksum: 11b5e5ce2b090c573f8fad7b517cbca1bb9a247587306f05ae71aef6f9b2cd2b923c304aa9663c2409cfde27b367286179f1379bc4ec18a3fbf2bb0d473b160a
   languageName: node
   linkType: hard
@@ -11076,7 +10907,7 @@ __metadata:
   version: 3.0.0
   resolution: "pkg-dir@npm:3.0.0"
   dependencies:
-    find-up: ^3.0.0
+    find-up: "npm:^3.0.0"
   checksum: 902a3d0c1f8ac43b1795fa1ba6ffeb37dfd53c91469e969790f6ed5e29ff2bdc50b63ba6115dc056d2efb4a040aa2446d512b3804bdafdf302f734fb3ec21847
   languageName: node
   linkType: hard
@@ -11085,7 +10916,7 @@ __metadata:
   version: 4.2.0
   resolution: "pkg-dir@npm:4.2.0"
   dependencies:
-    find-up: ^4.0.0
+    find-up: "npm:^4.0.0"
   checksum: c56bda7769e04907a88423feb320babaed0711af8c436ce3e56763ab1021ba107c7b0cafb11cde7529f669cfc22bffcaebffb573645cbd63842ea9fb17cd7728
   languageName: node
   linkType: hard
@@ -11110,9 +10941,9 @@ __metadata:
   version: 4.0.0
   resolution: "postcss-modules-local-by-default@npm:4.0.0"
   dependencies:
-    icss-utils: ^5.0.0
-    postcss-selector-parser: ^6.0.2
-    postcss-value-parser: ^4.1.0
+    icss-utils: "npm:^5.0.0"
+    postcss-selector-parser: "npm:^6.0.2"
+    postcss-value-parser: "npm:^4.1.0"
   peerDependencies:
     postcss: ^8.1.0
   checksum: 8ee9c0d9918fd838854d434731371874b25c412dde135df981cc28d37d0660496389b0f8653dbcdbb6ee81f2bec90cb5b14668f6208f6f517400ac064e234c5a
@@ -11123,7 +10954,7 @@ __metadata:
   version: 3.0.0
   resolution: "postcss-modules-scope@npm:3.0.0"
   dependencies:
-    postcss-selector-parser: ^6.0.4
+    postcss-selector-parser: "npm:^6.0.4"
   peerDependencies:
     postcss: ^8.1.0
   checksum: 60af503910363689568c2c3701cb019a61b58b3d739391145185eec211bea5d50ccb6ecbe6955b39d856088072fd50ea002e40a52b50e33b181ff5c41da0308a
@@ -11134,7 +10965,7 @@ __metadata:
   version: 4.0.0
   resolution: "postcss-modules-values@npm:4.0.0"
   dependencies:
-    icss-utils: ^5.0.0
+    icss-utils: "npm:^5.0.0"
   peerDependencies:
     postcss: ^8.1.0
   checksum: dd18d7631b5619fb9921b198c86847a2a075f32e0c162e0428d2647685e318c487a2566cc8cc669fc2077ef38115cde7a068e321f46fb38be3ad49646b639dbc
@@ -11145,8 +10976,8 @@ __metadata:
   version: 6.0.9
   resolution: "postcss-selector-parser@npm:6.0.9"
   dependencies:
-    cssesc: ^3.0.0
-    util-deprecate: ^1.0.2
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
   checksum: 07acc7b6565561b5ed65ed35fa27565e09c92b80278d933bf89c8cdcf59473d128d75320c720b184e80a617b122bb64957e7c60f99691dceabd587e2591f784e
   languageName: node
   linkType: hard
@@ -11162,9 +10993,9 @@ __metadata:
   version: 8.4.5
   resolution: "postcss@npm:8.4.5"
   dependencies:
-    nanoid: ^3.1.30
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.1
+    nanoid: "npm:^3.1.30"
+    picocolors: "npm:^1.0.0"
+    source-map-js: "npm:^1.0.1"
   checksum: e019240473575fc39d6ec38bfa748250c302dacdf3b1660df5f736c6d0279d067e0a4dd6aae2bf0999a0a687fe77ef7a887d550fdf91eeccf9e67dda969ea716
   languageName: node
   linkType: hard
@@ -11245,8 +11076,8 @@ __metadata:
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
   dependencies:
-    err-code: ^2.0.2
-    retry: ^0.12.0
+    err-code: "npm:^2.0.2"
+    retry: "npm:^0.12.0"
   checksum: 9c7045a1a2928094b5b9b15336dcd2a7b1c052f674550df63cc3f36cd44028e5080448175b6f6ca32b642de81150f5e7b1a98b728f15cb069f2dd60ac2616b96
   languageName: node
   linkType: hard
@@ -11255,7 +11086,7 @@ __metadata:
   version: 0.3.0
   resolution: "promzard@npm:0.3.0"
   dependencies:
-    read: 1
+    read: "npm:1"
   checksum: 7fd8dbcd9764b35092da65867cc60fdcf2ea85d77e8ed1ae348ec0af1a22616f74053ccf8dad7d8de01e1e3aafe349d77ef56653c2db3791589ac2a8ef485149
   languageName: node
   linkType: hard
@@ -11292,8 +11123,8 @@ __metadata:
   version: 3.0.0
   resolution: "pump@npm:3.0.0"
   dependencies:
-    end-of-stream: ^1.1.0
-    once: ^1.3.1
+    end-of-stream: "npm:^1.1.0"
+    once: "npm:^1.3.1"
   checksum: bbdeda4f747cdf47db97428f3a135728669e56a0ae5f354a9ac5b74556556f5446a46f720a8f14ca2ece5be9b4d5d23c346db02b555f46739934cc6c093a5478
   languageName: node
   linkType: hard
@@ -11365,8 +11196,8 @@ __metadata:
   version: 4.3.4
   resolution: "query-string@npm:4.3.4"
   dependencies:
-    object-assign: ^4.1.0
-    strict-uri-encode: ^1.0.0
+    object-assign: "npm:^4.1.0"
+    strict-uri-encode: "npm:^1.0.0"
   checksum: 6181c343074c2049fbbcde63f87c1da5d3a49c6e34c8d94a61d692e886e0b8cd1ae4a4be00b598112bb9c4cb819e423ed503a5d246e4d24ecb0990d8bb21570b
   languageName: node
   linkType: hard
@@ -11389,9 +11220,9 @@ __metadata:
   version: 3.1.1
   resolution: "randomatic@npm:3.1.1"
   dependencies:
-    is-number: ^4.0.0
-    kind-of: ^6.0.0
-    math-random: ^1.0.1
+    is-number: "npm:^4.0.0"
+    kind-of: "npm:^6.0.0"
+    math-random: "npm:^1.0.1"
   checksum: 4b1da4b8e234d3d0bd2294a42541dfa03edbde85ee06fa0722e2b004e845da197d72fa7995723d32ea7d7402823ea62550034118cf22e94638560a509cec5bfc
   languageName: node
   linkType: hard
@@ -11400,7 +11231,7 @@ __metadata:
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
   dependencies:
-    safe-buffer: ^5.1.0
+    safe-buffer: "npm:^5.1.0"
   checksum: 50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
   languageName: node
   linkType: hard
@@ -11416,9 +11247,9 @@ __metadata:
   version: 2.1.7
   resolution: "raw-body@npm:2.1.7"
   dependencies:
-    bytes: 2.4.0
-    iconv-lite: 0.4.13
-    unpipe: 1.0.0
+    bytes: "npm:2.4.0"
+    iconv-lite: "npm:0.4.13"
+    unpipe: "npm:1.0.0"
   checksum: f3c41d596b8f583e08d506a279533e4c8f6b3a94ee424ef74ffd7f41e7bfc2dea3f419026ce5a6a48e96426174a507ae1a037158069f47a815edf00a643c2311
   languageName: node
   linkType: hard
@@ -11427,10 +11258,10 @@ __metadata:
   version: 1.2.8
   resolution: "rc@npm:1.2.8"
   dependencies:
-    deep-extend: ^0.6.0
-    ini: ~1.3.0
-    minimist: ^1.2.0
-    strip-json-comments: ~2.0.1
+    deep-extend: "npm:^0.6.0"
+    ini: "npm:~1.3.0"
+    minimist: "npm:^1.2.0"
+    strip-json-comments: "npm:~2.0.1"
   bin:
     rc: ./cli.js
   checksum: 24a07653150f0d9ac7168e52943cc3cb4b7a22c0e43c7dff3219977c2fdca5a2760a304a029c20811a0e79d351f57d46c9bde216193a0f73978496afc2b85b15
@@ -11441,7 +11272,7 @@ __metadata:
   version: 1.0.5
   resolution: "read-cmd-shim@npm:1.0.5"
   dependencies:
-    graceful-fs: ^4.1.2
+    graceful-fs: "npm:^4.1.2"
   checksum: ce3ccaa069239a6dcbbf9ba62ac8b7f786fac0cd0bc1d42d944ebc3059d6d2f5dd3e25eee3c26f77bc7b46778e48ba517bcde3ce0d1176ea7720f1aa68896a49
   languageName: node
   linkType: hard
@@ -11450,13 +11281,13 @@ __metadata:
   version: 4.0.3
   resolution: "read-installed@npm:4.0.3"
   dependencies:
-    debuglog: ^1.0.1
-    graceful-fs: ^4.1.2
-    read-package-json: ^2.0.0
-    readdir-scoped-modules: ^1.0.0
-    semver: 2 || 3 || 4 || 5
-    slide: ~1.1.3
-    util-extend: ^1.0.1
+    debuglog: "npm:^1.0.1"
+    graceful-fs: "npm:^4.1.2"
+    read-package-json: "npm:^2.0.0"
+    readdir-scoped-modules: "npm:^1.0.0"
+    semver: "npm:2 || 3 || 4 || 5"
+    slide: "npm:~1.1.3"
+    util-extend: "npm:^1.0.1"
   dependenciesMeta:
     graceful-fs:
       optional: true
@@ -11468,10 +11299,10 @@ __metadata:
   version: 2.1.2
   resolution: "read-package-json@npm:2.1.2"
   dependencies:
-    glob: ^7.1.1
-    json-parse-even-better-errors: ^2.3.0
-    normalize-package-data: ^2.0.0
-    npm-normalize-package-bin: ^1.0.0
+    glob: "npm:^7.1.1"
+    json-parse-even-better-errors: "npm:^2.3.0"
+    normalize-package-data: "npm:^2.0.0"
+    npm-normalize-package-bin: "npm:^1.0.0"
   checksum: 2ff44e00a2e71bd87209021e3dd2b21d94f72dad2f5230c9ec3afb66acaf6d8c3ee4b6d09aa5c1ec660207d5c8d0b92b4b932459038ab448e74f35dbd8f2aa6a
   languageName: node
   linkType: hard
@@ -11480,11 +11311,11 @@ __metadata:
   version: 2.0.13
   resolution: "read-package-json@npm:2.0.13"
   dependencies:
-    glob: ^7.1.1
-    graceful-fs: ^4.1.2
-    json-parse-better-errors: ^1.0.1
-    normalize-package-data: ^2.0.0
-    slash: ^1.0.0
+    glob: "npm:^7.1.1"
+    graceful-fs: "npm:^4.1.2"
+    json-parse-better-errors: "npm:^1.0.1"
+    normalize-package-data: "npm:^2.0.0"
+    slash: "npm:^1.0.0"
   dependenciesMeta:
     graceful-fs:
       optional: true
@@ -11496,11 +11327,11 @@ __metadata:
   version: 5.1.6
   resolution: "read-package-tree@npm:5.1.6"
   dependencies:
-    debuglog: ^1.0.1
-    dezalgo: ^1.0.0
-    once: ^1.3.0
-    read-package-json: ^2.0.0
-    readdir-scoped-modules: ^1.0.0
+    debuglog: "npm:^1.0.1"
+    dezalgo: "npm:^1.0.0"
+    once: "npm:^1.3.0"
+    read-package-json: "npm:^2.0.0"
+    readdir-scoped-modules: "npm:^1.0.0"
   checksum: d45d6b8eb3ce80061ebab1577b984866c9e33564fc6d904f81d8e8d73db880cb55dd41295296337bbb178066c86f1d3ed5244c52be352175b2cde5608088f9dc
   languageName: node
   linkType: hard
@@ -11509,8 +11340,8 @@ __metadata:
   version: 1.0.1
   resolution: "read-pkg-up@npm:1.0.1"
   dependencies:
-    find-up: ^1.0.0
-    read-pkg: ^1.0.0
+    find-up: "npm:^1.0.0"
+    read-pkg: "npm:^1.0.0"
   checksum: 36c4fc8bd73edf77a4eeb497b6e43010819ea4aef64cbf8e393439fac303398751c5a299feab84e179a74507e3a1416e1ed033a888b1dac3463bf46d1765f7ac
   languageName: node
   linkType: hard
@@ -11519,8 +11350,8 @@ __metadata:
   version: 3.0.0
   resolution: "read-pkg-up@npm:3.0.0"
   dependencies:
-    find-up: ^2.0.0
-    read-pkg: ^3.0.0
+    find-up: "npm:^2.0.0"
+    read-pkg: "npm:^3.0.0"
   checksum: 2cd0a180260b0d235990e6e9c8c2330a03882d36bc2eba8930e437ef23ee52a68a894e7e1ccb1c33f03bcceb270a861ee5f7eac686f238857755e2cddfb48ffd
   languageName: node
   linkType: hard
@@ -11529,8 +11360,8 @@ __metadata:
   version: 4.0.0
   resolution: "read-pkg-up@npm:4.0.0"
   dependencies:
-    find-up: ^3.0.0
-    read-pkg: ^3.0.0
+    find-up: "npm:^3.0.0"
+    read-pkg: "npm:^3.0.0"
   checksum: c889c5bd9a4de84bfb5234ed7e5450b90cf83d05a25025ba04cfe3e1f12302e689d5c445b1c67cc564fbd7e1b931f638fea0299a188e1fd36eac183a1167b533
   languageName: node
   linkType: hard
@@ -11539,9 +11370,9 @@ __metadata:
   version: 6.0.0
   resolution: "read-pkg-up@npm:6.0.0"
   dependencies:
-    find-up: ^4.0.0
-    read-pkg: ^5.1.1
-    type-fest: ^0.5.0
+    find-up: "npm:^4.0.0"
+    read-pkg: "npm:^5.1.1"
+    type-fest: "npm:^0.5.0"
   checksum: 5231f40d03afb0e5be566bcc5a0e43b78af9dd3804480d77d4ee2381577427a382044a6605c6fdddfa65c929da946f0bf1d242bc2fd13b22b38577328e6649f8
   languageName: node
   linkType: hard
@@ -11550,9 +11381,9 @@ __metadata:
   version: 1.1.0
   resolution: "read-pkg@npm:1.1.0"
   dependencies:
-    load-json-file: ^1.0.0
-    normalize-package-data: ^2.3.2
-    path-type: ^1.0.0
+    load-json-file: "npm:^1.0.0"
+    normalize-package-data: "npm:^2.3.2"
+    path-type: "npm:^1.0.0"
   checksum: 51fce9f7066787dc7688ea7014324cedeb9f38daa7dace4f1147d526f22354a07189ef728710bc97e27fcf5ed3a03b68ad8b60afb4251984640b6f09c180d572
   languageName: node
   linkType: hard
@@ -11561,9 +11392,9 @@ __metadata:
   version: 3.0.0
   resolution: "read-pkg@npm:3.0.0"
   dependencies:
-    load-json-file: ^4.0.0
-    normalize-package-data: ^2.3.2
-    path-type: ^3.0.0
+    load-json-file: "npm:^4.0.0"
+    normalize-package-data: "npm:^2.3.2"
+    path-type: "npm:^3.0.0"
   checksum: 65acf2df89fbcd506b48b7ced56a255ba00adf7ecaa2db759c86cc58212f6fd80f1f0b7a85c848551a5d0685232e9b64f45c1fd5b48d85df2761a160767eeb93
   languageName: node
   linkType: hard
@@ -11572,10 +11403,10 @@ __metadata:
   version: 5.2.0
   resolution: "read-pkg@npm:5.2.0"
   dependencies:
-    "@types/normalize-package-data": ^2.4.0
-    normalize-package-data: ^2.5.0
-    parse-json: ^5.0.0
-    type-fest: ^0.6.0
+    "@types/normalize-package-data": "npm:^2.4.0"
+    normalize-package-data: "npm:^2.5.0"
+    parse-json: "npm:^5.0.0"
+    type-fest: "npm:^0.6.0"
   checksum: b51a17d4b51418e777029e3a7694c9bd6c578a5ab99db544764a0b0f2c7c0f58f8a6bc101f86a6fceb8ba6d237d67c89acf6170f6b98695d0420ddc86cf109fb
   languageName: node
   linkType: hard
@@ -11584,7 +11415,7 @@ __metadata:
   version: 1.0.7
   resolution: "read@npm:1.0.7"
   dependencies:
-    mute-stream: ~0.0.4
+    mute-stream: "npm:~0.0.4"
   checksum: 443533f05d5bb11b36ef1c6d625aae4e2ced8967e93cf546f35aa77b4eb6bd157f4256619e446bae43467f8f6619c7bc5c76983348dffaf36afedf4224f46216
   languageName: node
   linkType: hard
@@ -11593,13 +11424,13 @@ __metadata:
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
   dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.3
-    isarray: ~1.0.0
-    process-nextick-args: ~2.0.0
-    safe-buffer: ~5.1.1
-    string_decoder: ~1.1.1
-    util-deprecate: ~1.0.1
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.3"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~2.0.0"
+    safe-buffer: "npm:~5.1.1"
+    string_decoder: "npm:~1.1.1"
+    util-deprecate: "npm:~1.0.1"
   checksum: 1708755e6cf9daff6ff60fa5b4575636472289c5b95d38058a91f94732b8d024a940a0d4d955639195ce42c22cab16973ee8fea8deedd24b5fec3dd596465f86
   languageName: node
   linkType: hard
@@ -11608,10 +11439,10 @@ __metadata:
   version: 1.1.14
   resolution: "readable-stream@npm:1.1.14"
   dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.1
-    isarray: 0.0.1
-    string_decoder: ~0.10.x
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.1"
+    isarray: "npm:0.0.1"
+    string_decoder: "npm:~0.10.x"
   checksum: b7f41b16b305103d598e3c8964fa30d52d6e0b5d9fdad567588964521691c24b279c7a8bb71f11927c3613acf355bac72d8396885a43d50425b2caafd49bc83d
   languageName: node
   linkType: hard
@@ -11620,10 +11451,10 @@ __metadata:
   version: 1.0.34
   resolution: "readable-stream@npm:1.0.34"
   dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.1
-    isarray: 0.0.1
-    string_decoder: ~0.10.x
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.1"
+    isarray: "npm:0.0.1"
+    string_decoder: "npm:~0.10.x"
   checksum: 02272551396ed8930ddee1a088bdf0379f0f7cc47ac49ed8804e998076cb7daec9fbd2b1fd9c0490ec72e56e8bb3651abeb8080492b8e0a9c3f2158330908ed6
   languageName: node
   linkType: hard
@@ -11632,9 +11463,9 @@ __metadata:
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
   dependencies:
-    inherits: ^2.0.3
-    string_decoder: ^1.1.1
-    util-deprecate: ^1.0.1
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
   checksum: 937bedd29ac8a68331666291922bea892fa2be1a33269e582de9f844a2002f146cf831e39cd49fe6a378d3f0c27358f259ed0e20d20f0bdc6a3f8fc21fce42dc
   languageName: node
   linkType: hard
@@ -11643,12 +11474,12 @@ __metadata:
   version: 2.0.6
   resolution: "readable-stream@npm:2.0.6"
   dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.1
-    isarray: ~1.0.0
-    process-nextick-args: ~1.0.6
-    string_decoder: ~0.10.x
-    util-deprecate: ~1.0.1
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.1"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~1.0.6"
+    string_decoder: "npm:~0.10.x"
+    util-deprecate: "npm:~1.0.1"
   checksum: 8c719705d2e2379dee91fa44dfdc47a7b5754558454dfe787121120d9c048efaa6f4666205492b4e73fe70eb49c61a36eac57e5062cb9a04b098675f065139cb
   languageName: node
   linkType: hard
@@ -11657,13 +11488,13 @@ __metadata:
   version: 2.1.5
   resolution: "readable-stream@npm:2.1.5"
   dependencies:
-    buffer-shims: ^1.0.0
-    core-util-is: ~1.0.0
-    inherits: ~2.0.1
-    isarray: ~1.0.0
-    process-nextick-args: ~1.0.6
-    string_decoder: ~0.10.x
-    util-deprecate: ~1.0.1
+    buffer-shims: "npm:^1.0.0"
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.1"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~1.0.6"
+    string_decoder: "npm:~0.10.x"
+    util-deprecate: "npm:~1.0.1"
   checksum: a7e5dd8211872bd31392e20a61e431be7c64aa975991f240037efc3e0d28456e45c627b2c81576f78789e60980df1310ba949278bac7d6cfa19892d051ae5e5f
   languageName: node
   linkType: hard
@@ -11672,10 +11503,10 @@ __metadata:
   version: 1.1.0
   resolution: "readdir-scoped-modules@npm:1.1.0"
   dependencies:
-    debuglog: ^1.0.1
-    dezalgo: ^1.0.0
-    graceful-fs: ^4.1.2
-    once: ^1.3.0
+    debuglog: "npm:^1.0.1"
+    dezalgo: "npm:^1.0.0"
+    graceful-fs: "npm:^4.1.2"
+    once: "npm:^1.3.0"
   checksum: 21a53741c488775cbf78b0b51f1b897e9c523b1bcf54567fc2c8ed09b12d9027741f45fcb720f388c0c3088021b54dc3f616c07af1531417678cc7962fc15e5c
   languageName: node
   linkType: hard
@@ -11684,9 +11515,9 @@ __metadata:
   version: 2.2.1
   resolution: "readdirp@npm:2.2.1"
   dependencies:
-    graceful-fs: ^4.1.11
-    micromatch: ^3.1.10
-    readable-stream: ^2.0.2
+    graceful-fs: "npm:^4.1.11"
+    micromatch: "npm:^3.1.10"
+    readable-stream: "npm:^2.0.2"
   checksum: 770d177372ff2212d382d425d55ca48301fcbf3231ab3827257bbcca7ff44fb51fe4af6acc2dda8512dc7f29da390e9fbea5b2b3fc724b86e85cc828395b7797
   languageName: node
   linkType: hard
@@ -11695,7 +11526,7 @@ __metadata:
   version: 3.6.0
   resolution: "readdirp@npm:3.6.0"
   dependencies:
-    picomatch: ^2.2.1
+    picomatch: "npm:^2.2.1"
   checksum: 6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
   languageName: node
   linkType: hard
@@ -11704,19 +11535,9 @@ __metadata:
   version: 3.0.3
   resolution: "realize-package-specifier@npm:3.0.3"
   dependencies:
-    dezalgo: ^1.0.1
-    npm-package-arg: ^4.1.1
+    dezalgo: "npm:^1.0.1"
+    npm-package-arg: "npm:^4.1.1"
   checksum: 26f684b12cb5d4cf4a6746aa02f8fa976f746f52ac21ea7cedc5262f26507c61c084aa695abe97de42bafe41cafc0daad5a6ce8be7396ac60b784100051ea4b5
-  languageName: node
-  linkType: hard
-
-"redent@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "redent@npm:1.0.0"
-  dependencies:
-    indent-string: ^2.1.0
-    strip-indent: ^1.0.1
-  checksum: 9fa48d250d4e645acac9de57cb82dc29cd7f5f27257ec367461e3dd0c9f14c55f1c40fd3d9cf7f9a3ed337f209ad4e0370abfcf5cf75569ebd31c97a7949b8a2
   languageName: node
   linkType: hard
 
@@ -11724,8 +11545,8 @@ __metadata:
   version: 2.0.0
   resolution: "redent@npm:2.0.0"
   dependencies:
-    indent-string: ^3.0.0
-    strip-indent: ^2.0.0
+    indent-string: "npm:^3.0.0"
+    strip-indent: "npm:^2.0.0"
   checksum: 4435add945631e81121cd1284e54c28aa654b1e3b606f32f5624ea0eb1aa9460df8f5475ee0a5dab27210e476e54bfc02316463a74d707d2fc8417603a020e6f
   languageName: node
   linkType: hard
@@ -11734,7 +11555,7 @@ __metadata:
   version: 9.0.0
   resolution: "regenerate-unicode-properties@npm:9.0.0"
   dependencies:
-    regenerate: ^1.4.2
+    regenerate: "npm:^1.4.2"
   checksum: dc648891572f1d8326c01b335b126d766fe6684e5e760d4daa6c1d214d162b8c027fe0e6ee0a3e3d8d20bd869567f363f6be60bdfc054a14e7ad7d347891a506
   languageName: node
   linkType: hard
@@ -11764,7 +11585,7 @@ __metadata:
   version: 0.14.5
   resolution: "regenerator-transform@npm:0.14.5"
   dependencies:
-    "@babel/runtime": ^7.8.4
+    "@babel/runtime": "npm:^7.8.4"
   checksum: d3005b61a4fca820cd5091af689e94e57d5d5d7581368bad9c1881edf6987a2a5a7f0a9e177cd23f1d8ab7eda00c749a1eb5d4c73cabb27d8711c0e83c6c29d9
   languageName: node
   linkType: hard
@@ -11773,7 +11594,7 @@ __metadata:
   version: 0.4.4
   resolution: "regex-cache@npm:0.4.4"
   dependencies:
-    is-equal-shallow: ^0.1.3
+    is-equal-shallow: "npm:^0.1.3"
   checksum: d3e374638b577ae560a445c7f36b801cab4815f7d25e1a9afc2328c01d5c0d203ea0d24e95635843e25ebc54e061f1790f7d47aa3839c49f67bbc53358ad9066
   languageName: node
   linkType: hard
@@ -11782,8 +11603,8 @@ __metadata:
   version: 1.0.2
   resolution: "regex-not@npm:1.0.2"
   dependencies:
-    extend-shallow: ^3.0.2
-    safe-regex: ^1.1.0
+    extend-shallow: "npm:^3.0.2"
+    safe-regex: "npm:^1.1.0"
   checksum: a0f8d6045f63b22e9759db10e248369c443b41cedd7dba0922d002b66c2734bc2aef0d98c4d45772d1f756245f4c5203856b88b9624bba2a58708858a8d485d6
   languageName: node
   linkType: hard
@@ -11806,12 +11627,12 @@ __metadata:
   version: 4.8.0
   resolution: "regexpu-core@npm:4.8.0"
   dependencies:
-    regenerate: ^1.4.2
-    regenerate-unicode-properties: ^9.0.0
-    regjsgen: ^0.5.2
-    regjsparser: ^0.7.0
-    unicode-match-property-ecmascript: ^2.0.0
-    unicode-match-property-value-ecmascript: ^2.0.0
+    regenerate: "npm:^1.4.2"
+    regenerate-unicode-properties: "npm:^9.0.0"
+    regjsgen: "npm:^0.5.2"
+    regjsparser: "npm:^0.7.0"
+    unicode-match-property-ecmascript: "npm:^2.0.0"
+    unicode-match-property-value-ecmascript: "npm:^2.0.0"
   checksum: cea09893ae49956ba11c3a7433295c61bfbaa92792f565fb54c463dfdd5a81a150ba67a22cd4ecded005425cbb78dc0ea34d5ff771f07f9d31931bafb189e367
   languageName: node
   linkType: hard
@@ -11820,7 +11641,7 @@ __metadata:
   version: 4.2.1
   resolution: "registry-auth-token@npm:4.2.1"
   dependencies:
-    rc: ^1.2.8
+    rc: "npm:^1.2.8"
   checksum: ae23c68b8cd9d3afc99e160791f83a1e74aae9e3229a2a602b849c91164567fc6a3c31b7f2c1ac0e1e622be0d6671773439a55923e3bc1062d55a5c8dd843b65
   languageName: node
   linkType: hard
@@ -11829,7 +11650,7 @@ __metadata:
   version: 5.1.0
   resolution: "registry-url@npm:5.1.0"
   dependencies:
-    rc: ^1.2.8
+    rc: "npm:^1.2.8"
   checksum: c2c455342b5836cbed5162092eba075c7a02c087d9ce0fde8aeb4dc87a8f4a34a542e58bf4d8ec2d4cb73f04408cb3148ceb1f76647f76b978cfec22047dc6d6
   languageName: node
   linkType: hard
@@ -11845,7 +11666,7 @@ __metadata:
   version: 0.7.0
   resolution: "regjsparser@npm:0.7.0"
   dependencies:
-    jsesc: ~0.5.0
+    jsesc: "npm:~0.5.0"
   bin:
     regjsparser: bin/parser
   checksum: 4b891ff0d2c835717d6e7ad9194da7f5271e410422fe51fa73b1f33978df8f6784e2a079938c9827f62fd13c258ae7e7e69f910799bb003b6a0b5e8854801719
@@ -11856,7 +11677,7 @@ __metadata:
   version: 1.0.0
   resolution: "release-zalgo@npm:1.0.0"
   dependencies:
-    es6-error: ^4.0.1
+    es6-error: "npm:^4.0.1"
   checksum: 9e161feb073f9e3aa714bb077d67592c34ee578f5b9cff8e2d492423fe2002d5b1e6d11ffcd5c564b9a0ee9435f25569567b658a82b9af931e7ac1313925628a
   languageName: node
   linkType: hard
@@ -11886,35 +11707,35 @@ __metadata:
   version: 2.0.1
   resolution: "repeating@npm:2.0.1"
   dependencies:
-    is-finite: ^1.0.0
+    is-finite: "npm:^1.0.0"
   checksum: 7f5cd293ec47d9c074ef0852800d5ff5c49028ce65242a7528d84f32bd2fe200b142930562af58c96d869c5a3046e87253030058e45231acaa129c1a7087d2e7
   languageName: node
   linkType: hard
 
-"request@npm:2, request@npm:^2.47.0, request@npm:^2.49.0, request@npm:^2.55.0, request@npm:^2.74.0, request@npm:^2.87.0, request@npm:^2.88.0":
+"request@npm:2, request@npm:^2.47.0, request@npm:^2.49.0, request@npm:^2.55.0, request@npm:^2.74.0":
   version: 2.88.2
   resolution: "request@npm:2.88.2"
   dependencies:
-    aws-sign2: ~0.7.0
-    aws4: ^1.8.0
-    caseless: ~0.12.0
-    combined-stream: ~1.0.6
-    extend: ~3.0.2
-    forever-agent: ~0.6.1
-    form-data: ~2.3.2
-    har-validator: ~5.1.3
-    http-signature: ~1.2.0
-    is-typedarray: ~1.0.0
-    isstream: ~0.1.2
-    json-stringify-safe: ~5.0.1
-    mime-types: ~2.1.19
-    oauth-sign: ~0.9.0
-    performance-now: ^2.1.0
-    qs: ~6.5.2
-    safe-buffer: ^5.1.2
-    tough-cookie: ~2.5.0
-    tunnel-agent: ^0.6.0
-    uuid: ^3.3.2
+    aws-sign2: "npm:~0.7.0"
+    aws4: "npm:^1.8.0"
+    caseless: "npm:~0.12.0"
+    combined-stream: "npm:~1.0.6"
+    extend: "npm:~3.0.2"
+    forever-agent: "npm:~0.6.1"
+    form-data: "npm:~2.3.2"
+    har-validator: "npm:~5.1.3"
+    http-signature: "npm:~1.2.0"
+    is-typedarray: "npm:~1.0.0"
+    isstream: "npm:~0.1.2"
+    json-stringify-safe: "npm:~5.0.1"
+    mime-types: "npm:~2.1.19"
+    oauth-sign: "npm:~0.9.0"
+    performance-now: "npm:^2.1.0"
+    qs: "npm:~6.5.2"
+    safe-buffer: "npm:^5.1.2"
+    tough-cookie: "npm:~2.5.0"
+    tunnel-agent: "npm:^0.6.0"
+    uuid: "npm:^3.3.2"
   checksum: 0ec66e7af1391e51ad231de3b1c6c6aef3ebd0a238aa50d4191c7a792dcdb14920eea8d570c702dc5682f276fe569d176f9b8ebc6031a3cf4a630a691a431a63
   languageName: node
   linkType: hard
@@ -11923,27 +11744,27 @@ __metadata:
   version: 2.72.0
   resolution: "request@npm:2.72.0"
   dependencies:
-    aws-sign2: ~0.6.0
-    aws4: ^1.2.1
-    bl: ~1.1.2
-    caseless: ~0.11.0
-    combined-stream: ~1.0.5
-    extend: ~3.0.0
-    forever-agent: ~0.6.1
-    form-data: ~1.0.0-rc3
-    har-validator: ~2.0.6
-    hawk: ~3.1.3
-    http-signature: ~1.1.0
-    is-typedarray: ~1.0.0
-    isstream: ~0.1.2
-    json-stringify-safe: ~5.0.1
-    mime-types: ~2.1.7
-    node-uuid: ~1.4.7
-    oauth-sign: ~0.8.1
-    qs: ~6.1.0
-    stringstream: ~0.0.4
-    tough-cookie: ~2.2.0
-    tunnel-agent: ~0.4.1
+    aws-sign2: "npm:~0.6.0"
+    aws4: "npm:^1.2.1"
+    bl: "npm:~1.1.2"
+    caseless: "npm:~0.11.0"
+    combined-stream: "npm:~1.0.5"
+    extend: "npm:~3.0.0"
+    forever-agent: "npm:~0.6.1"
+    form-data: "npm:~1.0.0-rc3"
+    har-validator: "npm:~2.0.6"
+    hawk: "npm:~3.1.3"
+    http-signature: "npm:~1.1.0"
+    is-typedarray: "npm:~1.0.0"
+    isstream: "npm:~0.1.2"
+    json-stringify-safe: "npm:~5.0.1"
+    mime-types: "npm:~2.1.7"
+    node-uuid: "npm:~1.4.7"
+    oauth-sign: "npm:~0.8.1"
+    qs: "npm:~6.1.0"
+    stringstream: "npm:~0.0.4"
+    tough-cookie: "npm:~2.2.0"
+    tunnel-agent: "npm:~0.4.1"
   checksum: 287f886bcfd336cba772896a646d995bdd2139bbeaa793fc17d33ae6ed2df891f2388a88da11e9d6258e13e9e1755ecf44803e0d8f5ecb2b5a2c78943f6af2b3
   languageName: node
   linkType: hard
@@ -11952,27 +11773,27 @@ __metadata:
   version: 2.75.0
   resolution: "request@npm:2.75.0"
   dependencies:
-    aws-sign2: ~0.6.0
-    aws4: ^1.2.1
-    bl: ~1.1.2
-    caseless: ~0.11.0
-    combined-stream: ~1.0.5
-    extend: ~3.0.0
-    forever-agent: ~0.6.1
-    form-data: ~2.0.0
-    har-validator: ~2.0.6
-    hawk: ~3.1.3
-    http-signature: ~1.1.0
-    is-typedarray: ~1.0.0
-    isstream: ~0.1.2
-    json-stringify-safe: ~5.0.1
-    mime-types: ~2.1.7
-    node-uuid: ~1.4.7
-    oauth-sign: ~0.8.1
-    qs: ~6.2.0
-    stringstream: ~0.0.4
-    tough-cookie: ~2.3.0
-    tunnel-agent: ~0.4.1
+    aws-sign2: "npm:~0.6.0"
+    aws4: "npm:^1.2.1"
+    bl: "npm:~1.1.2"
+    caseless: "npm:~0.11.0"
+    combined-stream: "npm:~1.0.5"
+    extend: "npm:~3.0.0"
+    forever-agent: "npm:~0.6.1"
+    form-data: "npm:~2.0.0"
+    har-validator: "npm:~2.0.6"
+    hawk: "npm:~3.1.3"
+    http-signature: "npm:~1.1.0"
+    is-typedarray: "npm:~1.0.0"
+    isstream: "npm:~0.1.2"
+    json-stringify-safe: "npm:~5.0.1"
+    mime-types: "npm:~2.1.7"
+    node-uuid: "npm:~1.4.7"
+    oauth-sign: "npm:~0.8.1"
+    qs: "npm:~6.2.0"
+    stringstream: "npm:~0.0.4"
+    tough-cookie: "npm:~2.3.0"
+    tunnel-agent: "npm:~0.4.1"
   checksum: 75daec8e8ffdb9343328e8fc1c3318bf29410a026ba51b2fc9d88fd80f5d0452c10a5dbddf182cc654c2a575eeefbbd59ce9459428fbee59f34cc945f5ec6bc9
   languageName: node
   linkType: hard
@@ -12037,29 +11858,29 @@ __metadata:
   version: 1.22.0
   resolution: "resolve@npm:1.22.0"
   dependencies:
-    is-core-module: ^2.8.1
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
+    is-core-module: "npm:^2.8.1"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
   checksum: efe07a7cd69015a95a5f4e6cc3d372354b93d67a70410ec686413b2054dfa0d5ef16ff52c057a83634debb17f278b99db6dbc60367a4475ae01dda29c6eaa6e4
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@1.1.7#~builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A1.1.7#optional!builtin<compat/resolve>":
   version: 1.1.7
-  resolution: "resolve@patch:resolve@npm%3A1.1.7#~builtin<compat/resolve>::version=1.1.7&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.1.7#optional!builtin<compat/resolve>::version=1.1.7&hash=3bafbf"
   checksum: f4f1471423d600a10944785222fa7250237ed8c98aa6b1e1f4dc0bb3dbfbcafcaac69a2ed23cd1f6f485ed23e7c939894ac1978284e4163754fade8a05358823
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.0.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.0.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>":
   version: 1.22.0
-  resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.0#optional!builtin<compat/resolve>::version=1.22.0&hash=c3c19d"
   dependencies:
-    is-core-module: ^2.8.1
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
+    is-core-module: "npm:^2.8.1"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
   checksum: ef8061e81f40c39070748e8e263c8767d8fcc7c34e9ee85211b29fbc2aedb1ae7cda7d735c2cdbe9367060e9f85ec11c2694e370c121c6bcbb472a7bd0b19555
@@ -12070,7 +11891,7 @@ __metadata:
   version: 1.0.2
   resolution: "responselike@npm:1.0.2"
   dependencies:
-    lowercase-keys: ^1.0.0
+    lowercase-keys: "npm:^1.0.0"
   checksum: 1c2861d1950790da96159ca490eda645130eaf9ccc4d76db20f685ba944feaf30f45714b4318f550b8cd72990710ad68355ff15c41da43ed9a93c102c0ffa403
   languageName: node
   linkType: hard
@@ -12079,8 +11900,8 @@ __metadata:
   version: 2.0.0
   resolution: "restore-cursor@npm:2.0.0"
   dependencies:
-    onetime: ^2.0.0
-    signal-exit: ^3.0.2
+    onetime: "npm:^2.0.0"
+    signal-exit: "npm:^3.0.2"
   checksum: f5b335bee06f440445e976a7031a3ef53691f9b7c4a9d42a469a0edaf8a5508158a0d561ff2b26a1f4f38783bcca2c0e5c3a44f927326f6694d5b44d7a4993e6
   languageName: node
   linkType: hard
@@ -12089,8 +11910,8 @@ __metadata:
   version: 3.1.0
   resolution: "restore-cursor@npm:3.1.0"
   dependencies:
-    onetime: ^5.1.0
-    signal-exit: ^3.0.2
+    onetime: "npm:^5.1.0"
+    signal-exit: "npm:^3.0.2"
   checksum: 8051a371d6aa67ff21625fa94e2357bd81ffdc96267f3fb0fc4aaf4534028343836548ef34c240ffa8c25b280ca35eb36be00b3cb2133fa4f51896d7e73c6b4f
   languageName: node
   linkType: hard
@@ -12141,7 +11962,7 @@ __metadata:
   version: 0.1.3
   resolution: "right-align@npm:0.1.3"
   dependencies:
-    align-text: ^0.1.1
+    align-text: "npm:^0.1.1"
   checksum: 8fdafcb1e4cadd03d392f2a2185ab39265deb80bbe37c6ee4b0a552937c84a10fae5afd7ab4623734f7c5356b1d748daf4130529a2fbc8caa311b6257473ec95
   languageName: node
   linkType: hard
@@ -12150,7 +11971,7 @@ __metadata:
   version: 2.7.1
   resolution: "rimraf@npm:2.7.1"
   dependencies:
-    glob: ^7.1.3
+    glob: "npm:^7.1.3"
   bin:
     rimraf: ./bin.js
   checksum: 4eef73d406c6940927479a3a9dee551e14a54faf54b31ef861250ac815172bade86cc6f7d64a4dc5e98b65e4b18a2e1c9ff3b68d296be0c748413f092bb0dd40
@@ -12161,7 +11982,7 @@ __metadata:
   version: 2.6.3
   resolution: "rimraf@npm:2.6.3"
   dependencies:
-    glob: ^7.1.3
+    glob: "npm:^7.1.3"
   bin:
     rimraf: ./bin.js
   checksum: f1e646f8c567795f2916aef7aadf685b543da6b9a53e482bb04b07472c7eef2b476045ba1e29f401c301c66b630b22b815ab31fdd60c5e1ae6566ff523debf45
@@ -12172,7 +11993,7 @@ __metadata:
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
   dependencies:
-    glob: ^7.1.3
+    glob: "npm:^7.1.3"
   bin:
     rimraf: bin.js
   checksum: 9cb7757acb489bd83757ba1a274ab545eafd75598a9d817e0c3f8b164238dd90eba50d6b848bd4dcc5f3040912e882dc7ba71653e35af660d77b25c381d402e8
@@ -12183,7 +12004,7 @@ __metadata:
   version: 2.4.5
   resolution: "rimraf@npm:2.4.5"
   dependencies:
-    glob: ^6.0.1
+    glob: "npm:^6.0.1"
   bin:
     rimraf: ./bin.js
   checksum: 5251a36053165d23248efec5077f9addc13ad7f742a02dcd9ac7adda9e208cbf7523901e96a9ca6c33059bd0b573b97eab3334cf1d9976cc5ddc8b3c24d9ddd7
@@ -12194,7 +12015,7 @@ __metadata:
   version: 2.5.4
   resolution: "rimraf@npm:2.5.4"
   dependencies:
-    glob: ^7.0.5
+    glob: "npm:^7.0.5"
   bin:
     rimraf: ./bin.js
   checksum: 02556efee08012469e358ed54f6e59e2a3589f07d4b15c6156ae57d391cb6983dd35d02a2a1b9c4c9d129d90fb00db980a5c44ea248ecff2737c246ed02686b1
@@ -12205,7 +12026,7 @@ __metadata:
   version: 1.2.0
   resolution: "rmdir@npm:1.2.0"
   dependencies:
-    node.flow: 1.2.3
+    node.flow: "npm:1.2.3"
   checksum: d305fc2f08cb38cf09a20adac4bc62b67e99fbffb5cbac965aad6644bb83904d887e78842a76d19583880943a5bd4278af9639e7b8d260a120b20391fb1e69b0
   languageName: node
   linkType: hard
@@ -12221,7 +12042,7 @@ __metadata:
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
   dependencies:
-    queue-microtask: ^1.2.2
+    queue-microtask: "npm:^1.2.2"
   checksum: 200b5ab25b5b8b7113f9901bfe3afc347e19bb7475b267d55ad0eb86a62a46d77510cb0f232507c9e5d497ebda569a08a9867d0d14f57a82ad5564d991588b39
   languageName: node
   linkType: hard
@@ -12230,7 +12051,7 @@ __metadata:
   version: 4.0.8
   resolution: "rx-lite-aggregates@npm:4.0.8"
   dependencies:
-    rx-lite: "*"
+    rx-lite: "npm:*"
   checksum: e21f95feca7e63b861fd711a980924cbaa9cb8ebc4786c7cbc287e153d5e96fbd48c0a8a978e53594174d4a68d5d2263b823a2b975c80a955f5748eb59cdec60
   languageName: node
   linkType: hard
@@ -12246,7 +12067,7 @@ __metadata:
   version: 5.5.12
   resolution: "rxjs@npm:5.5.12"
   dependencies:
-    symbol-observable: 1.0.1
+    symbol-observable: "npm:1.0.1"
   checksum: da1a467cda40792f41d16998e4766ab27f14c077b2b333a35ff0b26251211d646f7aadd0e8255e1f7da95c038f40f1322be030424376592b28361388a3001115
   languageName: node
   linkType: hard
@@ -12255,7 +12076,7 @@ __metadata:
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:
-    tslib: ^1.9.0
+    tslib: "npm:^1.9.0"
   checksum: e556a13a9aa89395e5c9d825eabcfa325568d9c9990af720f3f29f04a888a3b854f25845c2b55875d875381abcae2d8100af9cacdc57576e7ed6be030a01d2fe
   languageName: node
   linkType: hard
@@ -12278,7 +12099,7 @@ __metadata:
   version: 1.1.0
   resolution: "safe-regex@npm:1.1.0"
   dependencies:
-    ret: ~0.1.10
+    ret: "npm:~0.1.10"
   checksum: 547d58aa5184cbef368fd5ed5f28d20f911614748c5da6b35f53fd6626396707587251e6e3d1e3010fd3ff1212e413841b8825eaa5f317017ca62a30899af31a
   languageName: node
   linkType: hard
@@ -12290,29 +12111,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-graph@npm:2.2.5":
-  version: 2.2.5
-  resolution: "sass-graph@npm:2.2.5"
-  dependencies:
-    glob: ^7.0.0
-    lodash: ^4.0.0
-    scss-tokenizer: ^0.2.3
-    yargs: ^13.3.2
-  bin:
-    sassgraph: bin/sassgraph
-  checksum: a829206865b68cab24ebe559e4e69763279e390c2bc7f17607d57194763485bf9601ee86dbf160681207088c2aea8c1843cec458b1d2d6dacab1a846cf4b3aee
-  languageName: node
-  linkType: hard
-
 "sass-loader@npm:^10.1.0":
   version: 10.2.1
   resolution: "sass-loader@npm:10.2.1"
   dependencies:
-    klona: ^2.0.4
-    loader-utils: ^2.0.0
-    neo-async: ^2.6.2
-    schema-utils: ^3.0.0
-    semver: ^7.3.2
+    klona: "npm:^2.0.4"
+    loader-utils: "npm:^2.0.0"
+    neo-async: "npm:^2.6.2"
+    schema-utils: "npm:^3.0.0"
+    semver: "npm:^7.3.2"
   peerDependencies:
     fibers: ">= 3.1.0"
     node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0
@@ -12340,9 +12147,9 @@ __metadata:
   version: 2.7.1
   resolution: "schema-utils@npm:2.7.1"
   dependencies:
-    "@types/json-schema": ^7.0.5
-    ajv: ^6.12.4
-    ajv-keywords: ^3.5.2
+    "@types/json-schema": "npm:^7.0.5"
+    ajv: "npm:^6.12.4"
+    ajv-keywords: "npm:^3.5.2"
   checksum: f484f34464edd8758712d5d3ba25a306e367dac988aecaf4ce112e99baae73f33a807b5cf869240bb6648c80720b36af2d7d72be3a27faa49a2d4fc63fa3f85f
   languageName: node
   linkType: hard
@@ -12351,9 +12158,9 @@ __metadata:
   version: 3.1.1
   resolution: "schema-utils@npm:3.1.1"
   dependencies:
-    "@types/json-schema": ^7.0.8
-    ajv: ^6.12.5
-    ajv-keywords: ^3.5.2
+    "@types/json-schema": "npm:^7.0.8"
+    ajv: "npm:^6.12.5"
+    ajv-keywords: "npm:^3.5.2"
   checksum: 55a8da802a5f8f0ce6f68b6a139f3261cb423bd23795766da866a0f5738fc40303370fbe0c3eeba60b2a91c569ad7ce5318fea455f8fe866098c5a3a6b9050b0
   languageName: node
   linkType: hard
@@ -12365,21 +12172,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scss-tokenizer@npm:^0.2.3":
-  version: 0.2.3
-  resolution: "scss-tokenizer@npm:0.2.3"
-  dependencies:
-    js-base64: ^2.1.8
-    source-map: ^0.4.2
-  checksum: ea039f9d40a6b5ef76a141e69c6fc9d2370ac99f6406237ef5446e02e1f16068fa4e183e7eca5abf973324e56e078da235aefd4e2be46c84a02d14aeae6bfefa
-  languageName: node
-  linkType: hard
-
 "semver-diff@npm:^2.0.0":
   version: 2.1.0
   resolution: "semver-diff@npm:2.1.0"
   dependencies:
-    semver: ^5.0.3
+    semver: "npm:^5.0.3"
   checksum: 5825827a82e848908c6b6f9248aad4a15fe5baeed74ae41d67cf6d96107425028a5a5432e17abf10f0696719b0efcbbc34b47d071a70fb85e11cb451feb637e6
   languageName: node
   linkType: hard
@@ -12433,7 +12230,7 @@ __metadata:
   version: 7.3.5
   resolution: "semver@npm:7.3.5"
   dependencies:
-    lru-cache: ^6.0.0
+    lru-cache: "npm:^6.0.0"
   bin:
     semver: bin/semver.js
   checksum: d450455b2601396dbc7d9f058a6709b1c0b99d74a911f9436c77887600ffcdb5f63d5adffa0c3b8f0092937d8a41cc61c6437bcba375ef4151cb1335ebe4f1f9
@@ -12462,18 +12259,18 @@ __metadata:
   version: 0.13.2
   resolution: "send@npm:0.13.2"
   dependencies:
-    debug: ~2.2.0
-    depd: ~1.1.0
-    destroy: ~1.0.4
-    escape-html: ~1.0.3
-    etag: ~1.7.0
-    fresh: 0.3.0
-    http-errors: ~1.3.1
-    mime: 1.3.4
-    ms: 0.7.1
-    on-finished: ~2.3.0
-    range-parser: ~1.0.3
-    statuses: ~1.2.1
+    debug: "npm:~2.2.0"
+    depd: "npm:~1.1.0"
+    destroy: "npm:~1.0.4"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.7.0"
+    fresh: "npm:0.3.0"
+    http-errors: "npm:~1.3.1"
+    mime: "npm:1.3.4"
+    ms: "npm:0.7.1"
+    on-finished: "npm:~2.3.0"
+    range-parser: "npm:~1.0.3"
+    statuses: "npm:~1.2.1"
   checksum: 76a5e22cdf035446e9534d70434402e5db4dc860898e7702428d4f3d91a902f938a54701d048f09d6a40442bd597e720792733b61205ca88019f46469befa08a
   languageName: node
   linkType: hard
@@ -12482,7 +12279,7 @@ __metadata:
   version: 6.0.0
   resolution: "serialize-javascript@npm:6.0.0"
   dependencies:
-    randombytes: ^2.1.0
+    randombytes: "npm:^2.1.0"
   checksum: 73104922ef0a919064346eea21caab99de1a019a1f5fb54a7daa7fcabc39e83b387a2a363e52a889598c3b1bcf507c4b2a7b26df76e991a310657af20eea2e7c
   languageName: node
   linkType: hard
@@ -12491,7 +12288,7 @@ __metadata:
   version: 5.0.1
   resolution: "serialize-javascript@npm:5.0.1"
   dependencies:
-    randombytes: ^2.1.0
+    randombytes: "npm:^2.1.0"
   checksum: 646bd92a8298d764d38316f3006bce0b0def6d0e254791396ac34403847654d9346b0b6ed7865efd799d93d4c47d900e08a8fa7a6f7f8d2dbaebab5444c3b431
   languageName: node
   linkType: hard
@@ -12507,10 +12304,10 @@ __metadata:
   version: 2.0.1
   resolution: "set-value@npm:2.0.1"
   dependencies:
-    extend-shallow: ^2.0.1
-    is-extendable: ^0.1.1
-    is-plain-object: ^2.0.3
-    split-string: ^3.0.1
+    extend-shallow: "npm:^2.0.1"
+    is-extendable: "npm:^0.1.1"
+    is-plain-object: "npm:^2.0.3"
+    split-string: "npm:^3.0.1"
   checksum: 4c40573c4f6540456e4b38b95f570272c4cfbe1d12890ad4057886da8535047cd772dfadf5b58e2e87aa244dfb4c57e3586f6716b976fc47c5144b6b09e1811b
   languageName: node
   linkType: hard
@@ -12519,8 +12316,8 @@ __metadata:
   version: 2.0.1
   resolution: "sha@npm:2.0.1"
   dependencies:
-    graceful-fs: ^4.1.2
-    readable-stream: ^2.0.2
+    graceful-fs: "npm:^4.1.2"
+    readable-stream: "npm:^2.0.2"
   checksum: 97cdcf02871ca4c02ed96fee9db00e5df3203aad92e1c196341f1a6277d0d35928a2491d2dd704b15a08b1e49a9d11ac1724e7fb97d88188340b4e6ed0bd4759
   languageName: node
   linkType: hard
@@ -12529,7 +12326,7 @@ __metadata:
   version: 3.0.1
   resolution: "shallow-clone@npm:3.0.1"
   dependencies:
-    kind-of: ^6.0.2
+    kind-of: "npm:^6.0.2"
   checksum: 7bab09613a1b9f480c85a9823aebec533015579fa055ba6634aa56ba1f984380670eaf33b8217502931872aa1401c9fcadaa15f9f604d631536df475b05bcf1e
   languageName: node
   linkType: hard
@@ -12545,7 +12342,7 @@ __metadata:
   version: 1.2.0
   resolution: "shebang-command@npm:1.2.0"
   dependencies:
-    shebang-regex: ^1.0.0
+    shebang-regex: "npm:^1.0.0"
   checksum: 7b20dbf04112c456b7fc258622dafd566553184ac9b6938dd30b943b065b21dabd3776460df534cc02480db5e1b6aec44700d985153a3da46e7db7f9bd21326d
   languageName: node
   linkType: hard
@@ -12554,7 +12351,7 @@ __metadata:
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
   dependencies:
-    shebang-regex: ^3.0.0
+    shebang-regex: "npm:^3.0.0"
   checksum: a41692e7d89a553ef21d324a5cceb5f686d1f3c040759c50aab69688634688c5c327f26f3ecf7001ebfd78c01f3c7c0a11a7c8bfd0a8bc9f6240d4f40b224e4e
   languageName: node
   linkType: hard
@@ -12577,9 +12374,9 @@ __metadata:
   version: 1.0.4
   resolution: "side-channel@npm:1.0.4"
   dependencies:
-    call-bind: ^1.0.0
-    get-intrinsic: ^1.0.2
-    object-inspect: ^1.9.0
+    call-bind: "npm:^1.0.0"
+    get-intrinsic: "npm:^1.0.2"
+    object-inspect: "npm:^1.9.0"
   checksum: 054a5d23ee35054b2c4609b9fd2a0587760737782b5d765a9c7852264710cc39c6dcb56a9bbd6c12cd84071648aea3edb2359d2f6e560677eedadce511ac1da5
   languageName: node
   linkType: hard
@@ -12612,12 +12409,12 @@ __metadata:
   version: 9.2.4
   resolution: "sinon@npm:9.2.4"
   dependencies:
-    "@sinonjs/commons": ^1.8.1
-    "@sinonjs/fake-timers": ^6.0.1
-    "@sinonjs/samsam": ^5.3.1
-    diff: ^4.0.2
-    nise: ^4.0.4
-    supports-color: ^7.1.0
+    "@sinonjs/commons": "npm:^1.8.1"
+    "@sinonjs/fake-timers": "npm:^6.0.1"
+    "@sinonjs/samsam": "npm:^5.3.1"
+    diff: "npm:^4.0.2"
+    nise: "npm:^4.0.4"
+    supports-color: "npm:^7.1.0"
   checksum: 37fc3688c009ea1397e319ee8335407d25ff24b658af2761f30b490e9ae31b82b22cfb4d8bc504a99d934dd65a8f72f6ccbbe13656309a1db62192e96d4d470e
   languageName: node
   linkType: hard
@@ -12647,8 +12444,8 @@ __metadata:
   version: 0.1.1
   resolution: "sleuth@npm:0.1.1"
   dependencies:
-    is-require: 0.0.1
-    static-eval: ~0.1.0
+    is-require: "npm:0.0.1"
+    static-eval: "npm:~0.1.0"
   checksum: 4a4e87523b4f86332646ff4d096e9772a5c8e61beaca5dd192bf16a1a4122ccc3e76f1207d767b0427323382a7d0472db6f9083a86bcadd437750504d8b57efb
   languageName: node
   linkType: hard
@@ -12664,9 +12461,9 @@ __metadata:
   version: 2.1.0
   resolution: "slice-ansi@npm:2.1.0"
   dependencies:
-    ansi-styles: ^3.2.0
-    astral-regex: ^1.0.0
-    is-fullwidth-code-point: ^2.0.0
+    ansi-styles: "npm:^3.2.0"
+    astral-regex: "npm:^1.0.0"
+    is-fullwidth-code-point: "npm:^2.0.0"
   checksum: c317b21ec9e3d3968f3d5b548cbfc2eae331f58a03f1352621020799cbe695b3611ee972726f8f32d4ca530065a5ec9c74c97fde711c1f41b4a1585876b2c191
   languageName: node
   linkType: hard
@@ -12696,9 +12493,9 @@ __metadata:
   version: 2.1.1
   resolution: "snapdragon-node@npm:2.1.1"
   dependencies:
-    define-property: ^1.0.0
-    isobject: ^3.0.0
-    snapdragon-util: ^3.0.1
+    define-property: "npm:^1.0.0"
+    isobject: "npm:^3.0.0"
+    snapdragon-util: "npm:^3.0.1"
   checksum: 7616e6a1ca054afe3ad8defda17ebe4c73b0800d2e0efd635c44ee1b286f8ac7900517314b5330862ce99b28cd2782348ee78bae573ff0f55832ad81d9657f3f
   languageName: node
   linkType: hard
@@ -12707,7 +12504,7 @@ __metadata:
   version: 3.0.1
   resolution: "snapdragon-util@npm:3.0.1"
   dependencies:
-    kind-of: ^3.2.0
+    kind-of: "npm:^3.2.0"
   checksum: 4441856d343399ba7f37f79681949d51b922e290fcc07e7bc94655a50f584befa4fb08f40c3471cd160e004660161964d8ff140cba49baa59aa6caba774240e3
   languageName: node
   linkType: hard
@@ -12716,14 +12513,14 @@ __metadata:
   version: 0.8.2
   resolution: "snapdragon@npm:0.8.2"
   dependencies:
-    base: ^0.11.1
-    debug: ^2.2.0
-    define-property: ^0.2.5
-    extend-shallow: ^2.0.1
-    map-cache: ^0.2.2
-    source-map: ^0.5.6
-    source-map-resolve: ^0.5.0
-    use: ^3.1.0
+    base: "npm:^0.11.1"
+    debug: "npm:^2.2.0"
+    define-property: "npm:^0.2.5"
+    extend-shallow: "npm:^2.0.1"
+    map-cache: "npm:^0.2.2"
+    source-map: "npm:^0.5.6"
+    source-map-resolve: "npm:^0.5.0"
+    use: "npm:^3.1.0"
   checksum: dfdac1f73d47152d72fc07f4322da09bbddfa31c1c9c3ae7346f252f778c45afa5b03e90813332f02f04f6de8003b34a168c456f8bb719024d092f932520ffca
   languageName: node
   linkType: hard
@@ -12732,7 +12529,7 @@ __metadata:
   version: 1.0.9
   resolution: "sntp@npm:1.0.9"
   dependencies:
-    hoek: 2.x.x
+    hoek: "npm:2.x.x"
   checksum: d0af20a7e62b3b761b33724464f12c35524f796d92cfd8198a52c88c418da9cc8746d1403bee843834cb75ac64accb42c55527d30e5fb90d6a3065c694f297f5
   languageName: node
   linkType: hard
@@ -12741,9 +12538,9 @@ __metadata:
   version: 6.1.1
   resolution: "socks-proxy-agent@npm:6.1.1"
   dependencies:
-    agent-base: ^6.0.2
-    debug: ^4.3.1
-    socks: ^2.6.1
+    agent-base: "npm:^6.0.2"
+    debug: "npm:^4.3.1"
+    socks: "npm:^2.6.1"
   checksum: 4d2ff6af0a4c49aa0f5aa3847468a75667795bc72c8271f85ee4c0a121f13f610674da43a6cbe77275e51596022f59da744d58f57d722dafbd1f54208cfa427d
   languageName: node
   linkType: hard
@@ -12752,8 +12549,8 @@ __metadata:
   version: 2.6.1
   resolution: "socks@npm:2.6.1"
   dependencies:
-    ip: ^1.1.5
-    smart-buffer: ^4.1.0
+    ip: "npm:^1.1.5"
+    smart-buffer: "npm:^4.1.0"
   checksum: e992192c7837bfa9093251abf3e78849741f332881900f481dcb3267d18b16595e93519f63dce29f39e4135789a7ed379d210dd68e98465564a40e81ccf9082a
   languageName: node
   linkType: hard
@@ -12762,7 +12559,7 @@ __metadata:
   version: 1.1.2
   resolution: "sort-keys@npm:1.1.2"
   dependencies:
-    is-plain-obj: ^1.0.0
+    is-plain-obj: "npm:^1.0.0"
   checksum: 5dd383b0299a40277051f7498c3999520138e2eb50d422962f658738341c9e82349fad4a3024d5ba1a3122688fbaf958f2a472d4c53bade55515097c2ce15420
   languageName: node
   linkType: hard
@@ -12792,11 +12589,11 @@ __metadata:
   version: 0.5.3
   resolution: "source-map-resolve@npm:0.5.3"
   dependencies:
-    atob: ^2.1.2
-    decode-uri-component: ^0.2.0
-    resolve-url: ^0.2.1
-    source-map-url: ^0.4.0
-    urix: ^0.1.0
+    atob: "npm:^2.1.2"
+    decode-uri-component: "npm:^0.2.0"
+    resolve-url: "npm:^0.2.1"
+    source-map-url: "npm:^0.4.0"
+    urix: "npm:^0.1.0"
   checksum: 410acbe93882e058858d4c1297be61da3e1533f95f25b95903edddc1fb719654e705663644677542d1fb78a66390238fad1a57115fc958a0724cf9bb509caf57
   languageName: node
   linkType: hard
@@ -12805,8 +12602,8 @@ __metadata:
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
-    buffer-from: ^1.0.0
-    source-map: ^0.6.0
+    buffer-from: "npm:^1.0.0"
+    source-map: "npm:^0.6.0"
   checksum: 9ee09942f415e0f721d6daad3917ec1516af746a8120bba7bb56278707a37f1eb8642bde456e98454b8a885023af81a16e646869975f06afc1a711fb90484e7d
   languageName: node
   linkType: hard
@@ -12815,15 +12612,6 @@ __metadata:
   version: 0.4.1
   resolution: "source-map-url@npm:0.4.1"
   checksum: f8af0678500d536c7f643e32094d6718a4070ab4ca2d2326532512cfbe2d5d25a45849b4b385879326f2d7523bb3b686d0360dd347a3cda09fd89a5c28d4bc58
-  languageName: node
-  linkType: hard
-
-"source-map@npm:^0.4.2":
-  version: 0.4.4
-  resolution: "source-map@npm:0.4.4"
-  dependencies:
-    amdefine: ">=0.0.4"
-  checksum: 685924f8b0dfb1580c2d12f85b1ba116f1382ed9c4b227d8a15958d39c3e5494ee21c5e3b4a5bf1c6c489041b9dbaeb7cff14dda7ad6458365c665492677f588
   languageName: node
   linkType: hard
 
@@ -12859,12 +12647,12 @@ __metadata:
   version: 1.4.3
   resolution: "spawn-wrap@npm:1.4.3"
   dependencies:
-    foreground-child: ^1.5.6
-    mkdirp: ^0.5.0
-    os-homedir: ^1.0.1
-    rimraf: ^2.6.2
-    signal-exit: ^3.0.2
-    which: ^1.3.0
+    foreground-child: "npm:^1.5.6"
+    mkdirp: "npm:^0.5.0"
+    os-homedir: "npm:^1.0.1"
+    rimraf: "npm:^2.6.2"
+    signal-exit: "npm:^3.0.2"
+    which: "npm:^1.3.0"
   checksum: b1fcfda5d1d3fe2055ee721133f8882af8255bfaf0e705dcbcc91205b2dd1c32ceab0d31a6960a67e04c51dcd3787a02471b1ccbfcd7b9c716f2405c492edb29
   languageName: node
   linkType: hard
@@ -12873,8 +12661,8 @@ __metadata:
   version: 3.1.1
   resolution: "spdx-correct@npm:3.1.1"
   dependencies:
-    spdx-expression-parse: ^3.0.0
-    spdx-license-ids: ^3.0.0
+    spdx-expression-parse: "npm:^3.0.0"
+    spdx-license-ids: "npm:^3.0.0"
   checksum: 25909eecc4024963a8e398399dbdd59ddb925bd7dbecd9c9cf6df0d75c29b68cd30b82123564acc51810eb02cfc4b634a2e16e88aa982433306012e318849249
   languageName: node
   linkType: hard
@@ -12890,8 +12678,8 @@ __metadata:
   version: 3.0.1
   resolution: "spdx-expression-parse@npm:3.0.1"
   dependencies:
-    spdx-exceptions: ^2.1.0
-    spdx-license-ids: ^3.0.0
+    spdx-exceptions: "npm:^2.1.0"
+    spdx-license-ids: "npm:^3.0.0"
   checksum: 6f8a41c87759fa184a58713b86c6a8b028250f158159f1d03ed9d1b6ee4d9eefdc74181c8ddc581a341aa971c3e7b79e30b59c23b05d2436d5de1c30bdef7171
   languageName: node
   linkType: hard
@@ -12907,7 +12695,7 @@ __metadata:
   version: 3.1.0
   resolution: "split-string@npm:3.1.0"
   dependencies:
-    extend-shallow: ^3.0.0
+    extend-shallow: "npm:^3.0.0"
   checksum: 72d7cd625445c7af215130e1e2bc183013bb9dd48a074eda1d35741e2b0dcb355e6df5b5558a62543a24dcec37dd1d6eb7a6228ff510d3c9de0f3dc1d1da8a70
   languageName: node
   linkType: hard
@@ -12916,7 +12704,7 @@ __metadata:
   version: 1.0.1
   resolution: "split@npm:1.0.1"
   dependencies:
-    through: 2
+    through: "npm:2"
   checksum: 7f489e7ed5ff8a2e43295f30a5197ffcb2d6202c9cf99357f9690d645b19c812bccf0be3ff336fea5054cda17ac96b91d67147d95dbfc31fbb5804c61962af85
   languageName: node
   linkType: hard
@@ -12925,15 +12713,15 @@ __metadata:
   version: 1.17.0
   resolution: "sshpk@npm:1.17.0"
   dependencies:
-    asn1: ~0.2.3
-    assert-plus: ^1.0.0
-    bcrypt-pbkdf: ^1.0.0
-    dashdash: ^1.12.0
-    ecc-jsbn: ~0.1.1
-    getpass: ^0.1.1
-    jsbn: ~0.1.0
-    safer-buffer: ^2.0.2
-    tweetnacl: ~0.14.0
+    asn1: "npm:~0.2.3"
+    assert-plus: "npm:^1.0.0"
+    bcrypt-pbkdf: "npm:^1.0.0"
+    dashdash: "npm:^1.12.0"
+    ecc-jsbn: "npm:~0.1.1"
+    getpass: "npm:^0.1.1"
+    jsbn: "npm:~0.1.0"
+    safer-buffer: "npm:^2.0.2"
+    tweetnacl: "npm:~0.14.0"
   bin:
     sshpk-conv: bin/sshpk-conv
     sshpk-sign: bin/sshpk-sign
@@ -12946,7 +12734,7 @@ __metadata:
   version: 8.0.1
   resolution: "ssri@npm:8.0.1"
   dependencies:
-    minipass: ^3.1.1
+    minipass: "npm:^3.1.1"
   checksum: 5cfae216ae02dcd154d1bbed2d0a60038a4b3a2fcaac3c7e47401ff4e058e551ee74cfdba618871bf168cd583db7b8324f94af6747d4303b73cd4c3f6dc5c9c2
   languageName: node
   linkType: hard
@@ -12962,8 +12750,8 @@ __metadata:
   version: 0.1.2
   resolution: "static-extend@npm:0.1.2"
   dependencies:
-    define-property: ^0.2.5
-    object-copy: ^0.1.0
+    define-property: "npm:^0.2.5"
+    object-copy: "npm:^0.1.0"
   checksum: 284f5865a9e19d079f1badbcd70d5f9f82e7a08393f818a220839cd5f71729e89105e1c95322bd28e833161d484cee671380ca443869ae89578eef2bf55c0653
   languageName: node
   linkType: hard
@@ -12979,15 +12767,6 @@ __metadata:
   version: 1.2.1
   resolution: "statuses@npm:1.2.1"
   checksum: e2b73edc628b02a4f99555087ce0fa9815c3b7f1e7df7622b536f3c812b23fe5c9ce9c9201370a19a4b6d93b508c2bb2ad111c4505a6fe1cd6b0f4d9b58d351a
-  languageName: node
-  linkType: hard
-
-"stdout-stream@npm:^1.4.0":
-  version: 1.4.1
-  resolution: "stdout-stream@npm:1.4.1"
-  dependencies:
-    readable-stream: ^2.0.1
-  checksum: be3e66c6d89183c0fae4908bd46c49e9687f8fff29ccaeeea00ae065a1e7af68f8a70c4d3b0c19b7c69b5a553d4354451d85e66af53ed68c6c9a23625ae22498
   languageName: node
   linkType: hard
 
@@ -13009,9 +12788,9 @@ __metadata:
   version: 1.0.2
   resolution: "string-width@npm:1.0.2"
   dependencies:
-    code-point-at: ^1.0.0
-    is-fullwidth-code-point: ^1.0.0
-    strip-ansi: ^3.0.0
+    code-point-at: "npm:^1.0.0"
+    is-fullwidth-code-point: "npm:^1.0.0"
+    strip-ansi: "npm:^3.0.0"
   checksum: c558438baed23a9ab9370bb6a939acbdb2b2ffc517838d651aad0f5b2b674fb85d460d9b1d0b6a4c210dffd09e3235222d89a5bd4c0c1587f78b2bb7bc00c65e
   languageName: node
   linkType: hard
@@ -13020,9 +12799,9 @@ __metadata:
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
-    emoji-regex: ^8.0.0
-    is-fullwidth-code-point: ^3.0.0
-    strip-ansi: ^6.0.1
+    emoji-regex: "npm:^8.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+    strip-ansi: "npm:^6.0.1"
   checksum: 1e525e92e5eae0afd7454086eed9c818ee84374bb80328fc41217ae72ff5f065ef1c9d7f72da41de40c75fa8bb3dee63d92373fd492c84260a552c636392a47b
   languageName: node
   linkType: hard
@@ -13031,8 +12810,8 @@ __metadata:
   version: 2.1.1
   resolution: "string-width@npm:2.1.1"
   dependencies:
-    is-fullwidth-code-point: ^2.0.0
-    strip-ansi: ^4.0.0
+    is-fullwidth-code-point: "npm:^2.0.0"
+    strip-ansi: "npm:^4.0.0"
   checksum: e5f2b169fcf8a4257a399f95d069522f056e92ec97dbdcb9b0cdf14d688b7ca0b1b1439a1c7b9773cd79446cbafd582727279d6bfdd9f8edd306ea5e90e5b610
   languageName: node
   linkType: hard
@@ -13041,9 +12820,9 @@ __metadata:
   version: 3.1.0
   resolution: "string-width@npm:3.1.0"
   dependencies:
-    emoji-regex: ^7.0.1
-    is-fullwidth-code-point: ^2.0.0
-    strip-ansi: ^5.1.0
+    emoji-regex: "npm:^7.0.1"
+    is-fullwidth-code-point: "npm:^2.0.0"
+    strip-ansi: "npm:^5.1.0"
   checksum: 85fa0d4f106e7999bb68c1c640c76fa69fb8c069dab75b009e29c123914e2d3b532e6cfa4b9d1bd913176fc83dedd7a2d7bf40d21a81a8a1978432cedfb65b91
   languageName: node
   linkType: hard
@@ -13052,8 +12831,8 @@ __metadata:
   version: 1.0.4
   resolution: "string.prototype.trimend@npm:1.0.4"
   dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
   checksum: 9fca11ab237f31cf55736e3e987deb312dd8e1bea7515e0f62949f1494f714083089a432ad5d99ea83f690a9290f58d0ce3d3f3356f5717e4c349d7d1b642af7
   languageName: node
   linkType: hard
@@ -13062,8 +12841,8 @@ __metadata:
   version: 1.0.4
   resolution: "string.prototype.trimstart@npm:1.0.4"
   dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
   checksum: 4e4f836f9416c3db176587ab4e9b62f45b11489ab93c2b14e796c82a4f1c912278f31a4793cc00c2bee11002e56c964e9f131b8f78d96ffbd89822a11bd786fe
   languageName: node
   linkType: hard
@@ -13072,7 +12851,7 @@ __metadata:
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
-    safe-buffer: ~5.2.0
+    safe-buffer: "npm:~5.2.0"
   checksum: 810614ddb030e271cd591935dcd5956b2410dd079d64ff92a1844d6b7588bf992b3e1b69b0f4d34a3e06e0bd73046ac646b5264c1987b20d0601f81ef35d731d
   languageName: node
   linkType: hard
@@ -13088,7 +12867,7 @@ __metadata:
   version: 1.1.1
   resolution: "string_decoder@npm:1.1.1"
   dependencies:
-    safe-buffer: ~5.1.0
+    safe-buffer: "npm:~5.1.0"
   checksum: b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
   languageName: node
   linkType: hard
@@ -13104,7 +12883,7 @@ __metadata:
   version: 3.0.1
   resolution: "strip-ansi@npm:3.0.1"
   dependencies:
-    ansi-regex: ^2.0.0
+    ansi-regex: "npm:^2.0.0"
   checksum: f6e7fbe8e700105dccf7102eae20e4f03477537c74b286fd22cfc970f139002ed6f0d9c10d0e21aa9ed9245e0fa3c9275930e8795c5b947da136e4ecb644a70f
   languageName: node
   linkType: hard
@@ -13113,7 +12892,7 @@ __metadata:
   version: 4.0.0
   resolution: "strip-ansi@npm:4.0.0"
   dependencies:
-    ansi-regex: ^3.0.0
+    ansi-regex: "npm:^3.0.0"
   checksum: d75d9681e0637ea316ddbd7d4d3be010b1895a17e885155e0ed6a39755ae0fd7ef46e14b22162e66a62db122d3a98ab7917794e255532ab461bb0a04feb03e7d
   languageName: node
   linkType: hard
@@ -13122,7 +12901,7 @@ __metadata:
   version: 5.2.0
   resolution: "strip-ansi@npm:5.2.0"
   dependencies:
-    ansi-regex: ^4.1.0
+    ansi-regex: "npm:^4.1.0"
   checksum: de4658c8a097ce3b15955bc6008f67c0790f85748bdc025b7bc8c52c7aee94bc4f9e50624516150ed173c3db72d851826cd57e7a85fe4e4bb6dbbebd5d297fdf
   languageName: node
   linkType: hard
@@ -13131,7 +12910,7 @@ __metadata:
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
   dependencies:
-    ansi-regex: ^5.0.1
+    ansi-regex: "npm:^5.0.1"
   checksum: 1ae5f212a126fe5b167707f716942490e3933085a5ff6c008ab97ab2f272c8025d3aa218b7bd6ab25729ca20cc81cddb252102f8751e13482a5199e873680952
   languageName: node
   linkType: hard
@@ -13140,7 +12919,7 @@ __metadata:
   version: 2.0.0
   resolution: "strip-bom@npm:2.0.0"
   dependencies:
-    is-utf8: ^0.2.0
+    is-utf8: "npm:^0.2.0"
   checksum: 4fcbb248af1d5c1f2d710022b7d60245077e7942079bfb7ef3fc8c1ae78d61e96278525ba46719b15ab12fced5c7603777105bc898695339d7c97c64d300ed0b
   languageName: node
   linkType: hard
@@ -13163,17 +12942,6 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: bddf8ccd47acd85c0e09ad7375409d81653f645fda13227a9d459642277c253d877b68f2e5e4d819fe75733b0e626bac7e954c04f3236f6d196f79c94fa4a96f
-  languageName: node
-  linkType: hard
-
-"strip-indent@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "strip-indent@npm:1.0.1"
-  dependencies:
-    get-stdin: ^4.0.1
-  bin:
-    strip-indent: cli.js
-  checksum: 671370d44105b63daf4582a42f0a0168d58a351f6558eb913d1ede05d0ad5f964548b99f15c63fa6c7415c3980aad72f28c62997fd98fbb6da2eee1051d3c21a
   languageName: node
   linkType: hard
 
@@ -13202,7 +12970,7 @@ __metadata:
   version: 1.0.1
   resolution: "strip-outer@npm:1.0.1"
   dependencies:
-    escape-string-regexp: ^1.0.2
+    escape-string-regexp: "npm:^1.0.2"
   checksum: c0f38e6f37563d878a221b1c76f0822f180ec5fc39be5ada30ee637a7d5b59d19418093bad2b4db1e69c40d7a7a7ac50828afce07276cf3d51ac8965cb140dfb
   languageName: node
   linkType: hard
@@ -13218,7 +12986,7 @@ __metadata:
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
-    has-flag: ^4.0.0
+    has-flag: "npm:^4.0.0"
   checksum: ea1d3c275dd604c974670f63943ed9bd83623edc102430c05adb8efc56ba492746b6e95386e7831b872ec3807fd89dd8eb43f735195f37b5ec343e4234cc7e89
   languageName: node
   linkType: hard
@@ -13234,7 +13002,7 @@ __metadata:
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:
-    has-flag: ^3.0.0
+    has-flag: "npm:^3.0.0"
   checksum: 6ae5ff319bfbb021f8a86da8ea1f8db52fac8bd4d499492e30ec17095b58af11f0c55f8577390a749b1c4dde691b6a0315dab78f5f54c9b3d83f8fb5905c1c05
   languageName: node
   linkType: hard
@@ -13243,7 +13011,7 @@ __metadata:
   version: 6.1.0
   resolution: "supports-color@npm:6.1.0"
   dependencies:
-    has-flag: ^3.0.0
+    has-flag: "npm:^3.0.0"
   checksum: ebf2befe41b55932c6d77192b91775f1403c389440ce2dab6f72663cf32ee87a1d9dea3512131a18e45ccac91424a8873b266142828489d0206d65ee93d224b6
   languageName: node
   linkType: hard
@@ -13252,7 +13020,7 @@ __metadata:
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
-    has-flag: ^4.0.0
+    has-flag: "npm:^4.0.0"
   checksum: afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
   languageName: node
   linkType: hard
@@ -13261,8 +13029,8 @@ __metadata:
   version: 2.2.0
   resolution: "supports-hyperlinks@npm:2.2.0"
   dependencies:
-    has-flag: ^4.0.0
-    supports-color: ^7.0.0
+    has-flag: "npm:^4.0.0"
+    supports-color: "npm:^7.0.0"
   checksum: 022677b8891c75bfdab99cf471248ddc823c666c6d5811fbee1257d502cdfb0047c5a3b3fd34854da7b688716af921470abdeabbe80fb035ae1157f457134b48
   languageName: node
   linkType: hard
@@ -13299,10 +13067,10 @@ __metadata:
   version: 5.4.6
   resolution: "table@npm:5.4.6"
   dependencies:
-    ajv: ^6.10.2
-    lodash: ^4.17.14
-    slice-ansi: ^2.1.0
-    string-width: ^3.0.0
+    ajv: "npm:^6.10.2"
+    lodash: "npm:^4.17.14"
+    slice-ansi: "npm:^2.1.0"
+    string-width: "npm:^3.0.0"
   checksum: 87ad7b7cc926aa06e0e2a91a0fb4fcb8b365da87969bc5c74b54cae5d518a089245f44bf80f945ec1aa74c405782db15eeb1dd1926315d842cdc9dbb9371672e
   languageName: node
   linkType: hard
@@ -13318,9 +13086,9 @@ __metadata:
   version: 2.2.2
   resolution: "tar@npm:2.2.2"
   dependencies:
-    block-stream: "*"
-    fstream: ^1.0.12
-    inherits: 2
+    block-stream: "npm:*"
+    fstream: "npm:^1.0.12"
+    inherits: "npm:2"
   checksum: 52da9fe8968c091680b697c5eb56762f932d706730b320bd8b4135ca32aaa2c7223bab1113bf33cca92e28964d579588d621ce262edf614c3afbe8a2cd2e1895
   languageName: node
   linkType: hard
@@ -13329,12 +13097,12 @@ __metadata:
   version: 6.1.11
   resolution: "tar@npm:6.1.11"
   dependencies:
-    chownr: ^2.0.0
-    fs-minipass: ^2.0.0
-    minipass: ^3.0.0
-    minizlib: ^2.1.1
-    mkdirp: ^1.0.3
-    yallist: ^4.0.0
+    chownr: "npm:^2.0.0"
+    fs-minipass: "npm:^2.0.0"
+    minipass: "npm:^3.0.0"
+    minizlib: "npm:^2.1.1"
+    mkdirp: "npm:^1.0.3"
+    yallist: "npm:^4.0.0"
   checksum: 5a016f5330f43815420797b87ade578e2ea60affd47439c988a3fc8f7bb6b36450d627c31ba6a839346fae248b4c8c12bb06bb0716211f37476838c7eff91f05
   languageName: node
   linkType: hard
@@ -13350,7 +13118,7 @@ __metadata:
   version: 1.2.0
   resolution: "term-size@npm:1.2.0"
   dependencies:
-    execa: ^0.7.0
+    execa: "npm:^0.7.0"
   checksum: 2fbb2668cdd3b5e63038c28355145e98789d16143fc6754462cd4a194706c7153f15c2a6f05f579ffed27bcf2f35bdf752007927457128cc9a9ce3ec20075649
   languageName: node
   linkType: hard
@@ -13359,8 +13127,8 @@ __metadata:
   version: 2.1.1
   resolution: "terminal-link@npm:2.1.1"
   dependencies:
-    ansi-escapes: ^4.2.1
-    supports-hyperlinks: ^2.0.0
+    ansi-escapes: "npm:^4.2.1"
+    supports-hyperlinks: "npm:^2.0.0"
   checksum: 947458a5cd5408d2ffcdb14aee50bec8fb5022ae683b896b2f08ed6db7b2e7d42780d5c8b51e930e9c322bd7c7a517f4fa7c76983d0873c83245885ac5ee13e3
   languageName: node
   linkType: hard
@@ -13369,15 +13137,15 @@ __metadata:
   version: 4.2.3
   resolution: "terser-webpack-plugin@npm:4.2.3"
   dependencies:
-    cacache: ^15.0.5
-    find-cache-dir: ^3.3.1
-    jest-worker: ^26.5.0
-    p-limit: ^3.0.2
-    schema-utils: ^3.0.0
-    serialize-javascript: ^5.0.1
-    source-map: ^0.6.1
-    terser: ^5.3.4
-    webpack-sources: ^1.4.3
+    cacache: "npm:^15.0.5"
+    find-cache-dir: "npm:^3.3.1"
+    jest-worker: "npm:^26.5.0"
+    p-limit: "npm:^3.0.2"
+    schema-utils: "npm:^3.0.0"
+    serialize-javascript: "npm:^5.0.1"
+    source-map: "npm:^0.6.1"
+    terser: "npm:^5.3.4"
+    webpack-sources: "npm:^1.4.3"
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: 52bd036b72b596b162e65dce314f1ee7ba1e82b97200d919b61ad50592dc72608b5fe50d7e3f6c0934e42183dfc746b98b922c9e1d00d75253933f799687fa4b
@@ -13388,9 +13156,9 @@ __metadata:
   version: 5.10.0
   resolution: "terser@npm:5.10.0"
   dependencies:
-    commander: ^2.20.0
-    source-map: ~0.7.2
-    source-map-support: ~0.5.20
+    commander: "npm:^2.20.0"
+    source-map: "npm:~0.7.2"
+    source-map-support: "npm:~0.5.20"
   peerDependencies:
     acorn: ^8.5.0
   peerDependenciesMeta:
@@ -13406,11 +13174,11 @@ __metadata:
   version: 4.2.3
   resolution: "test-exclude@npm:4.2.3"
   dependencies:
-    arrify: ^1.0.1
-    micromatch: ^2.3.11
-    object-assign: ^4.1.0
-    read-pkg-up: ^1.0.1
-    require-main-filename: ^1.0.1
+    arrify: "npm:^1.0.1"
+    micromatch: "npm:^2.3.11"
+    object-assign: "npm:^4.1.0"
+    read-pkg-up: "npm:^1.0.1"
+    require-main-filename: "npm:^1.0.1"
   checksum: b141824d0b1e11169f97617606a6eb33e5585331674cfd5a280517695bc83d3a49a68ff744a33b0b6dddd7a7d4e00c52082854f37fd3af513856194f2d6ed275
   languageName: node
   linkType: hard
@@ -13419,10 +13187,10 @@ __metadata:
   version: 5.2.3
   resolution: "test-exclude@npm:5.2.3"
   dependencies:
-    glob: ^7.1.3
-    minimatch: ^3.0.4
-    read-pkg-up: ^4.0.0
-    require-main-filename: ^2.0.0
+    glob: "npm:^7.1.3"
+    minimatch: "npm:^3.0.4"
+    read-pkg-up: "npm:^4.0.0"
+    require-main-filename: "npm:^2.0.0"
   checksum: 36d767a6ab71b170aa42092a5d540d6974a350fcfed342f29351c6e47cf061b73fabb4fe8b316ce989d6a7f058475417af209818e3702f5e7e17f4544a93535c
   languageName: node
   linkType: hard
@@ -13438,8 +13206,8 @@ __metadata:
   version: 0.6.5
   resolution: "through2@npm:0.6.5"
   dependencies:
-    readable-stream: ">=1.0.33-1 <1.1.0-0"
-    xtend: ">=4.0.0 <4.1.0-0"
+    readable-stream: "npm:>=1.0.33-1 <1.1.0-0"
+    xtend: "npm:>=4.0.0 <4.1.0-0"
   checksum: 3294325d73b120ffbb8cd00e28a649a99e194cef2638bf782b6c2eb0c163b388f7b7bb908003949f58f9f6b8f771defd24b6e4df051eb410fd87931521963b98
   languageName: node
   linkType: hard
@@ -13455,8 +13223,8 @@ __metadata:
   version: 0.1.7
   resolution: "timers-ext@npm:0.1.7"
   dependencies:
-    es5-ext: ~0.10.46
-    next-tick: 1
+    es5-ext: "npm:~0.10.46"
+    next-tick: "npm:1"
   checksum: fc43c6a01f52875e57d301ae9ec47b3021c6d9b96de5bc6e4e5fc4a3d2b25ebaab69faf6fe85520efbef0ad784537748f88f7efd7b6b2bf0a177c8bc7a66ca7c
   languageName: node
   linkType: hard
@@ -13465,12 +13233,12 @@ __metadata:
   version: 0.2.1
   resolution: "tiny-lr@npm:0.2.1"
   dependencies:
-    body-parser: ~1.14.0
-    debug: ~2.2.0
-    faye-websocket: ~0.10.0
-    livereload-js: ^2.2.0
-    parseurl: ~1.3.0
-    qs: ~5.1.0
+    body-parser: "npm:~1.14.0"
+    debug: "npm:~2.2.0"
+    faye-websocket: "npm:~0.10.0"
+    livereload-js: "npm:^2.2.0"
+    parseurl: "npm:~1.3.0"
+    qs: "npm:~5.1.0"
   checksum: 1c8e27b954cecdeab979d79c15c5a5b3819e3e2a93c7aa49d28d3c650faae8e1c481edd1a4a31ead83e8d35a813c058c4473bf068d1029c8041336f4ab969f1e
   languageName: node
   linkType: hard
@@ -13479,7 +13247,7 @@ __metadata:
   version: 2.3.0
   resolution: "tiny-worker@npm:2.3.0"
   dependencies:
-    esm: ^3.2.25
+    esm: "npm:^3.2.25"
   checksum: 3106cace86e673216426a517e96fb72ce642ba79002554e4c6bceb585ba77cf5e5e68b452c752cada6136ae94fdbf11c56943a70de6c6bc6a2a3a9ae439746c9
   languageName: node
   linkType: hard
@@ -13497,7 +13265,7 @@ __metadata:
   version: 0.0.28
   resolution: "tmp@npm:0.0.28"
   dependencies:
-    os-tmpdir: ~1.0.1
+    os-tmpdir: "npm:~1.0.1"
   checksum: 2be352b43206411d4f7c29d09afa03c94e93386fdd87d9973aecd2b6569b8fda1e7a96ed613ac9b2dc30038a9a3ec762b9f4b910d311e565124653750a991dac
   languageName: node
   linkType: hard
@@ -13506,7 +13274,7 @@ __metadata:
   version: 0.0.33
   resolution: "tmp@npm:0.0.33"
   dependencies:
-    os-tmpdir: ~1.0.2
+    os-tmpdir: "npm:~1.0.2"
   checksum: 69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
   languageName: node
   linkType: hard
@@ -13529,7 +13297,7 @@ __metadata:
   version: 0.3.0
   resolution: "to-object-path@npm:0.3.0"
   dependencies:
-    kind-of: ^3.0.2
+    kind-of: "npm:^3.0.2"
   checksum: 731832a977614c03a770363ad2bd9e9c82f233261861724a8e612bb90c705b94b1a290a19f52958e8e179180bb9b71121ed65e245691a421467726f06d1d7fc3
   languageName: node
   linkType: hard
@@ -13545,8 +13313,8 @@ __metadata:
   version: 2.1.1
   resolution: "to-regex-range@npm:2.1.1"
   dependencies:
-    is-number: ^3.0.0
-    repeat-string: ^1.6.1
+    is-number: "npm:^3.0.0"
+    repeat-string: "npm:^1.6.1"
   checksum: 440d82dbfe0b2e24f36dd8a9467240406ad1499fc8b2b0f547372c22ed1d092ace2a3eb522bb09bfd9c2f39bf1ca42eb78035cf6d2b8c9f5c78da3abc96cd949
   languageName: node
   linkType: hard
@@ -13555,7 +13323,7 @@ __metadata:
   version: 5.0.1
   resolution: "to-regex-range@npm:5.0.1"
   dependencies:
-    is-number: ^7.0.0
+    is-number: "npm:^7.0.0"
   checksum: 487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
   languageName: node
   linkType: hard
@@ -13564,10 +13332,10 @@ __metadata:
   version: 3.0.2
   resolution: "to-regex@npm:3.0.2"
   dependencies:
-    define-property: ^2.0.2
-    extend-shallow: ^3.0.2
-    regex-not: ^1.0.2
-    safe-regex: ^1.1.0
+    define-property: "npm:^2.0.2"
+    extend-shallow: "npm:^3.0.2"
+    regex-not: "npm:^1.0.2"
+    safe-regex: "npm:^1.1.0"
   checksum: 99d0b8ef397b3f7abed4bac757b0f0bb9f52bfd39167eb7105b144becfaa9a03756892352d01ac6a911f0c1ceef9f81db68c46899521a3eed054082042796120
   languageName: node
   linkType: hard
@@ -13583,8 +13351,8 @@ __metadata:
   version: 2.5.0
   resolution: "tough-cookie@npm:2.5.0"
   dependencies:
-    psl: ^1.1.28
-    punycode: ^2.1.1
+    psl: "npm:^1.1.28"
+    punycode: "npm:^2.1.1"
   checksum: e1cadfb24d40d64ca16de05fa8192bc097b66aeeb2704199b055ff12f450e4f30c927ce250f53d01f39baad18e1c11d66f65e545c5c6269de4c366fafa4c0543
   languageName: node
   linkType: hard
@@ -13600,7 +13368,7 @@ __metadata:
   version: 2.3.4
   resolution: "tough-cookie@npm:2.3.4"
   dependencies:
-    punycode: ^1.4.1
+    punycode: "npm:^1.4.1"
   checksum: 2d38481f3b18bc4469eb4c438003bd3fe33b0f74c54f56891ba11f39893d4c46557c09aaa2e49f2f585f28291fa35fe0e6915ed64f65957c7c9316775b6e6d89
   languageName: node
   linkType: hard
@@ -13609,13 +13377,6 @@ __metadata:
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
   checksum: 047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
-  languageName: node
-  linkType: hard
-
-"trim-newlines@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "trim-newlines@npm:1.0.0"
-  checksum: ae859c83d0dbcbde32245509f7c51a4bc9696d56e080bc19acc95c4188381e34fba05a4b2fefb47b4ee4537150a11d57a0fd3cd1179837c06210795d7f62e795
   languageName: node
   linkType: hard
 
@@ -13630,7 +13391,7 @@ __metadata:
   version: 1.0.0
   resolution: "trim-repeated@npm:1.0.0"
   dependencies:
-    escape-string-regexp: ^1.0.2
+    escape-string-regexp: "npm:^1.0.2"
   checksum: 89acada0142ed0cdb113615a3e82fdb09e7fdb0e3504ded62762dd935bc27debfcc38edefa497dc7145d8dc8602d40dd9eec891e0ea6c28fa0cc384200b692db
   languageName: node
   linkType: hard
@@ -13642,21 +13403,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"true-case-path@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "true-case-path@npm:1.0.3"
-  dependencies:
-    glob: ^7.1.2
-  checksum: 6235caddf342fd04281001e6724fd302bdc77b4977bcff4d1fea8ca3539e75398b14120b48f1cf3de9a0ce35a5fa1aaf62e0e0a60e7322a1b37e772af876e19b
-  languageName: node
-  linkType: hard
-
 "ts-mocha@npm:^7.0.0":
   version: 7.0.0
   resolution: "ts-mocha@npm:7.0.0"
   dependencies:
-    ts-node: 7.0.1
-    tsconfig-paths: ^3.5.0
+    ts-node: "npm:7.0.1"
+    tsconfig-paths: "npm:^3.5.0"
   peerDependencies:
     mocha: ^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X
   dependenciesMeta:
@@ -13672,14 +13424,14 @@ __metadata:
   version: 7.0.1
   resolution: "ts-node@npm:7.0.1"
   dependencies:
-    arrify: ^1.0.0
-    buffer-from: ^1.1.0
-    diff: ^3.1.0
-    make-error: ^1.1.1
-    minimist: ^1.2.0
-    mkdirp: ^0.5.1
-    source-map-support: ^0.5.6
-    yn: ^2.0.0
+    arrify: "npm:^1.0.0"
+    buffer-from: "npm:^1.1.0"
+    diff: "npm:^3.1.0"
+    make-error: "npm:^1.1.1"
+    minimist: "npm:^1.2.0"
+    mkdirp: "npm:^0.5.1"
+    source-map-support: "npm:^0.5.6"
+    yn: "npm:^2.0.0"
   bin:
     ts-node: dist/bin.js
   checksum: d6307766a716a77999e11c7f310312cf9d6addb98859d71e71d611ecafa6bdb90f07365f9acf7e9489cb43cfc2211486303172c3bcda370d20f0be54884fe647
@@ -13690,10 +13442,10 @@ __metadata:
   version: 3.12.0
   resolution: "tsconfig-paths@npm:3.12.0"
   dependencies:
-    "@types/json5": ^0.0.29
-    json5: ^1.0.1
-    minimist: ^1.2.0
-    strip-bom: ^3.0.0
+    "@types/json5": "npm:^0.0.29"
+    json5: "npm:^1.0.1"
+    minimist: "npm:^1.2.0"
+    strip-bom: "npm:^3.0.0"
   checksum: 3e3ccdd48868cd6e9ba2ebbd0ca9bc316cc50953490f23a0469c04fac22d9a33c0812e5102c9fdb22aab1fbca809bd1a34fe65b2c41f68e2688bc487f7928518
   languageName: node
   linkType: hard
@@ -13709,7 +13461,7 @@ __metadata:
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
   dependencies:
-    tslib: ^1.8.1
+    tslib: "npm:^1.8.1"
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 02f19e458ec78ead8fffbf711f834ad8ecd2cc6ade4ec0320790713dccc0a412b99e7fd907c4cda2a1dc602c75db6f12e0108e87a5afad4b2f9e90a24cabd5a2
@@ -13720,7 +13472,7 @@ __metadata:
   version: 0.6.0
   resolution: "tunnel-agent@npm:0.6.0"
   dependencies:
-    safe-buffer: ^5.0.1
+    safe-buffer: "npm:^5.0.1"
   checksum: 4c7a1b813e7beae66fdbf567a65ec6d46313643753d0beefb3c7973d66fcec3a1e7f39759f0a0b4465883499c6dc8b0750ab8b287399af2e583823e40410a17a
   languageName: node
   linkType: hard
@@ -13736,7 +13488,7 @@ __metadata:
   version: 0.3.2
   resolution: "type-check@npm:0.3.2"
   dependencies:
-    prelude-ls: ~1.1.2
+    prelude-ls: "npm:~1.1.2"
   checksum: 776217116b2b4e50e368c7ee0c22c0a85e982881c16965b90d52f216bc296d6a52ef74f9202d22158caacc092a7645b0b8d5fe529a96e3fe35d0fb393966c875
   languageName: node
   linkType: hard
@@ -13787,8 +13539,8 @@ __metadata:
   version: 1.6.18
   resolution: "type-is@npm:1.6.18"
   dependencies:
-    media-typer: 0.3.0
-    mime-types: ~2.1.24
+    media-typer: "npm:0.3.0"
+    mime-types: "npm:~2.1.24"
   checksum: a23daeb538591b7efbd61ecf06b6feb2501b683ffdc9a19c74ef5baba362b4347e42f1b4ed81f5882a8c96a3bfff7f93ce3ffaf0cbbc879b532b04c97a55db9d
   languageName: node
   linkType: hard
@@ -13824,9 +13576,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^3.8.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^3.8.3#optional!builtin<compat/typescript>":
   version: 3.9.10
-  resolution: "typescript@patch:typescript@npm%3A3.9.10#~builtin<compat/typescript>::version=3.9.10&hash=142761"
+  resolution: "typescript@patch:typescript@npm%3A3.9.10#optional!builtin<compat/typescript>::version=3.9.10&hash=3bd3d3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
@@ -13838,9 +13590,9 @@ __metadata:
   version: 2.8.29
   resolution: "uglify-js@npm:2.8.29"
   dependencies:
-    source-map: ~0.5.1
-    uglify-to-browserify: ~1.0.0
-    yargs: ~3.10.0
+    source-map: "npm:~0.5.1"
+    uglify-to-browserify: "npm:~1.0.0"
+    yargs: "npm:~3.10.0"
   dependenciesMeta:
     uglify-to-browserify:
       optional: true
@@ -13875,10 +13627,10 @@ __metadata:
   version: 1.0.1
   resolution: "unbox-primitive@npm:1.0.1"
   dependencies:
-    function-bind: ^1.1.1
-    has-bigints: ^1.0.1
-    has-symbols: ^1.0.2
-    which-boxed-primitive: ^1.0.2
+    function-bind: "npm:^1.1.1"
+    has-bigints: "npm:^1.0.1"
+    has-symbols: "npm:^1.0.2"
+    which-boxed-primitive: "npm:^1.0.2"
   checksum: 6f0b91b0744c6f9fd05afa70484914b70686596be628543a143fab018733f902ff39fad2c3cf8f00fd5d32ba8bce8edf9cf61cee940c1af892316e112b25812b
   languageName: node
   linkType: hard
@@ -13894,8 +13646,8 @@ __metadata:
   version: 2.0.0
   resolution: "unicode-match-property-ecmascript@npm:2.0.0"
   dependencies:
-    unicode-canonical-property-names-ecmascript: ^2.0.0
-    unicode-property-aliases-ecmascript: ^2.0.0
+    unicode-canonical-property-names-ecmascript: "npm:^2.0.0"
+    unicode-property-aliases-ecmascript: "npm:^2.0.0"
   checksum: 4d05252cecaf5c8e36d78dc5332e03b334c6242faf7cf16b3658525441386c0a03b5f603d42cbec0f09bb63b9fd25c9b3b09667aee75463cac3efadae2cd17ec
   languageName: node
   linkType: hard
@@ -13918,10 +13670,10 @@ __metadata:
   version: 1.0.1
   resolution: "union-value@npm:1.0.1"
   dependencies:
-    arr-union: ^3.1.0
-    get-value: ^2.0.6
-    is-extendable: ^0.1.1
-    set-value: ^2.0.1
+    arr-union: "npm:^3.1.0"
+    get-value: "npm:^2.0.6"
+    is-extendable: "npm:^0.1.1"
+    set-value: "npm:^2.0.1"
   checksum: 8758d880cb9545f62ce9cfb9b791b2b7a206e0ff5cc4b9d7cd6581da2c6839837fbb45e639cf1fd8eef3cae08c0201b614b7c06dd9f5f70d9dbe7c5fe2fbf592
   languageName: node
   linkType: hard
@@ -13930,7 +13682,7 @@ __metadata:
   version: 1.1.1
   resolution: "unique-filename@npm:1.1.1"
   dependencies:
-    unique-slug: ^2.0.0
+    unique-slug: "npm:^2.0.0"
   checksum: d005bdfaae6894da8407c4de2b52f38b3c58ec86e79fc2ee19939da3085374413b073478ec54e721dc8e32b102cf9e50d0481b8331abdc62202e774b789ea874
   languageName: node
   linkType: hard
@@ -13939,7 +13691,7 @@ __metadata:
   version: 2.0.2
   resolution: "unique-slug@npm:2.0.2"
   dependencies:
-    imurmurhash: ^0.1.4
+    imurmurhash: "npm:^0.1.4"
   checksum: 9eabc51680cf0b8b197811a48857e41f1364b25362300c1ff636c0eca5ec543a92a38786f59cf0697e62c6f814b11ecbe64e8093db71246468a1f03b80c83970
   languageName: node
   linkType: hard
@@ -13948,7 +13700,7 @@ __metadata:
   version: 1.0.0
   resolution: "unique-string@npm:1.0.0"
   dependencies:
-    crypto-random-string: ^1.0.0
+    crypto-random-string: "npm:^1.0.0"
   checksum: 79cc2a6515a51e6350c74f65c92246511966c47528f1119318cbe8d68a508842f4e5a2a81857a65f3919629397a525f820505116dd89cac425294598e35ca12c
   languageName: node
   linkType: hard
@@ -13971,8 +13723,8 @@ __metadata:
   version: 1.0.0
   resolution: "unset-value@npm:1.0.0"
   dependencies:
-    has-value: ^0.3.1
-    isobject: ^3.0.0
+    has-value: "npm:^0.3.1"
+    isobject: "npm:^3.0.0"
   checksum: 68a796dde4a373afdbf017de64f08490a3573ebee549136da0b3a2245299e7f65f647ef70dc13c4ac7f47b12fba4de1646fa0967a365638578fedce02b9c0b1f
   languageName: node
   linkType: hard
@@ -13981,18 +13733,18 @@ __metadata:
   version: 3.0.1
   resolution: "update-notifier@npm:3.0.1"
   dependencies:
-    boxen: ^3.0.0
-    chalk: ^2.0.1
-    configstore: ^4.0.0
-    has-yarn: ^2.1.0
-    import-lazy: ^2.1.0
-    is-ci: ^2.0.0
-    is-installed-globally: ^0.1.0
-    is-npm: ^3.0.0
-    is-yarn-global: ^0.3.0
-    latest-version: ^5.0.0
-    semver-diff: ^2.0.0
-    xdg-basedir: ^3.0.0
+    boxen: "npm:^3.0.0"
+    chalk: "npm:^2.0.1"
+    configstore: "npm:^4.0.0"
+    has-yarn: "npm:^2.1.0"
+    import-lazy: "npm:^2.1.0"
+    is-ci: "npm:^2.0.0"
+    is-installed-globally: "npm:^0.1.0"
+    is-npm: "npm:^3.0.0"
+    is-yarn-global: "npm:^0.3.0"
+    latest-version: "npm:^5.0.0"
+    semver-diff: "npm:^2.0.0"
+    xdg-basedir: "npm:^3.0.0"
   checksum: 4ddce2b8a1be04ebf0f7342216d5f2c9d2f1dc37a1b0fb6f6cc0beeec1fc6c20e095f11c9b6b54a319ae471716c1bb25b6f779568d8ee2b59612f4bbd923e685
   languageName: node
   linkType: hard
@@ -14001,7 +13753,7 @@ __metadata:
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
   dependencies:
-    punycode: ^2.1.0
+    punycode: "npm:^2.1.0"
   checksum: 4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
   languageName: node
   linkType: hard
@@ -14024,7 +13776,7 @@ __metadata:
   version: 3.0.0
   resolution: "url-parse-lax@npm:3.0.0"
   dependencies:
-    prepend-http: ^2.0.0
+    prepend-http: "npm:^2.0.0"
   checksum: 16f918634d41a4fab9e03c5f9702968c9930f7c29aa1a8c19a6dc01f97d02d9b700ab9f47f8da0b9ace6e0c0e99c27848994de1465b494bced6940c653481e55
   languageName: node
   linkType: hard
@@ -14033,8 +13785,8 @@ __metadata:
   version: 5.0.0
   resolution: "url-regex@npm:5.0.0"
   dependencies:
-    ip-regex: ^4.1.0
-    tlds: ^1.203.0
+    ip-regex: "npm:^4.1.0"
+    tlds: "npm:^1.203.0"
   checksum: 86d7bd8ecf5e8bd6152376292e6953d9a7cab668384d7967ea8201d87edf41799fbda5ff4110a3c16090c7c5b21787e46a6f2b2189a46deb3fd8e0aa9224a347
   languageName: node
   linkType: hard
@@ -14064,12 +13816,12 @@ __metadata:
   version: 0.12.4
   resolution: "util@npm:0.12.4"
   dependencies:
-    inherits: ^2.0.3
-    is-arguments: ^1.0.4
-    is-generator-function: ^1.0.7
-    is-typed-array: ^1.1.3
-    safe-buffer: ^5.1.2
-    which-typed-array: ^1.1.2
+    inherits: "npm:^2.0.3"
+    is-arguments: "npm:^1.0.4"
+    is-generator-function: "npm:^1.0.7"
+    is-typed-array: "npm:^1.1.3"
+    safe-buffer: "npm:^5.1.2"
+    which-typed-array: "npm:^1.1.2"
   checksum: 3e04e6feb68bccdc9fdfa013050719b3b41ce698ff5e244ee683d675b7fb9b91c8a1594b164696ee2201cca9579c286b968d0aabd9c9069ae1667413940a4e49
   languageName: node
   linkType: hard
@@ -14094,8 +13846,8 @@ __metadata:
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
   dependencies:
-    spdx-correct: ^3.0.0
-    spdx-expression-parse: ^3.0.0
+    spdx-correct: "npm:^3.0.0"
+    spdx-expression-parse: "npm:^3.0.0"
   checksum: 7b91e455a8de9a0beaa9fe961e536b677da7f48c9a493edf4d4d4a87fd80a7a10267d438723364e432c2fcd00b5650b5378275cded362383ef570276e6312f4f
   languageName: node
   linkType: hard
@@ -14104,7 +13856,7 @@ __metadata:
   version: 3.0.0
   resolution: "validate-npm-package-name@npm:3.0.0"
   dependencies:
-    builtins: ^1.0.3
+    builtins: "npm:^1.0.3"
   checksum: 064f21f59aefae6cc286dd4a50b15d14adb0227e0facab4316197dfb8d06801669e997af5081966c15f7828a5e6ff1957bd20886aeb6b9d0fa430e4cb5db9c4a
   languageName: node
   linkType: hard
@@ -14113,7 +13865,7 @@ __metadata:
   version: 2.2.2
   resolution: "validate-npm-package-name@npm:2.2.2"
   dependencies:
-    builtins: 0.0.7
+    builtins: "npm:0.0.7"
   checksum: 8184da7f70d8ca3041b96a7905cce3eb12a9267ab9057ea58886ea326979aec9c00877d4ee4395597800ad562c3ea8c14d25690e2757870f3940287c3616b94d
   languageName: node
   linkType: hard
@@ -14122,9 +13874,9 @@ __metadata:
   version: 1.10.0
   resolution: "verror@npm:1.10.0"
   dependencies:
-    assert-plus: ^1.0.0
-    core-util-is: 1.0.2
-    extsprintf: ^1.2.0
+    assert-plus: "npm:^1.0.0"
+    core-util-is: "npm:1.0.2"
+    extsprintf: "npm:^1.2.0"
   checksum: 37ccdf8542b5863c525128908ac80f2b476eed36a32cb944de930ca1e2e78584cc435c4b9b4c68d0fc13a47b45ff364b4be43aa74f8804f9050140f660fb660d
   languageName: node
   linkType: hard
@@ -14133,8 +13885,8 @@ __metadata:
   version: 2.3.1
   resolution: "watchpack@npm:2.3.1"
   dependencies:
-    glob-to-regexp: ^0.4.1
-    graceful-fs: ^4.1.2
+    glob-to-regexp: "npm:^0.4.1"
+    graceful-fs: "npm:^4.1.2"
   checksum: 00e44f5cc6ca299dd1ff52bf926a70a23ae1aeb6b399b7e32569d6d31ef1fc9bc3f5570ade6fef220dd6d74ee70259c9621b79cf487552caf1ea2727aa40f984
   languageName: node
   linkType: hard
@@ -14143,7 +13895,7 @@ __metadata:
   version: 1.0.1
   resolution: "wcwidth@npm:1.0.1"
   dependencies:
-    defaults: ^1.0.3
+    defaults: "npm:^1.0.3"
   checksum: 5b61ca583a95e2dd85d7078400190efd452e05751a64accb8c06ce4db65d7e0b0cde9917d705e826a2e05cc2548f61efde115ffa374c3e436d04be45c889e5b4
   languageName: node
   linkType: hard
@@ -14152,15 +13904,15 @@ __metadata:
   version: 2.0.0
   resolution: "web-resource-inliner@npm:2.0.0"
   dependencies:
-    async: ^0.9.0
-    clean-css: 1.1.7
-    cli-color: ^0.3.2
-    datauri: ~0.2.0
-    htmlparser2: ^3.9.0
-    lodash: ^3.10.1
-    request: ^2.49.0
-    uglify-js: ^2.4.1
-    xtend: ^4.0.0
+    async: "npm:^0.9.0"
+    clean-css: "npm:1.1.7"
+    cli-color: "npm:^0.3.2"
+    datauri: "npm:~0.2.0"
+    htmlparser2: "npm:^3.9.0"
+    lodash: "npm:^3.10.1"
+    request: "npm:^2.49.0"
+    uglify-js: "npm:^2.4.1"
+    xtend: "npm:^4.0.0"
   checksum: cfac3be6befeca146717399706c51497d58ad614fd82c4161b132bbc2d7856ca1ea28fd425960797eb6cf62943282a9be7d91f93d8f5f555eabf8165a023a862
   languageName: node
   linkType: hard
@@ -14176,8 +13928,8 @@ __metadata:
   version: 1.4.3
   resolution: "webpack-sources@npm:1.4.3"
   dependencies:
-    source-list-map: ^2.0.0
-    source-map: ~0.6.1
+    source-list-map: "npm:^2.0.0"
+    source-map: "npm:~0.6.1"
   checksum: 78dafb3e1e297d3f4eb6204311e8c64d28cd028f82887ba33aaf03fffc82482d8e1fdf6de25a60f4dde621d3565f4c3b1bfb350f09add8f4e54e00279ff3db5e
   languageName: node
   linkType: hard
@@ -14186,8 +13938,8 @@ __metadata:
   version: 2.3.1
   resolution: "webpack-sources@npm:2.3.1"
   dependencies:
-    source-list-map: ^2.0.1
-    source-map: ^0.6.1
+    source-list-map: "npm:^2.0.1"
+    source-map: "npm:^0.6.1"
   checksum: caf56a9a478eca7e77feca2b6ddc7673f1384eb870280014b300c40cf42abca656f639ff58a8d55a889a92a810ae3c22e71e578aa38fde416e8c2e6827a6ddfd
   languageName: node
   linkType: hard
@@ -14196,30 +13948,30 @@ __metadata:
   version: 5.0.0
   resolution: "webpack@npm:5.0.0"
   dependencies:
-    "@types/eslint-scope": ^3.7.0
-    "@types/estree": ^0.0.45
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-module-context": 1.9.0
-    "@webassemblyjs/wasm-edit": 1.9.0
-    "@webassemblyjs/wasm-parser": 1.9.0
-    acorn: ^8.0.3
-    browserslist: ^4.14.3
-    chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.2.0
-    eslint-scope: ^5.1.0
-    events: ^3.2.0
-    glob-to-regexp: ^0.4.1
-    graceful-fs: ^4.2.4
-    json-parse-better-errors: ^1.0.2
-    loader-runner: ^4.1.0
-    mime-types: ^2.1.27
-    neo-async: ^2.6.2
-    pkg-dir: ^4.2.0
-    schema-utils: ^3.0.0
-    tapable: ^2.0.0
-    terser-webpack-plugin: ^4.1.0
-    watchpack: ^2.0.0
-    webpack-sources: ^2.0.1
+    "@types/eslint-scope": "npm:^3.7.0"
+    "@types/estree": "npm:^0.0.45"
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-module-context": "npm:1.9.0"
+    "@webassemblyjs/wasm-edit": "npm:1.9.0"
+    "@webassemblyjs/wasm-parser": "npm:1.9.0"
+    acorn: "npm:^8.0.3"
+    browserslist: "npm:^4.14.3"
+    chrome-trace-event: "npm:^1.0.2"
+    enhanced-resolve: "npm:^5.2.0"
+    eslint-scope: "npm:^5.1.0"
+    events: "npm:^3.2.0"
+    glob-to-regexp: "npm:^0.4.1"
+    graceful-fs: "npm:^4.2.4"
+    json-parse-better-errors: "npm:^1.0.2"
+    loader-runner: "npm:^4.1.0"
+    mime-types: "npm:^2.1.27"
+    neo-async: "npm:^2.6.2"
+    pkg-dir: "npm:^4.2.0"
+    schema-utils: "npm:^3.0.0"
+    tapable: "npm:^2.0.0"
+    terser-webpack-plugin: "npm:^4.1.0"
+    watchpack: "npm:^2.0.0"
+    webpack-sources: "npm:^2.0.1"
   peerDependenciesMeta:
     webpack-cli:
       optional: true
@@ -14233,9 +13985,9 @@ __metadata:
   version: 0.7.4
   resolution: "websocket-driver@npm:0.7.4"
   dependencies:
-    http-parser-js: ">=0.5.1"
-    safe-buffer: ">=5.1.0"
-    websocket-extensions: ">=0.1.1"
+    http-parser-js: "npm:>=0.5.1"
+    safe-buffer: "npm:>=5.1.0"
+    websocket-extensions: "npm:>=0.1.1"
   checksum: 5f09547912b27bdc57bac17b7b6527d8993aa4ac8a2d10588bb74aebaf785fdcf64fea034aae0c359b7adff2044dd66f3d03866e4685571f81b13e548f9021f1
   languageName: node
   linkType: hard
@@ -14251,7 +14003,7 @@ __metadata:
   version: 0.6.5
   resolution: "whatwg-url-compat@npm:0.6.5"
   dependencies:
-    tr46: ~0.0.1
+    tr46: "npm:~0.0.1"
   checksum: 61686aaf984f01ee920d63255e5e168478e29c79a64ec7236403ead7512caaa3bad3a2ee14922b7458d114de3df9c0457f0eeabd55cc16528464ed22b4e017a8
   languageName: node
   linkType: hard
@@ -14260,11 +14012,11 @@ __metadata:
   version: 1.0.2
   resolution: "which-boxed-primitive@npm:1.0.2"
   dependencies:
-    is-bigint: ^1.0.1
-    is-boolean-object: ^1.1.0
-    is-number-object: ^1.0.4
-    is-string: ^1.0.5
-    is-symbol: ^1.0.3
+    is-bigint: "npm:^1.0.1"
+    is-boolean-object: "npm:^1.1.0"
+    is-number-object: "npm:^1.0.4"
+    is-string: "npm:^1.0.5"
+    is-symbol: "npm:^1.0.3"
   checksum: 0a62a03c00c91dd4fb1035b2f0733c341d805753b027eebd3a304b9cb70e8ce33e25317add2fe9b5fea6f53a175c0633ae701ff812e604410ddd049777cd435e
   languageName: node
   linkType: hard
@@ -14280,12 +14032,12 @@ __metadata:
   version: 1.1.7
   resolution: "which-typed-array@npm:1.1.7"
   dependencies:
-    available-typed-arrays: ^1.0.5
-    call-bind: ^1.0.2
-    es-abstract: ^1.18.5
-    foreach: ^2.0.5
-    has-tostringtag: ^1.0.0
-    is-typed-array: ^1.1.7
+    available-typed-arrays: "npm:^1.0.5"
+    call-bind: "npm:^1.0.2"
+    es-abstract: "npm:^1.18.5"
+    foreach: "npm:^2.0.5"
+    has-tostringtag: "npm:^1.0.0"
+    is-typed-array: "npm:^1.1.7"
   checksum: 3b22173c483037c672a2a82cf19dbbd9446bf34cf8d0a5b8f8eefdcda85f821a0f8352cdf1a8c6181b40b6cc55be58f53e90eb18523e96b6cef1bf0633454d7d
   languageName: node
   linkType: hard
@@ -14294,7 +14046,7 @@ __metadata:
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:
-    isexe: ^2.0.0
+    isexe: "npm:^2.0.0"
   bin:
     which: ./bin/which
   checksum: e945a8b6bbf6821aaaef7f6e0c309d4b615ef35699576d5489b4261da9539f70393c6b2ce700ee4321c18f914ebe5644bc4631b15466ffbaad37d83151f6af59
@@ -14305,7 +14057,7 @@ __metadata:
   version: 2.0.2
   resolution: "which@npm:2.0.2"
   dependencies:
-    isexe: ^2.0.0
+    isexe: "npm:^2.0.0"
   bin:
     node-which: ./bin/node-which
   checksum: 66522872a768b60c2a65a57e8ad184e5372f5b6a9ca6d5f033d4b0dc98aff63995655a7503b9c0a2598936f532120e81dd8cc155e2e92ed662a2b9377cc4374f
@@ -14316,7 +14068,7 @@ __metadata:
   version: 1.2.14
   resolution: "which@npm:1.2.14"
   dependencies:
-    isexe: ^2.0.0
+    isexe: "npm:^2.0.0"
   bin:
     which: ./bin/which
   checksum: 307d72767a0f1fd6bf2cfe5545f8738e5c840ddd3cad3a8c85694a9437e9fbd2a570b8007807a4028fb84c495ba8f21d2d43a4372eb551c6f4fdaa63839097bf
@@ -14327,7 +14079,7 @@ __metadata:
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
   dependencies:
-    string-width: ^1.0.2 || 2 || 3 || 4
+    string-width: "npm:^1.0.2 || 2 || 3 || 4"
   checksum: 1d9c2a3e36dfb09832f38e2e699c367ef190f96b82c71f809bc0822c306f5379df87bab47bed27ea99106d86447e50eb972d3c516c2f95782807a9d082fbea95
   languageName: node
   linkType: hard
@@ -14336,7 +14088,7 @@ __metadata:
   version: 2.0.1
   resolution: "widest-line@npm:2.0.1"
   dependencies:
-    string-width: ^2.1.1
+    string-width: "npm:^2.1.1"
   checksum: c8c908c737b522a8cf46254bc85b3b0c9e6934a054840d9b01ea7f36442aa11c8393579fa57bc9ef9a5c5ea69f49e78783ce27b8a8ebab4f855ca044efa584fa
   languageName: node
   linkType: hard
@@ -14382,8 +14134,8 @@ __metadata:
   version: 3.0.8
   resolution: "worker-loader@npm:3.0.8"
   dependencies:
-    loader-utils: ^2.0.0
-    schema-utils: ^3.0.0
+    loader-utils: "npm:^2.0.0"
+    schema-utils: "npm:^3.0.0"
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: a81218a21efa05ab75265e9f6af9c2e27774aa8ca10737f849a094fa2b422ec14df82c35cbb285edb9f2d128b8038ae7dba6183c2f4fbdce20f216662df28244
@@ -14401,8 +14153,8 @@ __metadata:
   version: 2.1.0
   resolution: "wrap-ansi@npm:2.1.0"
   dependencies:
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
+    string-width: "npm:^1.0.1"
+    strip-ansi: "npm:^3.0.1"
   checksum: 1a47367eef192fc9ecaf00238bad5de8987c3368082b619ab36c5e2d6d7b0a2aef95a2ca65840be598c56ced5090a3ba487956c7aee0cac7c45017502fa980fb
   languageName: node
   linkType: hard
@@ -14411,8 +14163,8 @@ __metadata:
   version: 3.0.1
   resolution: "wrap-ansi@npm:3.0.1"
   dependencies:
-    string-width: ^2.1.1
-    strip-ansi: ^4.0.0
+    string-width: "npm:^2.1.1"
+    strip-ansi: "npm:^4.0.0"
   checksum: ad6fed8f242c26755badaf452da154122d0d862f8b7aab56e758466857f230efafdc5fbffca026650b947ac3fc0eb563df5c05b9e2190a52a4a68f4eef3d4555
   languageName: node
   linkType: hard
@@ -14421,9 +14173,9 @@ __metadata:
   version: 5.1.0
   resolution: "wrap-ansi@npm:5.1.0"
   dependencies:
-    ansi-styles: ^3.2.0
-    string-width: ^3.0.0
-    strip-ansi: ^5.0.0
+    ansi-styles: "npm:^3.2.0"
+    string-width: "npm:^3.0.0"
+    strip-ansi: "npm:^5.0.0"
   checksum: fcd0b39b7453df512f2fe8c714a1c1b147fe3e6a4b5a2e4de6cadc3af47212f335eceaffe588e98322d6345e72672137e2c0b834d8a662e73a32296c1c8216bb
   languageName: node
   linkType: hard
@@ -14432,9 +14184,9 @@ __metadata:
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
-    ansi-styles: ^4.0.0
-    string-width: ^4.1.0
-    strip-ansi: ^6.0.0
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
   checksum: d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
   languageName: node
   linkType: hard
@@ -14450,9 +14202,9 @@ __metadata:
   version: 2.4.3
   resolution: "write-file-atomic@npm:2.4.3"
   dependencies:
-    graceful-fs: ^4.1.11
-    imurmurhash: ^0.1.4
-    signal-exit: ^3.0.2
+    graceful-fs: "npm:^4.1.11"
+    imurmurhash: "npm:^0.1.4"
+    signal-exit: "npm:^3.0.2"
   checksum: 8cb4bba0c1ab814a9b127844da0db4fb8c5e06ddbe6317b8b319377c73b283673036c8b9360120062898508b9428d81611cf7fa97584504a00bc179b2a580b92
   languageName: node
   linkType: hard
@@ -14461,9 +14213,9 @@ __metadata:
   version: 1.1.4
   resolution: "write-file-atomic@npm:1.1.4"
   dependencies:
-    graceful-fs: ^4.1.2
-    imurmurhash: ^0.1.4
-    slide: ^1.1.5
+    graceful-fs: "npm:^4.1.2"
+    imurmurhash: "npm:^0.1.4"
+    slide: "npm:^1.1.5"
   checksum: 734a9758029b85be3bd74105a04c46e8aef0e2691f75e6394ae86013b13815f59bbbbeb62f6906db0e5ffc2c55d254251743047ea0ccb50bd6e9cdc1a1768001
   languageName: node
   linkType: hard
@@ -14472,9 +14224,9 @@ __metadata:
   version: 1.2.0
   resolution: "write-file-atomic@npm:1.2.0"
   dependencies:
-    graceful-fs: ^4.1.2
-    imurmurhash: ^0.1.4
-    slide: ^1.1.5
+    graceful-fs: "npm:^4.1.2"
+    imurmurhash: "npm:^0.1.4"
+    slide: "npm:^1.1.5"
   checksum: 265d57299846e50f85cac58b9fb3df120008f6db0e817ea3e6025ffaf97fd6fe2b71e070de7a743789ea8b0965ba1b76a0748f38ffaa4331a800a944da8035aa
   languageName: node
   linkType: hard
@@ -14483,7 +14235,7 @@ __metadata:
   version: 1.0.3
   resolution: "write@npm:1.0.3"
   dependencies:
-    mkdirp: ^0.5.1
+    mkdirp: "npm:^0.5.1"
   checksum: 2ab5472e32ce2d25279a9d22365c5dd5b95fe40497ca43fa329aa61687fca56e36837615a1b6adfc4ca540389383185680a23497d75a1698b1dcbb52741d29a4
   languageName: node
   linkType: hard
@@ -14562,7 +14314,7 @@ __metadata:
   version: 10.1.0
   resolution: "yargs-parser@npm:10.1.0"
   dependencies:
-    camelcase: ^4.1.0
+    camelcase: "npm:^4.1.0"
   checksum: dafdda1b32acfe83d661d373c93e92d13e067ab8603ad269305fa674a5dba4c11db41cbc23557a489302ba171c83ec2951b412bdd33d79db88505ae8f62c8b90
   languageName: node
   linkType: hard
@@ -14571,8 +14323,8 @@ __metadata:
   version: 13.1.2
   resolution: "yargs-parser@npm:13.1.2"
   dependencies:
-    camelcase: ^5.0.0
-    decamelize: ^1.2.0
+    camelcase: "npm:^5.0.0"
+    decamelize: "npm:^1.2.0"
   checksum: aeded49d2285c5e284e48b7c69eab4a6cf1c94decfdba073125cc4054ff49da7128a3c7c840edb6b497a075e455be304e89ba4b9228be35f1ed22f4a7bba62cc
   languageName: node
   linkType: hard
@@ -14588,10 +14340,10 @@ __metadata:
   version: 2.0.0
   resolution: "yargs-unparser@npm:2.0.0"
   dependencies:
-    camelcase: ^6.0.0
-    decamelize: ^4.0.0
-    flat: ^5.0.2
-    is-plain-obj: ^2.1.0
+    camelcase: "npm:^6.0.0"
+    decamelize: "npm:^4.0.0"
+    flat: "npm:^5.0.2"
+    is-plain-obj: "npm:^2.1.0"
   checksum: a5a7d6dc157efa95122e16780c019f40ed91d4af6d2bac066db8194ed0ec5c330abb115daa5a79ff07a9b80b8ea80c925baacf354c4c12edd878c0529927ff03
   languageName: node
   linkType: hard
@@ -14600,17 +14352,17 @@ __metadata:
   version: 14.0.0
   resolution: "yargs@npm:14.0.0"
   dependencies:
-    cliui: ^5.0.0
-    decamelize: ^1.2.0
-    find-up: ^3.0.0
-    get-caller-file: ^2.0.1
-    require-directory: ^2.1.1
-    require-main-filename: ^2.0.0
-    set-blocking: ^2.0.0
-    string-width: ^3.0.0
-    which-module: ^2.0.0
-    y18n: ^4.0.0
-    yargs-parser: ^13.1.1
+    cliui: "npm:^5.0.0"
+    decamelize: "npm:^1.2.0"
+    find-up: "npm:^3.0.0"
+    get-caller-file: "npm:^2.0.1"
+    require-directory: "npm:^2.1.1"
+    require-main-filename: "npm:^2.0.0"
+    set-blocking: "npm:^2.0.0"
+    string-width: "npm:^3.0.0"
+    which-module: "npm:^2.0.0"
+    y18n: "npm:^4.0.0"
+    yargs-parser: "npm:^13.1.1"
   checksum: 3611ee0459cf0919519a158d0726498b4d73aec82f135c42594be59cffabd6ad20b754161544469044be9c858d911a3cb8738cd992222a2c110361e1f6517616
   languageName: node
   linkType: hard
@@ -14619,31 +14371,31 @@ __metadata:
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:
-    cliui: ^7.0.2
-    escalade: ^3.1.1
-    get-caller-file: ^2.0.5
-    require-directory: ^2.1.1
-    string-width: ^4.2.0
-    y18n: ^5.0.5
-    yargs-parser: ^20.2.2
+    cliui: "npm:^7.0.2"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.0"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^20.2.2"
   checksum: b1dbfefa679848442454b60053a6c95d62f2d2e21dd28def92b647587f415969173c6e99a0f3bab4f1b67ee8283bf735ebe3544013f09491186ba9e8a9a2b651
   languageName: node
   linkType: hard
 
-"yargs@npm:^13.2.2, yargs@npm:^13.3.2":
+"yargs@npm:^13.2.2":
   version: 13.3.2
   resolution: "yargs@npm:13.3.2"
   dependencies:
-    cliui: ^5.0.0
-    find-up: ^3.0.0
-    get-caller-file: ^2.0.1
-    require-directory: ^2.1.1
-    require-main-filename: ^2.0.0
-    set-blocking: ^2.0.0
-    string-width: ^3.0.0
-    which-module: ^2.0.0
-    y18n: ^4.0.0
-    yargs-parser: ^13.1.2
+    cliui: "npm:^5.0.0"
+    find-up: "npm:^3.0.0"
+    get-caller-file: "npm:^2.0.1"
+    require-directory: "npm:^2.1.1"
+    require-main-filename: "npm:^2.0.0"
+    set-blocking: "npm:^2.0.0"
+    string-width: "npm:^3.0.0"
+    which-module: "npm:^2.0.0"
+    y18n: "npm:^4.0.0"
+    yargs-parser: "npm:^13.1.2"
   checksum: 6612f9f0ffeee07fff4c85f153d10eba4072bf5c11e1acba96153169f9d771409dfb63253dbb0841ace719264b663cd7b18c75c0eba91af7740e76094239d386
   languageName: node
   linkType: hard
@@ -14652,13 +14404,13 @@ __metadata:
   version: 3.32.0
   resolution: "yargs@npm:3.32.0"
   dependencies:
-    camelcase: ^2.0.1
-    cliui: ^3.0.3
-    decamelize: ^1.1.1
-    os-locale: ^1.4.0
-    string-width: ^1.0.1
-    window-size: ^0.1.4
-    y18n: ^3.2.0
+    camelcase: "npm:^2.0.1"
+    cliui: "npm:^3.0.3"
+    decamelize: "npm:^1.1.1"
+    os-locale: "npm:^1.4.0"
+    string-width: "npm:^1.0.1"
+    window-size: "npm:^0.1.4"
+    y18n: "npm:^3.2.0"
   checksum: 7465b2d28d1f716fe19ca9f6c37862591a7b2a1198ef502cb84e56e952b058bc42d843dafb7fbaf05aef37ea064433828803e8ae9a64ed8340f2358d44b25d4f
   languageName: node
   linkType: hard
@@ -14667,10 +14419,10 @@ __metadata:
   version: 3.10.0
   resolution: "yargs@npm:3.10.0"
   dependencies:
-    camelcase: ^1.0.2
-    cliui: ^2.1.0
-    decamelize: ^1.0.0
-    window-size: 0.1.0
+    camelcase: "npm:^1.0.2"
+    cliui: "npm:^2.1.0"
+    decamelize: "npm:^1.0.0"
+    window-size: "npm:0.1.0"
   checksum: df727126b4e664987c5bb1f346fbde24d2d5e6bd435d081d816f1f5890811ceb82f90ac7e6eb849eae749dde6fe5a2eda2c6f2b22021824976399fb4362413c1
   languageName: node
   linkType: hard

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,44 +1510,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.0":
-  version: 3.7.3
-  resolution: "@types/eslint-scope@npm:3.7.3"
-  dependencies:
-    "@types/eslint": "npm:*"
-    "@types/estree": "npm:*"
-  checksum: 3084e2619be57ca318dfddc2557fef855d63ea378d42b6b355216ea3e3aed82ce6adbfa6b620bff1d67aefa95245c5b41e998338bc307c948f8cbf08840b9bb2
-  languageName: node
-  linkType: hard
-
 "@types/eslint-visitor-keys@npm:^1.0.0":
   version: 1.0.0
   resolution: "@types/eslint-visitor-keys@npm:1.0.0"
   checksum: 3d9186b6b5a85442d956fa708a6e46e815671a6a397558fe7e7d25459f61f5b5647b5d63b48f6061df2aca0ae1f800f1b5577179daee91bd15f15037a622d001
-  languageName: node
-  linkType: hard
-
-"@types/eslint@npm:*":
-  version: 8.4.1
-  resolution: "@types/eslint@npm:8.4.1"
-  dependencies:
-    "@types/estree": "npm:*"
-    "@types/json-schema": "npm:*"
-  checksum: 3ba1ddb8d2362316bafe65f90aa41ce23f923f8ae6a131e382540a7c0d8ad5f04117e6aba788392717a616bd6e2589a1d954630c49edb364d28dc8eeb5214890
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:*":
-  version: 0.0.50
-  resolution: "@types/estree@npm:0.0.50"
-  checksum: e72326154f3910a7928a7a2b387604c4a05c590a79f3c79d54c88f136476bce9bdfdfffe0586f1aeb60e05bb84256a9307f8e297c51ededa6d195277cd8a603b
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:^0.0.45":
-  version: 0.0.45
-  resolution: "@types/estree@npm:0.0.45"
-  checksum: dce1fb977d9aab2492cfc831e76abdc7c0944e42974bf7b907d02d28b9356e38c7534ade5a6b7f4f2dd12347f02d78051a4e0f4685bf8b7d60ebf85263a48bf9
   languageName: node
   linkType: hard
 
@@ -1561,7 +1527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8":
+"@types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
   checksum: 46a9e92b7922495a50f55632d802f7e7ab2dffd76b3f894baf7b28012e73983df832977bedd748aa9a2bc8400c6e8659ca39faf6ccd93d71d41d5b0293338a0e
@@ -1760,201 +1726,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/ast@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/ast@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/helper-module-context": "npm:1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
-    "@webassemblyjs/wast-parser": "npm:1.9.0"
-  checksum: 8246c714346cdcd3ab204a2b09904d9d36c4f7da8f30cc217b0b7272a3ef57a3c21e95d51b26601641133fb66fea5cc46c357cf897808512f13b3d1c2efe88e4
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/floating-point-hex-parser@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.9.0"
-  checksum: 17acfdfe6650691ae8d0279e6ff4fb8b5efce64e12f3fa18c6a7d279968cc72eb21c0db7ebb5be9d627d05fa7014cef087843d999de96c917079f57d7dac8f77
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-api-error@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-api-error@npm:1.9.0"
-  checksum: 892851b25cf4b4b307490328f45858414326dac667ca15244b5e959fa6e22478b29dabeb581d49ef8a2874e291d0417a3a959be70428c39cd40870e73b394dbc
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-buffer@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-buffer@npm:1.9.0"
-  checksum: b09a3e27d9127ccaab095bd171336e7675bb5b832e05b701ff174a853b763154a49f5382c4c3f2f1cc746b1cff3f2025452145cf807ddf788133bcccf5920ca8
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-code-frame@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-code-frame@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/wast-printer": "npm:1.9.0"
-  checksum: 010969a6c8b016680a9b1383ff4b8147c363608dd1e29602154e5460954af4fd48daed518a76b232ca43935d4b6bebf54fba38da56f809e2bd12f063d84013ec
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-fsm@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-fsm@npm:1.9.0"
-  checksum: ef0c99b58716d757a1a41f99fb46578d3f07d97b60cd51deaeffdf0aad09ec47f5093ee8d098d12324d57f8812609704c377fccfe9a32d02c0a658a4a33dce94
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-module-context@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-module-context@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.9.0"
-  checksum: 130a9ac1141770b9f70ad568ec2dc769e92c756f91b06ece9cda2c2a5e80e21ec9c8c2a945a5839bf379e52fa921ae134245a7492e1b9ae0e8c557bb9b4953c3
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-wasm-bytecode@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.9.0"
-  checksum: 1741993e1c723f56b619a4981ec975f903886aa3f1f50c7bdb2eaa45ca4ad8d023d6ae7413ef643f060567b1f12a9dcfad6c43688879c46ee4f0b53aa71cd5c9
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-wasm-section@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-wasm-section@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.9.0"
-    "@webassemblyjs/helper-buffer": "npm:1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
-    "@webassemblyjs/wasm-gen": "npm:1.9.0"
-  checksum: 2a5baa7749c50a4a428f372ab88b7e52956b48798d44e7291b4aa8558b247337dba791112ce8a4f5b2281e1b9014e6d44d0141476a5fcde6016fac2e009671e8
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/ieee754@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/ieee754@npm:1.9.0"
-  dependencies:
-    "@xtuc/ieee754": "npm:^1.2.0"
-  checksum: 0eff34ec7048400b30282ab9af6ad19d2852dab2f5ffaec8bdc697b8380bc2c9dbe6cadf65f49e68242c82ee3caa8aa6e46c89dbfdab37615189b4da2eab3819
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/leb128@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/leb128@npm:1.9.0"
-  dependencies:
-    "@xtuc/long": "npm:4.2.2"
-  checksum: 441be8634733b33b710f44d4394552d6290bb1a0a8311b384b1865b58c3549d0ddeaf1c3985bbee024a8df12c597be3580fc1cde2ae003dcbf26762b493a7a2f
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/utf8@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/utf8@npm:1.9.0"
-  checksum: 9566689a1bcf555d6b79d0da79e24ff2be23c0395e5a19ed3c2ceca7831e50b867e0b1c66b3ff1b1d7f297b2d2414314967a884a77634ad0acff8a78489e2b19
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-edit@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wasm-edit@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.9.0"
-    "@webassemblyjs/helper-buffer": "npm:1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
-    "@webassemblyjs/helper-wasm-section": "npm:1.9.0"
-    "@webassemblyjs/wasm-gen": "npm:1.9.0"
-    "@webassemblyjs/wasm-opt": "npm:1.9.0"
-    "@webassemblyjs/wasm-parser": "npm:1.9.0"
-    "@webassemblyjs/wast-printer": "npm:1.9.0"
-  checksum: 07f4cb4a73989622c524f9264b6afe664d33354f081499f04db675aed2b79498bd43600c3d7bebcb9f93ccce6a094b3c28f3f7b11ea62e9e82074c2ae68dc058
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-gen@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wasm-gen@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
-    "@webassemblyjs/ieee754": "npm:1.9.0"
-    "@webassemblyjs/leb128": "npm:1.9.0"
-    "@webassemblyjs/utf8": "npm:1.9.0"
-  checksum: 876826bef91f3af9e48118fb269c348871d5b6f019e071065556da56a3a5818630b00133e07c9dd2cc767e7f2c70934f3ed0060330ce3e37910e9c9df25f1600
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-opt@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wasm-opt@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.9.0"
-    "@webassemblyjs/helper-buffer": "npm:1.9.0"
-    "@webassemblyjs/wasm-gen": "npm:1.9.0"
-    "@webassemblyjs/wasm-parser": "npm:1.9.0"
-  checksum: 3d5558e078b660cd9777950f2df60f005f3cbdbcfa6c8c19dc0cf012f44f5bfa97c991d7ac26b3e78596bad0538e92dd00b5db4b51ebc373da8e329a03639190
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-parser@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wasm-parser@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.9.0"
-    "@webassemblyjs/helper-api-error": "npm:1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
-    "@webassemblyjs/ieee754": "npm:1.9.0"
-    "@webassemblyjs/leb128": "npm:1.9.0"
-    "@webassemblyjs/utf8": "npm:1.9.0"
-  checksum: 1e8615b9f9c3c431c9635c9a9884bca89eff1ab2383ad849341c23e09899454482a8f8813d33bf86ee1b0acc97c7c83926961a9b34d4804fa5d559610ab0a4a2
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wast-parser@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wast-parser@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.9.0"
-    "@webassemblyjs/floating-point-hex-parser": "npm:1.9.0"
-    "@webassemblyjs/helper-api-error": "npm:1.9.0"
-    "@webassemblyjs/helper-code-frame": "npm:1.9.0"
-    "@webassemblyjs/helper-fsm": "npm:1.9.0"
-    "@xtuc/long": "npm:4.2.2"
-  checksum: c79952466fdf7816be527b1db102952b777b12318eabb5c40df074cd8361e3a7b0179a985534fa8b5a7b93668b07ba46875ffeb5da03ca5177c80ba960ebdffc
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wast-printer@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wast-printer@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.9.0"
-    "@webassemblyjs/wast-parser": "npm:1.9.0"
-    "@xtuc/long": "npm:4.2.2"
-  checksum: f3d106aa884cbb7687307db7adeb3b98abff9de81b9ba8c1065267340b5e9de64ffc533044ab916b1f4ce8a67fb03efa54b29b61c8e908abe4c07edf82f614cd
-  languageName: node
-  linkType: hard
-
-"@xtuc/ieee754@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@xtuc/ieee754@npm:1.2.0"
-  checksum: a8565d29d135039bd99ae4b2220d3e167d22cf53f867e491ed479b3f84f895742d0097f935b19aab90265a23d5d46711e4204f14c479ae3637fbf06c4666882f
-  languageName: node
-  linkType: hard
-
-"@xtuc/long@npm:4.2.2":
-  version: 4.2.2
-  resolution: "@xtuc/long@npm:4.2.2"
-  checksum: 8582cbc69c79ad2d31568c412129bf23d2b1210a1dfb60c82d5a1df93334da4ee51f3057051658569e2c196d8dc33bc05ae6b974a711d0d16e801e1d0647ccd1
-  languageName: node
-  linkType: hard
-
 "abab@npm:^1.0.0":
   version: 1.0.4
   resolution: "abab@npm:1.0.4"
@@ -2018,15 +1789,6 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: bd0b2c2b0f334bbee48828ff897c12bd2eb5898d03bf556dcc8942022cec795ac5bb5b6b585e2de687db6231faf07e096b59a361231dd8c9344d5df5f7f0e526
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.0.3, acorn@npm:^8.5.0":
-  version: 8.7.0
-  resolution: "acorn@npm:8.7.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 8168e567c2f0b9fb7a418d2651b4b614326a0814b4937ebddee0f5e5e25ddd6320aec0c20d3a67efd97a02d836cc7f9e5c84befe3daeeea68ed89a48ee8f7a5d
   languageName: node
   linkType: hard
 
@@ -3031,7 +2793,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.14.3, browserslist@npm:^4.17.5, browserslist@npm:^4.19.1":
+"browserslist@npm:^4.17.5, browserslist@npm:^4.19.1":
   version: 4.19.1
   resolution: "browserslist@npm:4.19.1"
   dependencies:
@@ -3095,7 +2857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^15.0.5, cacache@npm:^15.2.0":
+"cacache@npm:^15.2.0":
   version: 15.3.0
   resolution: "cacache@npm:15.3.0"
   dependencies:
@@ -3450,13 +3212,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrome-trace-event@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "chrome-trace-event@npm:1.0.3"
-  checksum: 080ce2d20c2b9e0f8461a380e9585686caa768b1c834a464470c9dc74cda07f27611c7b727a2cd768a9cecd033297fdec4ce01f1e58b62227882c1059dec321c
-  languageName: node
-  linkType: hard
-
 "ci-info@npm:^2.0.0":
   version: 2.0.0
   resolution: "ci-info@npm:2.0.0"
@@ -3753,7 +3508,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.20.0, commander@npm:^2.9.0":
+"commander@npm:^2.9.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
@@ -4662,16 +4417,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.2.0":
-  version: 5.8.3
-  resolution: "enhanced-resolve@npm:5.8.3"
-  dependencies:
-    graceful-fs: "npm:^4.2.4"
-    tapable: "npm:^2.2.0"
-  checksum: c50de36c067359833577fb031de6a3b3d0eeb0627cb81fea1e132116d0b5a4fc746e0c8525f683de0a656f25aad08d3da773775b27608db1695ac47ac64ff673
-  languageName: node
-  linkType: hard
-
 "entities@npm:1.0":
   version: 1.0.0
   resolution: "entities@npm:1.0.0"
@@ -4936,7 +4681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:*, eslint-import-resolver-node@npm:^0.3.6":
+"eslint-import-resolver-node@npm:^0.3.6":
   version: 0.3.6
   resolution: "eslint-import-resolver-node@npm:0.3.6"
   dependencies:
@@ -4989,7 +4734,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^5.0.0, eslint-scope@npm:^5.1.0":
+"eslint-scope@npm:^5.0.0":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
   dependencies:
@@ -5162,13 +4907,6 @@ __metadata:
     d: "npm:1"
     es5-ext: "npm:~0.10.14"
   checksum: 75082fa8ffb3929766d0f0a063bfd6046bd2a80bea2666ebaa0cfd6f4a9116be6647c15667bea77222afc12f5b4071b68d393cf39fdaa0e8e81eda006160aff0
-  languageName: node
-  linkType: hard
-
-"events@npm:^3.2.0":
-  version: 3.3.0
-  resolution: "events@npm:3.3.0"
-  checksum: d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
   languageName: node
   linkType: hard
 
@@ -6281,13 +6019,6 @@ __metadata:
   dependencies:
     is-glob: "npm:^2.0.0"
   checksum: b9d59dc532d47aaaa4841046ff631b325a707f738445300b83b7a1ee603dd060c041a378e8a195c887d479bb703685cee4725c8f54b8dacef65355375f57d32a
-  languageName: node
-  linkType: hard
-
-"glob-to-regexp@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "glob-to-regexp@npm:0.4.1"
-  checksum: 0486925072d7a916f052842772b61c3e86247f0a80cc0deb9b5a3e8a1a9faad5b04fb6f58986a09f34d3e96cd2a22a24b7e9882fb1cf904c31e9a310de96c429
   languageName: node
   linkType: hard
 
@@ -7867,17 +7598,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^26.5.0":
-  version: 26.6.2
-  resolution: "jest-worker@npm:26.6.2"
-  dependencies:
-    "@types/node": "npm:*"
-    merge-stream: "npm:^2.0.0"
-    supports-color: "npm:^7.0.0"
-  checksum: 07e4dba650381604cda253ab6d5837fe0279c8d68c25884995b45bfe149a7a1e1b5a97f304b4518f257dac2a9ddc1808d57d650649c3ab855e9e60cf824d2970
-  languageName: node
-  linkType: hard
-
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -7967,7 +7687,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-parse-better-errors@npm:^1.0.1, json-parse-better-errors@npm:^1.0.2":
+"json-parse-better-errors@npm:^1.0.1":
   version: 1.0.2
   resolution: "json-parse-better-errors@npm:1.0.2"
   checksum: 2f1287a7c833e397c9ddd361a78638e828fc523038bb3441fd4fc144cfd2c6cd4963ffb9e207e648cf7b692600f1e1e524e965c32df5152120910e4903a47dcb
@@ -8301,13 +8021,6 @@ __metadata:
     pify: "npm:^3.0.0"
     strip-bom: "npm:^3.0.0"
   checksum: 6b48f6a0256bdfcc8970be2c57f68f10acb2ee7e63709b386b2febb6ad3c86198f840889cdbe71d28f741cbaa2f23a7771206b138cd1bdd159564511ca37c1d5
-  languageName: node
-  linkType: hard
-
-"loader-runner@npm:^4.1.0":
-  version: 4.2.0
-  resolution: "loader-runner@npm:4.2.0"
-  checksum: 907dee8c4d5841962005e22bf2fa10f7ea5849356243b43e443227641fa202f5edf1c996e5b36697e027533013d35554a46e75d3db8183731f11b5f38db565ea
   languageName: node
   linkType: hard
 
@@ -8992,7 +8705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.11, mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.7":
+"mime-types@npm:^2.1.11, mime-types@npm:^2.1.12, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.7":
   version: 2.1.34
   resolution: "mime-types@npm:2.1.34"
   dependencies:
@@ -9322,8 +9035,7 @@ __metadata:
     tiny-worker: "npm:2.3.0"
     toposort: "npm:^2.0.2"
     ts-mocha: "npm:^7.0.0"
-    typescript: "npm:^3.8.3"
-    webpack: "npm:5.0.0"
+    typescript: "npm:^4.9.3"
     worker-loader: "npm:^3.0.5"
     yargs: "npm:14.0.0"
   peerDependencies:
@@ -10912,7 +10624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pkg-dir@npm:^4.1.0, pkg-dir@npm:^4.2.0":
+"pkg-dir@npm:^4.1.0":
   version: 4.2.0
   resolution: "pkg-dir@npm:4.2.0"
   dependencies:
@@ -12284,15 +11996,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "serialize-javascript@npm:5.0.1"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 646bd92a8298d764d38316f3006bce0b0def6d0e254791396ac34403847654d9346b0b6ed7865efd799d93d4c47d900e08a8fa7a6f7f8d2dbaebab5444c3b431
-  languageName: node
-  linkType: hard
-
 "set-blocking@npm:^2.0.0, set-blocking@npm:~2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
@@ -12571,13 +12274,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-list-map@npm:^2.0.0, source-list-map@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "source-list-map@npm:2.0.1"
-  checksum: 2e5e421b185dcd857f46c3c70e2e711a65d717b78c5f795e2e248c9d67757882ea989b80ebc08cf164eeeda5f4be8aa95d3b990225070b2daaaf3257c5958149
-  languageName: node
-  linkType: hard
-
 "source-map-js@npm:^1.0.1":
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
@@ -12598,7 +12294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.13, source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.6, source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.13, source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.6":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -12626,13 +12322,6 @@ __metadata:
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
-  languageName: node
-  linkType: hard
-
-"source-map@npm:~0.7.2":
-  version: 0.7.3
-  resolution: "source-map@npm:0.7.3"
-  checksum: 7d2ddb51f3d2451847692a9ac7808da2b2b3bf7aef92ece33128919040a7e74d9a5edfde7a781f035c974deff876afaf83f2e30484faffffb86484e7408f5d7c
   languageName: node
   linkType: hard
 
@@ -13075,13 +12764,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.0.0, tapable@npm:^2.2.0":
-  version: 2.2.1
-  resolution: "tapable@npm:2.2.1"
-  checksum: bc40e6efe1e554d075469cedaba69a30eeb373552aaf41caeaaa45bf56ffacc2674261b106245bd566b35d8f3329b52d838e851ee0a852120acae26e622925c9
-  languageName: node
-  linkType: hard
-
 "tar@npm:^2.0.0, tar@npm:~2.2.1":
   version: 2.2.2
   resolution: "tar@npm:2.2.2"
@@ -13130,43 +12812,6 @@ __metadata:
     ansi-escapes: "npm:^4.2.1"
     supports-hyperlinks: "npm:^2.0.0"
   checksum: 947458a5cd5408d2ffcdb14aee50bec8fb5022ae683b896b2f08ed6db7b2e7d42780d5c8b51e930e9c322bd7c7a517f4fa7c76983d0873c83245885ac5ee13e3
-  languageName: node
-  linkType: hard
-
-"terser-webpack-plugin@npm:^4.1.0":
-  version: 4.2.3
-  resolution: "terser-webpack-plugin@npm:4.2.3"
-  dependencies:
-    cacache: "npm:^15.0.5"
-    find-cache-dir: "npm:^3.3.1"
-    jest-worker: "npm:^26.5.0"
-    p-limit: "npm:^3.0.2"
-    schema-utils: "npm:^3.0.0"
-    serialize-javascript: "npm:^5.0.1"
-    source-map: "npm:^0.6.1"
-    terser: "npm:^5.3.4"
-    webpack-sources: "npm:^1.4.3"
-  peerDependencies:
-    webpack: ^4.0.0 || ^5.0.0
-  checksum: 52bd036b72b596b162e65dce314f1ee7ba1e82b97200d919b61ad50592dc72608b5fe50d7e3f6c0934e42183dfc746b98b922c9e1d00d75253933f799687fa4b
-  languageName: node
-  linkType: hard
-
-"terser@npm:^5.3.4":
-  version: 5.10.0
-  resolution: "terser@npm:5.10.0"
-  dependencies:
-    commander: "npm:^2.20.0"
-    source-map: "npm:~0.7.2"
-    source-map-support: "npm:~0.5.20"
-  peerDependencies:
-    acorn: ^8.5.0
-  peerDependenciesMeta:
-    acorn:
-      optional: true
-  bin:
-    terser: bin/terser
-  checksum: c5ce5356b6428dd2ccffd067ff1ecf7cc8ff08bd3b73840540915b6d46575d51e208e68224a76169217690a42203367498ca50a82a0fea8b8a6ac0c9025df632
   languageName: node
   linkType: hard
 
@@ -13566,23 +13211,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^3.8.3":
-  version: 3.9.10
-  resolution: "typescript@npm:3.9.10"
+"typescript@npm:^4.9.3":
+  version: 4.9.3
+  resolution: "typescript@npm:4.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 863cc06070fa18a0f9c6a83265fb4922a8b51bf6f2c6760fb0b73865305ce617ea4bc6477381f9f4b7c3a8cb4a455b054f5469e6e41307733fe6a2bd9aae82f8
+  checksum: bddcb0794f2b8aa52094b9de9d70848fdf46ccecac68403e1c407dc9f1a4e4e28979887acd648e1917b1144e5d8fbfb4c824309d8806d393b4194aa39c71fe5e
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^3.8.3#optional!builtin<compat/typescript>":
-  version: 3.9.10
-  resolution: "typescript@patch:typescript@npm%3A3.9.10#optional!builtin<compat/typescript>::version=3.9.10&hash=3bd3d3"
+"typescript@patch:typescript@npm%3A^4.9.3#optional!builtin<compat/typescript>":
+  version: 4.9.3
+  resolution: "typescript@patch:typescript@npm%3A4.9.3#optional!builtin<compat/typescript>::version=4.9.3&hash=d73830"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 9041fb3886e7d6a560f985227b8c941d17a750f2edccb5f9b3a15a2480574654d9be803ad4a14aabcc2f2553c4d272a25fd698a7c42692f03f66b009fb46883c
+  checksum: 26a1e4c75656e1d8d912d16bf9d2c0fa76b6339d9288681cb999577209e8f73e79c2a91631ed5104c69bbcd565d2451ea0c6beef5119acfe127ed4a88b34cf08
   languageName: node
   linkType: hard
 
@@ -13881,16 +13526,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.0.0":
-  version: 2.3.1
-  resolution: "watchpack@npm:2.3.1"
-  dependencies:
-    glob-to-regexp: "npm:^0.4.1"
-    graceful-fs: "npm:^4.1.2"
-  checksum: 00e44f5cc6ca299dd1ff52bf926a70a23ae1aeb6b399b7e32569d6d31ef1fc9bc3f5570ade6fef220dd6d74ee70259c9621b79cf487552caf1ea2727aa40f984
-  languageName: node
-  linkType: hard
-
 "wcwidth@npm:^1.0.0":
   version: 1.0.1
   resolution: "wcwidth@npm:1.0.1"
@@ -13921,63 +13556,6 @@ __metadata:
   version: 2.0.1
   resolution: "webidl-conversions@npm:2.0.1"
   checksum: 8f0a4918879925b9003cc50e419d6abbb6bd0831bde5a230d2c01379f5d3b1525f5b3c3d84b21e6c8f348320c843cb4d01e223b043c59c7f1444721504261e12
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "webpack-sources@npm:1.4.3"
-  dependencies:
-    source-list-map: "npm:^2.0.0"
-    source-map: "npm:~0.6.1"
-  checksum: 78dafb3e1e297d3f4eb6204311e8c64d28cd028f82887ba33aaf03fffc82482d8e1fdf6de25a60f4dde621d3565f4c3b1bfb350f09add8f4e54e00279ff3db5e
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^2.0.1":
-  version: 2.3.1
-  resolution: "webpack-sources@npm:2.3.1"
-  dependencies:
-    source-list-map: "npm:^2.0.1"
-    source-map: "npm:^0.6.1"
-  checksum: caf56a9a478eca7e77feca2b6ddc7673f1384eb870280014b300c40cf42abca656f639ff58a8d55a889a92a810ae3c22e71e578aa38fde416e8c2e6827a6ddfd
-  languageName: node
-  linkType: hard
-
-"webpack@npm:5.0.0":
-  version: 5.0.0
-  resolution: "webpack@npm:5.0.0"
-  dependencies:
-    "@types/eslint-scope": "npm:^3.7.0"
-    "@types/estree": "npm:^0.0.45"
-    "@webassemblyjs/ast": "npm:1.9.0"
-    "@webassemblyjs/helper-module-context": "npm:1.9.0"
-    "@webassemblyjs/wasm-edit": "npm:1.9.0"
-    "@webassemblyjs/wasm-parser": "npm:1.9.0"
-    acorn: "npm:^8.0.3"
-    browserslist: "npm:^4.14.3"
-    chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.2.0"
-    eslint-scope: "npm:^5.1.0"
-    events: "npm:^3.2.0"
-    glob-to-regexp: "npm:^0.4.1"
-    graceful-fs: "npm:^4.2.4"
-    json-parse-better-errors: "npm:^1.0.2"
-    loader-runner: "npm:^4.1.0"
-    mime-types: "npm:^2.1.27"
-    neo-async: "npm:^2.6.2"
-    pkg-dir: "npm:^4.2.0"
-    schema-utils: "npm:^3.0.0"
-    tapable: "npm:^2.0.0"
-    terser-webpack-plugin: "npm:^4.1.0"
-    watchpack: "npm:^2.0.0"
-    webpack-sources: "npm:^2.0.1"
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: 22649a87d4642dff3121168677a9f005c131d366c24048ccf66645854dbc90fb13cbeb80d6523e2822f5fb37195f4cb02ffb95a09065b3f91d4cf5129515a918
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Implements better GitHub Actions cache strategy for Yarn.

**How did you fix it?**

I have separated global Yarn cache from local node_modules cache and use them separately.
