### PR TITLE
Fixes global Yarn cache storage on GHA

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,16 +23,18 @@ jobs:
       with:
         path: |
           ~/.yarn/berry
-        key: global-cache
+        key: yarn-global-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-v1
+        restore-keys: |
+          yarn-global-
 
     - uses: actions/cache@v3
       with:
         path: |
           ./.yarn/install-state.gz
           ./node_modules
-        key: ${{ runner.os }}-install-${{ hashFiles('yarn.lock') }}-v1
+        key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-v1
         restore-keys: |
-          ${{ runner.os }}-install-
+          yarn-${{ runner.os }}-install-
 
     - name: 'Use Node.js ${{matrix.node}}'
       uses: actions/setup-node@master


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes global Yarn cache storage on GHA

**How did you fix it?**

Correct cache keys are generated and used now for global cache, based on a file checksum
