### PR TITLE
Upgrade @babel/runtime-corejs2 to @babel/runtime-corejs3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,8 @@
     [
       "@babel/preset-env",
       {
+        "corejs": 3,
+        "useBuiltIns": "usage",
         "exclude": [
           "transform-async-to-generator",
           "transform-regenerator"
@@ -21,7 +23,12 @@
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-object-rest-spread",
     "babel-plugin-lodash",
-    "@babel/plugin-transform-runtime"
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        "corejs": 3
+      }
+    ]
   ],
   "env": {
     "coverage": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "chai": "^4.1.0",
     "coffee-script": "^1.11.1",
     "commander": "2.11.0",
+    "core-js": "^3.0.0",
     "cross-env": "6.0.3",
     "css-loader": "^5.0.1",
     "del": "5.1.0",
@@ -109,7 +110,7 @@
     "worker-loader": "^3.0.5"
   },
   "dependencies": {
-    "@babel/runtime-corejs2": "^7.0.0",
+    "@babel/runtime-corejs3": "^7.0.0",
     "chalk": "^2.4.2",
     "chokidar": "^3.5.2",
     "glob-parent": "5.1.2",


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fix ` WARN  deprecated core-js@2.6.12: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.` warning.

**How did you fix it?**

Upgrade @babel/runtime-corejs2 to @babel/runtime-corejs3

More details: https://github.com/sysgears/mochapack/issues/133 and [https://github.com/babel/babel/pull/7646](https://github.com/babel/babel/pull/7646)
